### PR TITLE
feat: OpenStack onboarding flow & per-lecturer credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
             "@types/react-dom": "^19.2.3",
             "@typescript-eslint/eslint-plugin": "^8.53.1",
             "@typescript-eslint/parser": "^8.53.1",
+            "@vitejs/plugin-basic-ssl": "^2.1.4",
             "@vitejs/plugin-react-swc": "^3.10.2",
             "eslint": "^9.39.2",
             "eslint-config-prettier": "^10.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useEffect, useState } from "react";
 import { useKeycloak } from "@react-keycloak/web";
 import { Routes, Route, Navigate } from "react-router-dom";
 import { Courses } from "./pages/Courses";
@@ -10,17 +10,70 @@ import { DashboardPage } from "./pages/DashboardPage";
 import { AppStorePage } from "./pages/AppStorePage";
 import { DeploymentWizardPage } from "./pages/DeploymentWizardPage";
 import { DeploymentDetailsPage } from "./pages/DeploymentDetailsPage";
+import { OpenStackSetup } from "./pages/OpenStackSetup";
+import { listOpenstackProjects } from "./api/openstackProjects";
 import logo from "figma:asset/5c87f57a05de8f8018669c9004318908d006dcd5.png";
 
 export default function App() {
   const { keycloak, initialized } = useKeycloak();
+  const [initTimedOut, setInitTimedOut] = useState(false);
+  const [projectsChecked, setProjectsChecked] = useState(false);
+  const [hasProjects, setHasProjects] = useState(false);
 
-  // Keycloak initialisiert noch
-  if (!initialized) {
-    return <div className="p-6">Loading…</div>;
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (!initialized) {
+        console.error("[Keycloak] Init timed out after 10s – initialized:", initialized);
+        setInitTimedOut(true);
+      }
+    }, 10_000);
+    return () => clearTimeout(timer);
+  }, [initialized]);
+
+  useEffect(() => {
+    if (!keycloak.authenticated) return;
+    const roles: string[] = (keycloak.tokenParsed as Record<string, any>)?.realm_access?.roles ?? [];
+    const isLecturer = roles.includes("lecturer") || roles.includes("teacher");
+    if (!isLecturer) {
+      setHasProjects(true);
+      setProjectsChecked(true);
+      return;
+    }
+    listOpenstackProjects()
+      .then((projects) => setHasProjects(projects.length > 0))
+      .catch(() => setHasProjects(false))
+      .finally(() => setProjectsChecked(true));
+  }, [keycloak.authenticated]);
+
+  console.log("[Keycloak] initialized:", initialized, "authenticated:", keycloak?.authenticated);
+
+  // Keycloak still initializing
+  if (!initialized && !initTimedOut) {
+    return <div className="p-6">Initializing Keycloak…</div>;
   }
 
-  // Wenn nicht eingeloggt: deine Login-Seite anzeigen, Button triggert keycloak.login()
+  if (!initialized && initTimedOut) {
+    return (
+      <div className="p-6 text-red-600">
+        <p>Failed to initialize Keycloak.</p>
+        <p className="text-sm text-gray-500 mt-2">
+          Check if Keycloak is reachable at{" "}
+          <a href={keycloak?.authServerUrl || "#"} target="_blank" rel="noreferrer" className="underline">
+            {keycloak?.authServerUrl || "the configured URL"}
+          </a>
+          .
+        </p>
+        <button
+          className="mt-4 px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={() => window.location.reload()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  // Not authenticated: show login page
   if (!keycloak.authenticated) {
     return (
       <Login
@@ -30,12 +83,28 @@ export default function App() {
     );
   }
 
+  // Waiting for project check
+  if (!projectsChecked) {
+    return <div className="p-6">Laden…</div>;
+  }
+
+  // Lecturer without projects → setup
+  if (!hasProjects) {
+    return (
+      <Routes>
+        <Route path="/setup" element={<OpenStackSetup onSuccess={() => { setHasProjects(true); }} />} />
+        <Route path="*" element={<Navigate to="/setup" replace />} />
+      </Routes>
+    );
+  }
+
   return (
     <div className="flex h-screen bg-slate-50">
       <Sidebar logo={logo} />
       <main className="flex-1 overflow-auto">
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />
+          <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
           <Route path="/dashboard" element={<DashboardPage />} />
           <Route path="/courses" element={<Courses />} />
           <Route path="/appstore" element={<AppStorePage />} />

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -33,7 +33,18 @@ export async function apiFetch<T>(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`API ${res.status}: ${text || res.statusText}`);
+    let message = text || res.statusText;
+    try {
+      const json = JSON.parse(text);
+      if (json?.message) message = json.message;
+      else if (json?.detail) message = json.detail;
+    } catch {
+      // not JSON, use raw text
+    }
+    const err = new Error(message) as Error & { status: number; body: string };
+    err.status = res.status;
+    err.body = text;
+    throw err;
   }
 
   return res.json() as Promise<T>;

--- a/src/api/openstackProjects.ts
+++ b/src/api/openstackProjects.ts
@@ -1,0 +1,76 @@
+import { apiFetch } from "./http";
+
+export type OpenstackCredentialsCreate = {
+  auth_url: string;
+  username: string;
+  password: string;
+  user_domain_name: string;
+  region_name: string;
+  openstack_project_id: string;
+  openstack_project_name: string;
+};
+
+export type OpenstackProjectResponse = {
+  id: string;
+  owner_user_id: string;
+  openstack_project_id: string;
+  openstack_project_name: string;
+  region_name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type OpenstackCredentialsResponse = OpenstackProjectResponse & {
+  auth_url: string;
+  username: string;
+  password: string;
+  user_domain_name: string;
+};
+
+type Envelope<T> = { data: T } & Record<string, unknown>;
+
+function unwrap<T>(resp: T | Envelope<T>): T {
+  if (resp && typeof resp === "object" && "data" in (resp as object)) {
+    return (resp as Envelope<T>).data;
+  }
+  return resp as T;
+}
+
+export async function listOpenstackProjects(): Promise<OpenstackProjectResponse[]> {
+  const resp = await apiFetch<OpenstackProjectResponse[] | Envelope<OpenstackProjectResponse[]>>(
+    "/api/v1/openstack-projects"
+  );
+  return unwrap(resp);
+}
+
+export async function createOpenstackProject(
+  data: OpenstackCredentialsCreate
+): Promise<OpenstackCredentialsResponse> {
+  const resp = await apiFetch<OpenstackCredentialsResponse | Envelope<OpenstackCredentialsResponse>>(
+    "/api/v1/openstack-projects",
+    { method: "POST", body: JSON.stringify(data) }
+  );
+  return unwrap(resp);
+}
+
+export async function deleteOpenstackProject(id: string): Promise<void> {
+  await apiFetch<void>(`/api/v1/openstack-projects/${id}`, { method: "DELETE" });
+}
+
+export async function getOpenstackProject(id: string): Promise<OpenstackCredentialsResponse> {
+  const resp = await apiFetch<OpenstackCredentialsResponse | Envelope<OpenstackCredentialsResponse>>(
+    `/api/v1/openstack-projects/${id}`
+  );
+  return unwrap(resp);
+}
+
+export async function updateOpenstackProject(
+  id: string,
+  data: OpenstackCredentialsCreate
+): Promise<OpenstackCredentialsResponse> {
+  const resp = await apiFetch<OpenstackCredentialsResponse | Envelope<OpenstackCredentialsResponse>>(
+    `/api/v1/openstack-projects/${id}`,
+    { method: "PUT", body: JSON.stringify(data) }
+  );
+  return unwrap(resp);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,42 +1,52 @@
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-  import { createRoot } from "react-dom/client";
-  import App from "./App.tsx";
-  import "./index.css";
+// Polyfill crypto.randomUUID for insecure contexts (plain HTTP on non-localhost).
+// keycloak-js v26+ requires crypto.randomUUID() which is only available in secure
+// contexts. crypto.getRandomValues() works everywhere and is sufficient for UUIDs.
+if (typeof crypto !== "undefined" && typeof crypto.randomUUID !== "function") {
+  crypto.randomUUID = function randomUUID(): `${string}-${string}-${string}-${string}-${string}` {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    // Set version (4) and variant (RFC 4122) bits
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}` as `${string}-${string}-${string}-${string}-${string}`;
+  };
+}
 
-import React from "react";
-//import ReactDOM from "react-dom/client";
 import { ReactKeycloakProvider } from "@react-keycloak/web";
 import { BrowserRouter } from "react-router-dom";
 import keycloak from "./auth/keycloak";
 
 const onKeycloakEvent = (event: unknown, error?: unknown) => {
-  // optional: Logging
-  // console.log("Keycloak event", event, error);
+  console.log("[Keycloak] event:", event, error);
 };
 
-const onKeycloakTokens = (tokens: unknown) => {
-  // optional: Debugging
-  // console.log("Keycloak tokens", tokens);
+const onKeycloakTokens = (_tokens: unknown) => {
+  console.log("[Keycloak] tokens received");
 };
 
 createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <ReactKeycloakProvider
-  authClient={keycloak}
-  initOptions={{
-    onLoad: "check-sso",
-    pkceMethod: "S256",
-    checkLoginIframe: false,
-  }}
-  onEvent={onKeycloakEvent}
-  onTokens={onKeycloakTokens}
->
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
-</ReactKeycloakProvider>
-
-  </React.StrictMode>
+  // StrictMode removed: ReactKeycloakProvider does not support double-mount
+  // (keycloak.init() can only be called once). Re-enable once migrated off
+  // @react-keycloak/web.
+  <ReactKeycloakProvider
+    authClient={keycloak}
+    initOptions={{
+      onLoad: "check-sso",
+      checkLoginIframe: false,
+      enableLogging: true,
+      // No pkceMethod: "S256" — requires crypto.subtle which needs HTTPS.
+      // Falls back to standard Authorization Code flow over plain HTTP.
+    }}
+    onEvent={onKeycloakEvent}
+    onTokens={onKeycloakTokens}
+  >
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </ReactKeycloakProvider>
 );
-
-  

--- a/src/pages/OpenStackConfig.tsx
+++ b/src/pages/OpenStackConfig.tsx
@@ -1,4 +1,4 @@
-import { Settings, RefreshCw, CheckCircle2, AlertCircle, Server, Eye, EyeOff, Shield, Lock, Workflow, FileCode, Cpu, Database } from 'lucide-react';
+import { Settings, RefreshCw, CheckCircle2, AlertCircle, Server, Eye, EyeOff, Shield, Lock, Workflow, FileCode, Trash2 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -6,25 +6,143 @@ import { Label } from '../components/ui/label';
 import { Badge } from '../components/ui/badge';
 import { Switch } from '../components/ui/switch';
 import { Textarea } from '../components/ui/textarea';
-import { useState } from 'react';
+import { Progress } from '../components/ui/progress';
+import { AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '../components/ui/alert-dialog';
+import { useState, useEffect } from 'react';
+import {
+  listOpenstackProjects,
+  getOpenstackProject,
+  createOpenstackProject,
+  updateOpenstackProject,
+  deleteOpenstackProject,
+  type OpenstackProjectResponse,
+  type OpenstackCredentialsCreate,
+} from '../api/openstackProjects';
+import { getQuotas, type QuotasResponse } from '../api/quotas';
+
+const percent = (used?: number, limit?: number) => {
+  if (!used || !limit || limit === 0) return 0;
+  return Math.min(100, Math.max(0, Math.round((used / limit) * 100)));
+};
+
+const formatGB = (v?: number) => {
+  if (v == null) return '—';
+  return v >= 1024 ? `${(v / 1024).toFixed(1)} TB` : `${v} GB`;
+};
+
+const formatMBasGB = (v?: number) => {
+  if (v == null) return '—';
+  return `${Math.round(v / 1024)} GB`;
+};
 
 export function OpenStackConfig() {
-  const [showApiKey, setShowApiKey] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
-  const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'testing'>('connected');
   const [settingsMode, setSettingsMode] = useState<'general' | 'admin'>('general');
-  
+
   // Admin-Einstellungen States
   const [autoApproveTemplates, setAutoApproveTemplates] = useState(false);
   const [encryptSecrets, setEncryptSecrets] = useState(true);
   const [autoImageCreation, setAutoImageCreation] = useState(false);
   const [enforceMinPrivilege, setEnforceMinPrivilege] = useState(true);
 
-  const handleTestConnection = () => {
-    setConnectionStatus('testing');
-    setTimeout(() => {
-      setConnectionStatus('connected');
-    }, 2000);
+  // Credentials state
+  const [existingProject, setExistingProject] = useState<OpenstackProjectResponse | null>(null);
+  const [credentialsLoading, setCredentialsLoading] = useState(true);
+  const [saveLoading, setSaveLoading] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const [form, setForm] = useState<OpenstackCredentialsCreate>({
+    auth_url: '',
+    username: '',
+    password: '',
+    user_domain_name: 'Default',
+    region_name: '',
+    openstack_project_id: '',
+    openstack_project_name: '',
+  });
+
+  // Quotas state
+  const [quotas, setQuotas] = useState<QuotasResponse | null>(null);
+  const [quotasLoading, setQuotasLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    listOpenstackProjects()
+      .then(async (projects) => {
+        if (!mounted || projects.length === 0) return;
+        const p = projects[0];
+        setExistingProject(p);
+        // Fetch full credentials (includes auth_url, username masked)
+        const creds = await getOpenstackProject(p.id);
+        if (!mounted) return;
+        setForm((prev) => ({
+          ...prev,
+          auth_url: creds.auth_url,
+          username: creds.username,
+          region_name: creds.region_name,
+          openstack_project_id: creds.openstack_project_id,
+          openstack_project_name: creds.openstack_project_name,
+          user_domain_name: creds.user_domain_name,
+        }));
+      })
+      .catch(() => {/* no credentials yet */})
+      .finally(() => { if (mounted) setCredentialsLoading(false); });
+
+    getQuotas()
+      .then((data) => { if (mounted) setQuotas(data); })
+      .catch(() => {/* ignore */})
+      .finally(() => { if (mounted) setQuotasLoading(false); });
+
+    return () => { mounted = false; };
+  }, []);
+
+  const set = (field: keyof OpenstackCredentialsCreate) =>
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  const handleSaveCredentials = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.password.trim() && existingProject) {
+      setSaveError('Bitte geben Sie das Passwort ein, um die Zugangsdaten zu aktualisieren.');
+      return;
+    }
+    setSaveError(null);
+    setSaveSuccess(false);
+    setSaveLoading(true);
+    try {
+      if (existingProject) {
+        await updateOpenstackProject(existingProject.id, form);
+      } else {
+        await createOpenstackProject(form);
+      }
+      setSaveSuccess(true);
+      setForm((prev) => ({ ...prev, password: '' }));
+      // Refresh project list to get updated data
+      const projects = await listOpenstackProjects();
+      if (projects.length > 0) setExistingProject(projects[0]);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Fehler beim Speichern der Zugangsdaten');
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  const connectionStatus = existingProject ? 'connected' : 'disconnected';
+
+  const handleDeleteProject = async () => {
+    if (!existingProject) return;
+    setDeleteLoading(true);
+    try {
+      await deleteOpenstackProject(existingProject.id);
+      setExistingProject(null);
+      setForm({ auth_url: '', username: '', password: '', user_domain_name: 'Default', region_name: '', openstack_project_id: '', openstack_project_name: '' });
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Fehler beim Löschen des Projekts');
+    } finally {
+      setDeleteLoading(false);
+    }
   };
 
   return (
@@ -83,15 +201,14 @@ export function OpenStackConfig() {
             <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-4">
-                  <div className={`
-                    w-12 h-12 rounded-full flex items-center justify-center
-                    ${connectionStatus === 'connected' ? 'bg-green-100' : 
-                      connectionStatus === 'testing' ? 'bg-blue-100' : 'bg-red-100'}
-                  `}>
-                    {connectionStatus === 'connected' ? (
+                  <div className={`w-12 h-12 rounded-full flex items-center justify-center ${
+                    credentialsLoading ? 'bg-slate-100' :
+                    connectionStatus === 'connected' ? 'bg-green-100' : 'bg-red-100'
+                  }`}>
+                    {credentialsLoading ? (
+                      <RefreshCw className="w-6 h-6 text-slate-400 animate-spin" />
+                    ) : connectionStatus === 'connected' ? (
                       <CheckCircle2 className="w-6 h-6 text-green-600" />
-                    ) : connectionStatus === 'testing' ? (
-                      <RefreshCw className="w-6 h-6 text-blue-600 animate-spin" />
                     ) : (
                       <AlertCircle className="w-6 h-6 text-red-600" />
                     )}
@@ -99,31 +216,24 @@ export function OpenStackConfig() {
                   <div>
                     <p className="text-slate-900">Verbindungsstatus</p>
                     <p className="text-sm text-slate-500">
-                      {connectionStatus === 'connected' ? 'Mit OpenStack verbunden' :
-                       connectionStatus === 'testing' ? 'Verbindung wird getestet...' : 'Nicht verbunden'}
+                      {credentialsLoading ? 'Wird geprüft...' :
+                       connectionStatus === 'connected'
+                         ? `Verbunden mit Projekt: ${existingProject?.openstack_project_name}`
+                         : 'Keine Zugangsdaten hinterlegt'}
                     </p>
                   </div>
                 </div>
-                <div className="flex items-center gap-3">
-                  <Badge 
-                    className={
-                      connectionStatus === 'connected' ? 'bg-green-100 text-green-700 hover:bg-green-100' :
-                      connectionStatus === 'testing' ? 'bg-blue-100 text-blue-700 hover:bg-blue-100' :
-                      'bg-red-100 text-red-700 hover:bg-red-100'
-                    }
-                  >
-                    {connectionStatus === 'connected' ? 'Aktiv' :
-                     connectionStatus === 'testing' ? 'Testend' : 'Inaktiv'}
-                  </Badge>
-                  <Button
-                    variant="outline"
-                    onClick={handleTestConnection}
-                    disabled={connectionStatus === 'testing'}
-                  >
-                    <RefreshCw className={`w-4 h-4 mr-2 ${connectionStatus === 'testing' ? 'animate-spin' : ''}`} />
-                    Verbindung testen
-                  </Button>
-                </div>
+                <Badge
+                  className={
+                    credentialsLoading ? 'bg-slate-100 text-slate-600' :
+                    connectionStatus === 'connected'
+                      ? 'bg-green-100 text-green-700 hover:bg-green-100'
+                      : 'bg-red-100 text-red-700 hover:bg-red-100'
+                  }
+                >
+                  {credentialsLoading ? 'Prüft...' :
+                   connectionStatus === 'connected' ? 'Aktiv' : 'Nicht verbunden'}
+                </Badge>
               </div>
             </CardContent>
           </Card>
@@ -136,788 +246,442 @@ export function OpenStackConfig() {
                   <Settings className="w-5 h-5" />
                   Authentifizierung
                 </CardTitle>
-                <CardDescription>OpenStack API-Zugangsdaten</CardDescription>
+                <CardDescription>
+                  {existingProject ? 'OpenStack-Zugangsdaten aktualisieren' : 'OpenStack-Zugangsdaten hinterlegen'}
+                </CardDescription>
               </CardHeader>
-              <CardContent className="space-y-4">
-                <div>
-                  <Label htmlFor="auth-url">Authentifizierungs-URL</Label>
-                  <Input 
-                    id="auth-url"
-                    className="mt-2"
-                    defaultValue="https://openstack.university.edu:5000/v3"
-                  />
-                </div>
+              <CardContent>
+                <form onSubmit={handleSaveCredentials} className="space-y-4">
+                  {saveError && (
+                    <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+                      {saveError}
+                    </div>
+                  )}
+                  {saveSuccess && (
+                    <div className="p-3 rounded-lg bg-green-50 border border-green-200 text-sm text-green-700">
+                      Zugangsdaten erfolgreich gespeichert.
+                    </div>
+                  )}
 
-                <div>
-                  <Label htmlFor="project-name">Projektname</Label>
-                  <Input 
-                    id="project-name"
-                    className="mt-2"
-                    defaultValue="DoziLab-Production"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="domain">Domain</Label>
-                  <Input 
-                    id="domain"
-                    className="mt-2"
-                    defaultValue="default"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="username">Benutzername</Label>
-                  <Input 
-                    id="username"
-                    className="mt-2"
-                    defaultValue="admin"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="password">Passwort</Label>
-                  <div className="relative mt-2">
-                    <Input 
-                      id="password"
-                      type={showPassword ? 'text' : 'password'}
-                      defaultValue="supersecretpassword"
+                  <div>
+                    <Label htmlFor="auth-url">Authentifizierungs-URL</Label>
+                    <Input
+                      id="auth-url"
+                      className="mt-2"
+                      placeholder="https://openstack.example.com:5000/v3"
+                      value={form.auth_url}
+                      onChange={set('auth_url')}
+                      required
                     />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
-                    >
-                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
                   </div>
-                </div>
 
-                <div>
-                  <Label htmlFor="api-key">API-Key (Optional)</Label>
-                  <div className="relative mt-2">
-                    <Input 
-                      id="api-key"
-                      type={showApiKey ? 'text' : 'password'}
-                      placeholder="API-Key eingeben, falls Key-basierte Auth verwendet wird"
-                      defaultValue="sk-1234567890abcdef"
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <Label htmlFor="project-id">Projekt-ID</Label>
+                      <Input
+                        id="project-id"
+                        className="mt-2"
+                        placeholder="abc123..."
+                        value={form.openstack_project_id}
+                        onChange={set('openstack_project_id')}
+                        required
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="project-name">Projektname</Label>
+                      <Input
+                        id="project-name"
+                        className="mt-2"
+                        placeholder="mein-projekt"
+                        value={form.openstack_project_name}
+                        onChange={set('openstack_project_name')}
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <Label htmlFor="region">Region</Label>
+                      <Input
+                        id="region"
+                        className="mt-2"
+                        placeholder="RegionOne"
+                        value={form.region_name}
+                        onChange={set('region_name')}
+                        required
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="domain">User Domain</Label>
+                      <Input
+                        id="domain"
+                        className="mt-2"
+                        placeholder="Default"
+                        value={form.user_domain_name}
+                        onChange={set('user_domain_name')}
+                        required
+                      />
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="username">Benutzername</Label>
+                    <Input
+                      id="username"
+                      className="mt-2"
+                      placeholder={existingProject ? '(gespeichert, zum Ändern neu eingeben)' : 'OpenStack-Benutzername'}
+                      value={form.username}
+                      onChange={set('username')}
+                      required={!existingProject}
                     />
-                    <button
-                      type="button"
-                      onClick={() => setShowApiKey(!showApiKey)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
-                    >
-                      {showApiKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
                   </div>
-                </div>
 
-                <Button className="w-full bg-teal-500 hover:bg-teal-600 text-white">
-                  Zugangsdaten speichern
-                </Button>
+                  <div>
+                    <Label htmlFor="password">Passwort</Label>
+                    <div className="relative mt-2">
+                      <Input
+                        id="password"
+                        type={showPassword ? 'text' : 'password'}
+                        placeholder={existingProject ? 'Leer lassen, um nicht zu ändern' : 'OpenStack-Passwort'}
+                        value={form.password}
+                        onChange={set('password')}
+                        required={!existingProject}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword((v) => !v)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                      >
+                        {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                      </button>
+                    </div>
+                  </div>
+
+                  <Button
+                    type="submit"
+                    className="w-full bg-teal-500 hover:bg-teal-600 text-white"
+                    disabled={saveLoading || credentialsLoading}
+                  >
+                    {saveLoading ? 'Wird gespeichert...' : 'Zugangsdaten speichern'}
+                  </Button>
+
+                  {existingProject && (
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="w-full text-red-600 border-red-200 hover:bg-red-50 hover:border-red-300"
+                          disabled={deleteLoading}
+                        >
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          {deleteLoading ? 'Wird gelöscht...' : 'Projekt entfernen'}
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Projekt entfernen?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Das OpenStack-Projekt <strong>{existingProject.openstack_project_name}</strong> wird aus dem System entfernt. Diese Aktion kann nicht rückgängig gemacht werden.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter className="flex-row justify-end gap-2">
+                          <AlertDialogCancel className="mt-0">Abbrechen</AlertDialogCancel>
+                          <Button
+                            type="button"
+                            style={{ backgroundColor: '#dc2626', color: '#ffffff' }}
+                            onClick={handleDeleteProject}
+                            disabled={deleteLoading}
+                          >
+                            {deleteLoading ? 'Wird gelöscht...' : 'Entfernen'}
+                          </Button>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
+                </form>
               </CardContent>
             </Card>
 
-            {/* Endpoints & Quotas */}
+            {/* Quotas */}
             <div className="space-y-6">
-              {/* Service Endpoints */}
               <Card className="border-slate-200 shadow-sm">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Server className="w-5 h-5" />
-                    Service-Endpunkte
+                    Ressourcen-Quotas
                   </CardTitle>
-                  <CardDescription>OpenStack-Serviceendpunkte</CardDescription>
+                  <CardDescription>Aktuelle Zuteilungslimits Ihres Projekts</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <div>
-                    <Label htmlFor="compute">Compute (Nova)</Label>
-                    <Input 
-                      id="compute"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:8774/v2.1"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="network">Netzwerk (Neutron)</Label>
-                    <Input 
-                      id="network"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:9696"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="storage">Block Storage (Cinder)</Label>
-                    <Input 
-                      id="storage"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:8776/v3"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="image">Image (Glance)</Label>
-                    <Input 
-                      id="image"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:9292"
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Resource Quotas */}
-              <Card className="border-slate-200 shadow-sm">
-                <CardHeader>
-                  <CardTitle>Ressourcen-Quotas</CardTitle>
-                  <CardDescription>Aktuelle Zuteilungslimits</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-3">
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">CPU-Kerne</span>
-                      <Badge variant="outline">64 Kerne</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Arbeitsspeicher</span>
-                      <Badge variant="outline">192 GB</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Speicher</span>
-                      <Badge variant="outline">3.0 TB</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">VM-Instanzen</span>
-                      <Badge variant="outline">25 Instanzen</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Floating IPs</span>
-                      <Badge variant="outline">10 IPs</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Security Groups</span>
-                      <Badge variant="outline">15 Gruppen</Badge>
-                    </div>
-                  </div>
-
-                  <Button variant="outline" className="w-full">
-                    Quota-Erhöhung anfordern
-                  </Button>
+                  {quotasLoading && (
+                    <p className="text-sm text-slate-500">Lädt...</p>
+                  )}
+                  {!quotasLoading && !quotas && (
+                    <p className="text-sm text-slate-500">Keine Quota-Daten verfügbar</p>
+                  )}
+                  {!quotasLoading && quotas && (() => {
+                    const qc = quotas.compute.cores;
+                    const qram = quotas.compute.ram;
+                    const qvol = quotas.volume.gigabytes;
+                    const qinst = quotas.compute.instances;
+                    const qfip = quotas.network.floatingip;
+                    return (
+                      <div className="space-y-4">
+                        <div>
+                          <div className="flex justify-between text-sm mb-1">
+                            <span className="text-slate-600">CPU-Kerne</span>
+                            <span className="text-slate-900">{qc.used} / {qc.limit}</span>
+                          </div>
+                          <Progress value={percent(qc.used, qc.limit)} className="h-2" />
+                        </div>
+                        <div>
+                          <div className="flex justify-between text-sm mb-1">
+                            <span className="text-slate-600">Arbeitsspeicher</span>
+                            <span className="text-slate-900">{formatMBasGB(qram.used)} / {formatMBasGB(qram.limit)}</span>
+                          </div>
+                          <Progress value={percent(qram.used, qram.limit)} className="h-2" />
+                        </div>
+                        <div>
+                          <div className="flex justify-between text-sm mb-1">
+                            <span className="text-slate-600">Speicher (Volumes)</span>
+                            <span className="text-slate-900">{formatGB(qvol.used)} / {formatGB(qvol.limit)}</span>
+                          </div>
+                          <Progress value={percent(qvol.used, qvol.limit)} className="h-2" />
+                        </div>
+                        <div>
+                          <div className="flex justify-between text-sm mb-1">
+                            <span className="text-slate-600">VM-Instanzen</span>
+                            <span className="text-slate-900">{qinst.used} / {qinst.limit}</span>
+                          </div>
+                          <Progress value={percent(qinst.used, qinst.limit)} className="h-2" />
+                        </div>
+                        <div>
+                          <div className="flex justify-between text-sm mb-1">
+                            <span className="text-slate-600">Floating IPs</span>
+                            <span className="text-slate-900">{qfip.used} / {qfip.limit}</span>
+                          </div>
+                          <Progress value={percent(qfip.used, qfip.limit)} className="h-2" />
+                        </div>
+                        <div className="pt-2 border-t border-slate-100">
+                          <div className="flex justify-between items-center text-xs text-slate-400">
+                            <span>Projekt: {quotas.project_name}</span>
+                            <span>Stand: {new Date(quotas.fetched_at).toLocaleTimeString('de-DE')}</span>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })()}
                 </CardContent>
               </Card>
             </div>
           </div>
-
-          {/* Additional Settings */}
-          <Card className="border-slate-200 shadow-sm">
-            <CardHeader>
-              <CardTitle>Erweiterte Einstellungen</CardTitle>
-              <CardDescription>Zusätzliche Konfigurationsoptionen</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="region">Region</Label>
-                  <Input 
-                    id="region"
-                    className="mt-2"
-                    defaultValue="RegionOne"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="availability-zone">Availability Zone</Label>
-                  <Input 
-                    id="availability-zone"
-                    className="mt-2"
-                    defaultValue="nova"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="timeout">Verbindungszeitüberschreitung (Sekunden)</Label>
-                  <Input 
-                    id="timeout"
-                    type="number"
-                    className="mt-2"
-                    defaultValue="30"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="retry">Wiederholversuche</Label>
-                  <Input 
-                    id="retry"
-                    type="number"
-                    className="mt-2"
-                    defaultValue="3"
-                  />
-                </div>
-              </div>
-
-              <div className="flex gap-3 mt-6">
-                <Button className="bg-teal-500 hover:bg-teal-600 text-white">
-                  Alle Einstellungen speichern
-                </Button>
-                <Button variant="outline">
-                  Auf Standardeinstellungen zurücksetzen
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
         </>
       )}
 
       {/* Admin-Spezifische Einstellungen */}
       {settingsMode === 'admin' && (
         <>
-          {/* Connection Status Card */}
-          <Card className="border-slate-200 shadow-sm">
-            <CardContent className="p-6">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <div className={`
-                    w-12 h-12 rounded-full flex items-center justify-center
-                    ${connectionStatus === 'connected' ? 'bg-green-100' : 
-                      connectionStatus === 'testing' ? 'bg-blue-100' : 'bg-red-100'}
-                  `}>
-                    {connectionStatus === 'connected' ? (
-                      <CheckCircle2 className="w-6 h-6 text-green-600" />
-                    ) : connectionStatus === 'testing' ? (
-                      <RefreshCw className="w-6 h-6 text-blue-600 animate-spin" />
-                    ) : (
-                      <AlertCircle className="w-6 h-6 text-red-600" />
-                    )}
-                  </div>
-                  <div>
-                    <p className="text-slate-900">Verbindungsstatus</p>
-                    <p className="text-sm text-slate-500">
-                      {connectionStatus === 'connected' ? 'Mit OpenStack verbunden' :
-                       connectionStatus === 'testing' ? 'Verbindung wird getestet...' : 'Nicht verbunden'}
-                    </p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3">
-                  <Badge 
-                    className={
-                      connectionStatus === 'connected' ? 'bg-green-100 text-green-700 hover:bg-green-100' :
-                      connectionStatus === 'testing' ? 'bg-blue-100 text-blue-700 hover:bg-blue-100' :
-                      'bg-red-100 text-red-700 hover:bg-red-100'
-                    }
-                  >
-                    {connectionStatus === 'connected' ? 'Aktiv' :
-                     connectionStatus === 'testing' ? 'Testend' : 'Inaktiv'}
-                  </Badge>
-                  <Button
-                    variant="outline"
-                    onClick={handleTestConnection}
-                    disabled={connectionStatus === 'testing'}
-                  >
-                    <RefreshCw className={`w-4 h-4 mr-2 ${connectionStatus === 'testing' ? 'animate-spin' : ''}`} />
-                    Verbindung testen
-                  </Button>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* Authentication Settings */}
-            <Card className="border-slate-200 shadow-sm">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Settings className="w-5 h-5" />
-                  Authentifizierung
-                </CardTitle>
-                <CardDescription>OpenStack API-Zugangsdaten</CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div>
-                  <Label htmlFor="auth-url">Authentifizierungs-URL</Label>
-                  <Input 
-                    id="auth-url"
-                    className="mt-2"
-                    defaultValue="https://openstack.university.edu:5000/v3"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="project-name">Projektname</Label>
-                  <Input 
-                    id="project-name"
-                    className="mt-2"
-                    defaultValue="DoziLab-Production"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="domain">Domain</Label>
-                  <Input 
-                    id="domain"
-                    className="mt-2"
-                    defaultValue="default"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="username">Benutzername</Label>
-                  <Input 
-                    id="username"
-                    className="mt-2"
-                    defaultValue="admin"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="password">Passwort</Label>
-                  <div className="relative mt-2">
-                    <Input 
-                      id="password"
-                      type={showPassword ? 'text' : 'password'}
-                      defaultValue="supersecretpassword"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
-                    >
-                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
-                  </div>
-                </div>
-
-                <div>
-                  <Label htmlFor="api-key">API-Key (Optional)</Label>
-                  <div className="relative mt-2">
-                    <Input 
-                      id="api-key"
-                      type={showApiKey ? 'text' : 'password'}
-                      placeholder="API-Key eingeben, falls Key-basierte Auth verwendet wird"
-                      defaultValue="sk-1234567890abcdef"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowApiKey(!showApiKey)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
-                    >
-                      {showApiKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
-                  </div>
-                </div>
-
-                <Button className="w-full bg-teal-500 hover:bg-teal-600 text-white">
-                  Zugangsdaten speichern
-                </Button>
-              </CardContent>
-            </Card>
-
-            {/* Endpoints & Quotas */}
-            <div className="space-y-6">
-              {/* Service Endpoints */}
-              <Card className="border-slate-200 shadow-sm">
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Server className="w-5 h-5" />
-                    Service-Endpunkte
-                  </CardTitle>
-                  <CardDescription>OpenStack-Serviceendpunkte</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div>
-                    <Label htmlFor="compute">Compute (Nova)</Label>
-                    <Input 
-                      id="compute"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:8774/v2.1"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="network">Netzwerk (Neutron)</Label>
-                    <Input 
-                      id="network"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:9696"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="storage">Block Storage (Cinder)</Label>
-                    <Input 
-                      id="storage"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:8776/v3"
-                    />
-                  </div>
-
-                  <div>
-                    <Label htmlFor="image">Image (Glance)</Label>
-                    <Input 
-                      id="image"
-                      className="mt-2"
-                      defaultValue="https://openstack.university.edu:9292"
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Resource Quotas */}
-              <Card className="border-slate-200 shadow-sm">
-                <CardHeader>
-                  <CardTitle>Ressourcen-Quotas</CardTitle>
-                  <CardDescription>Aktuelle Zuteilungslimits</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="space-y-3">
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">CPU-Kerne</span>
-                      <Badge variant="outline">64 Kerne</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Arbeitsspeicher</span>
-                      <Badge variant="outline">192 GB</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Speicher</span>
-                      <Badge variant="outline">3.0 TB</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">VM-Instanzen</span>
-                      <Badge variant="outline">25 Instanzen</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Floating IPs</span>
-                      <Badge variant="outline">10 IPs</Badge>
-                    </div>
-                    <div className="flex justify-between items-center p-3 bg-slate-50 rounded-lg">
-                      <span className="text-sm text-slate-600">Security Groups</span>
-                      <Badge variant="outline">15 Gruppen</Badge>
-                    </div>
-                  </div>
-
-                  <Button variant="outline" className="w-full">
-                    Quota-Erhöhung anfordern
-                  </Button>
-                </CardContent>
-              </Card>
-            </div>
-          </div>
-
-          {/* Admin-Einstellungen */}
+          {/* Template Approval Workflow */}
           <Card className="border-slate-200 shadow-sm">
             <CardHeader>
-              <CardTitle>Admin-Einstellungen</CardTitle>
-              <CardDescription>Zusätzliche Konfigurationsoptionen für Administratoren</CardDescription>
+              <CardTitle className="flex items-center gap-2">
+                <Workflow className="w-5 h-5" />
+                Template-Genehmigungsworkflow
+              </CardTitle>
+              <CardDescription>
+                Verwalten Sie den Prozess für die Freigabe neuer Templates
+              </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="region">Region</Label>
-                  <Input 
-                    id="region"
-                    className="mt-2"
-                    defaultValue="RegionOne"
-                  />
+              <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
+                <div className="flex-1">
+                  <p className="text-slate-900">Automatische Genehmigung</p>
+                  <p className="text-sm text-slate-500">
+                    Templates automatisch ohne manuelle Überprüfung freigeben
+                  </p>
                 </div>
-
-                <div>
-                  <Label htmlFor="availability-zone">Availability Zone</Label>
-                  <Input 
-                    id="availability-zone"
-                    className="mt-2"
-                    defaultValue="nova"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="timeout">Verbindungszeitüberschreitung (Sekunden)</Label>
-                  <Input 
-                    id="timeout"
-                    type="number"
-                    className="mt-2"
-                    defaultValue="30"
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="retry">Wiederholversuche</Label>
-                  <Input 
-                    id="retry"
-                    type="number"
-                    className="mt-2"
-                    defaultValue="3"
-                  />
-                </div>
+                <Switch
+                  checked={autoApproveTemplates}
+                  onCheckedChange={setAutoApproveTemplates}
+                />
               </div>
 
-              <div className="flex gap-3 mt-6">
-                <Button className="bg-teal-500 hover:bg-teal-600 text-white">
-                  Alle Einstellungen speichern
-                </Button>
-                <Button variant="outline">
-                  Auf Standardeinstellungen zurücksetzen
-                </Button>
+              <div className="space-y-3">
+                <Label>Ressourcen-Prüfschwellen für Genehmigung</Label>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                  <div>
+                    <Label htmlFor="max-cpu-threshold" className="text-sm text-slate-600">
+                      Max. CPU-Kerne
+                    </Label>
+                    <Input id="max-cpu-threshold" type="number" className="mt-2" defaultValue="8" />
+                  </div>
+                  <div>
+                    <Label htmlFor="max-ram-threshold" className="text-sm text-slate-600">
+                      Max. RAM (GB)
+                    </Label>
+                    <Input id="max-ram-threshold" type="number" className="mt-2" defaultValue="16" />
+                  </div>
+                  <div>
+                    <Label htmlFor="max-gpu-threshold" className="text-sm text-slate-600">
+                      Max. GPU-Einheiten
+                    </Label>
+                    <Input id="max-gpu-threshold" type="number" className="mt-2" defaultValue="1" />
+                  </div>
+                </div>
+                <p className="text-sm text-slate-500">
+                  Templates, die diese Schwellen überschreiten, benötigen manuelle Genehmigung
+                </p>
+              </div>
+
+              <div>
+                <Label htmlFor="approval-email">Benachrichtigungs-E-Mail für Genehmigungen</Label>
+                <Input
+                  id="approval-email"
+                  type="email"
+                  className="mt-2"
+                  defaultValue="admin@university.edu"
+                />
+              </div>
+
+              <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
+                <div className="flex gap-3">
+                  <Workflow className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-sm text-blue-900">Workflow-Status</p>
+                    <p className="text-sm text-blue-700 mt-1">
+                      Genehmigungsworkflow aktiv · 3 Templates warten auf Freigabe
+                    </p>
+                  </div>
+                </div>
               </div>
             </CardContent>
           </Card>
 
-          {/* Admin-Spezifische Einstellungen */}
-          <div className="space-y-6">
-            {/* Template Approval Workflow */}
-            <Card className="border-slate-200 shadow-sm">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Workflow className="w-5 h-5" />
-                  Template-Genehmigungsworkflow
-                </CardTitle>
-                <CardDescription>
-                  Verwalten Sie den Prozess für die Freigabe neuer Templates (AC 2.3, AC 2.4)
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
-                  <div className="flex-1">
-                    <p className="text-slate-900">Automatische Genehmigung</p>
-                    <p className="text-sm text-slate-500">
-                      Templates automatisch ohne manuelle Überprüfung freigeben
-                    </p>
-                  </div>
-                  <Switch
-                    checked={autoApproveTemplates}
-                    onCheckedChange={setAutoApproveTemplates}
-                  />
-                </div>
-
-                <div className="space-y-3">
-                  <Label>Ressourcen-Prüfschwellen für Genehmigung</Label>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                    <div>
-                      <Label htmlFor="max-cpu-threshold" className="text-sm text-slate-600">
-                        Max. CPU-Kerne
-                      </Label>
-                      <Input
-                        id="max-cpu-threshold"
-                        type="number"
-                        className="mt-2"
-                        defaultValue="8"
-                        placeholder="Max. CPU-Kerne"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="max-ram-threshold" className="text-sm text-slate-600">
-                        Max. RAM (GB)
-                      </Label>
-                      <Input
-                        id="max-ram-threshold"
-                        type="number"
-                        className="mt-2"
-                        defaultValue="16"
-                        placeholder="Max. RAM (GB)"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="max-gpu-threshold" className="text-sm text-slate-600">
-                        Max. GPU-Einheiten
-                      </Label>
-                      <Input
-                        id="max-gpu-threshold"
-                        type="number"
-                        className="mt-2"
-                        defaultValue="1"
-                        placeholder="Max. GPU"
-                      />
-                    </div>
-                  </div>
+          {/* Security & Secrets Management */}
+          <Card className="border-slate-200 shadow-sm">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Lock className="w-5 h-5" />
+                Sicherheit & Secrets-Verwaltung
+              </CardTitle>
+              <CardDescription>
+                Konfiguration für verschlüsselte Speicherung und sichere API-Nutzung
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
+                <div className="flex-1">
+                  <p className="text-slate-900">Verschlüsselte Secrets-Speicherung</p>
                   <p className="text-sm text-slate-500">
-                    Templates, die diese Schwellen überschreiten, benötigen manuelle Genehmigung
+                    Alle Zugangsdaten werden verschlüsselt gespeichert (kein Client-Side-Storage)
                   </p>
                 </div>
+                <Switch checked={encryptSecrets} onCheckedChange={setEncryptSecrets} />
+              </div>
 
-                <div>
-                  <Label htmlFor="approval-email">Benachrichtigungs-E-Mail für Genehmigungen</Label>
-                  <Input
-                    id="approval-email"
-                    type="email"
-                    className="mt-2"
-                    defaultValue="admin@university.edu"
-                    placeholder="admin@university.edu"
-                  />
-                </div>
-
-                <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg">
-                  <div className="flex gap-3">
-                    <Workflow className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
-                    <div>
-                      <p className="text-sm text-blue-900">Workflow-Status</p>
-                      <p className="text-sm text-blue-700 mt-1">
-                        Genehmigungsworkflow aktiv · 3 Templates warten auf Freigabe
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-
-            {/* Security & Secrets Management */}
-            <Card className="border-slate-200 shadow-sm">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Lock className="w-5 h-5" />
-                  Sicherheit & Secrets-Verwaltung
-                </CardTitle>
-                <CardDescription>
-                  Konfiguration für verschlüsselte Speicherung und sichere API-Nutzung (AC 3.1, AC 3.2)
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
-                  <div className="flex-1">
-                    <p className="text-slate-900">Verschlüsselte Secrets-Speicherung</p>
-                    <p className="text-sm text-slate-500">
-                      Alle Zugangsdaten werden verschlüsselt gespeichert (kein Client-Side-Storage)
-                    </p>
-                  </div>
-                  <Switch
-                    checked={encryptSecrets}
-                    onCheckedChange={setEncryptSecrets}
-                  />
-                </div>
-
-                <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
-                  <div className="flex-1">
-                    <p className="text-slate-900">Prinzip der minimalen Berechtigung</p>
-                    <p className="text-sm text-slate-500">
-                      OpenStack-APIs nur mit minimalen erforderlichen Rechten nutzen
-                    </p>
-                  </div>
-                  <Switch
-                    checked={enforceMinPrivilege}
-                    onCheckedChange={setEnforceMinPrivilege}
-                  />
-                </div>
-
-                <div>
-                  <Label htmlFor="encryption-key">Verschlüsselungs-Algorithmus</Label>
-                  <Input
-                    id="encryption-key"
-                    className="mt-2"
-                    defaultValue="AES-256-GCM"
-                    disabled
-                  />
-                  <p className="text-sm text-slate-500 mt-1">
-                    Industriestandard-Verschlüsselung für maximale Sicherheit
+              <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
+                <div className="flex-1">
+                  <p className="text-slate-900">Prinzip der minimalen Berechtigung</p>
+                  <p className="text-sm text-slate-500">
+                    OpenStack-APIs nur mit minimalen erforderlichen Rechten nutzen
                   </p>
                 </div>
+                <Switch checked={enforceMinPrivilege} onCheckedChange={setEnforceMinPrivilege} />
+              </div>
 
-                <div>
-                  <Label htmlFor="key-rotation">Schlüsselrotation (Tage)</Label>
-                  <Input
-                    id="key-rotation"
-                    type="number"
-                    className="mt-2"
-                    defaultValue="90"
-                    placeholder="Tage bis zur automatischen Rotation"
-                  />
-                </div>
+              <div>
+                <Label htmlFor="encryption-key">Verschlüsselungs-Algorithmus</Label>
+                <Input id="encryption-key" className="mt-2" defaultValue="AES-256-GCM" disabled />
+              </div>
 
-                <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
-                  <div className="flex gap-3">
-                    <CheckCircle2 className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
-                    <div>
-                      <p className="text-sm text-green-900">Sicherheitsstatus</p>
-                      <p className="text-sm text-green-700 mt-1">
-                        Alle Secrets verschlüsselt · Kein Client-Side-Storage · OpenStack-Policies konform
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+              <div>
+                <Label htmlFor="key-rotation">Schlüsselrotation (Tage)</Label>
+                <Input id="key-rotation" type="number" className="mt-2" defaultValue="90" />
+              </div>
 
-            {/* Automated Base Image Creation */}
-            <Card className="border-slate-200 shadow-sm">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <FileCode className="w-5 h-5" />
-                  Automatisierte Basis-Image-Erstellung
-                </CardTitle>
-                <CardDescription>
-                  Automatisierung für die Erstellung klonbarer VM-Templates (AC 2.5)
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
-                  <div className="flex-1">
-                    <p className="text-slate-900">Automatische Image-Erstellung aktivieren</p>
-                    <p className="text-sm text-slate-500">
-                      Basis-VMs werden automatisch als klonbare Templates gespeichert
+              <div className="p-4 bg-green-50 border border-green-200 rounded-lg">
+                <div className="flex gap-3">
+                  <CheckCircle2 className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+                  <div>
+                    <p className="text-sm text-green-900">Sicherheitsstatus</p>
+                    <p className="text-sm text-green-700 mt-1">
+                      Alle Secrets verschlüsselt · Kein Client-Side-Storage · OpenStack-Policies konform
                     </p>
                   </div>
-                  <Switch
-                    checked={autoImageCreation}
-                    onCheckedChange={setAutoImageCreation}
-                  />
                 </div>
+              </div>
+            </CardContent>
+          </Card>
 
-                <div>
-                  <Label htmlFor="automation-script">Automatisierungsskript-Pfad</Label>
-                  <Input
-                    id="automation-script"
-                    className="mt-2"
-                    defaultValue="/opt/dozilab/scripts/create-base-image.sh"
-                    placeholder="Pfad zum Automatisierungsskript"
-                  />
+          {/* Automated Base Image Creation */}
+          <Card className="border-slate-200 shadow-sm">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <FileCode className="w-5 h-5" />
+                Automatisierte Basis-Image-Erstellung
+              </CardTitle>
+              <CardDescription>
+                Automatisierung für die Erstellung klonbarer VM-Templates
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between p-4 bg-slate-50 rounded-lg">
+                <div className="flex-1">
+                  <p className="text-slate-900">Automatische Image-Erstellung aktivieren</p>
+                  <p className="text-sm text-slate-500">
+                    Basis-VMs werden automatisch als klonbare Templates gespeichert
+                  </p>
                 </div>
+                <Switch checked={autoImageCreation} onCheckedChange={setAutoImageCreation} />
+              </div>
 
-                <div>
-                  <Label htmlFor="base-image-template">Basis-Template-Konfiguration</Label>
-                  <Textarea
-                    id="base-image-template"
-                    className="mt-2 font-mono text-sm"
-                    rows={6}
-                    defaultValue={`# Base Image Automation Config
+              <div>
+                <Label htmlFor="automation-script">Automatisierungsskript-Pfad</Label>
+                <Input
+                  id="automation-script"
+                  className="mt-2"
+                  defaultValue="/opt/dozilab/scripts/create-base-image.sh"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="base-image-template">Basis-Template-Konfiguration</Label>
+                <Textarea
+                  id="base-image-template"
+                  className="mt-2 font-mono text-sm"
+                  rows={6}
+                  defaultValue={`# Base Image Automation Config
 image_format: qcow2
 snapshot_enabled: true
 clone_template: true
 auto_optimize: true
 cleanup_after_build: true`}
-                  />
-                </div>
+                />
+              </div>
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  <div>
-                    <Label htmlFor="image-retention" className="text-sm text-slate-600">
-                      Image-Aufbewahrung (Tage)
-                    </Label>
-                    <Input
-                      id="image-retention"
-                      type="number"
-                      className="mt-2"
-                      defaultValue="365"
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="max-concurrent-builds" className="text-sm text-slate-600">
-                      Max. gleichzeitige Builds
-                    </Label>
-                    <Input
-                      id="max-concurrent-builds"
-                      type="number"
-                      className="mt-2"
-                      defaultValue="3"
-                    />
-                  </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                <div>
+                  <Label htmlFor="image-retention" className="text-sm text-slate-600">
+                    Image-Aufbewahrung (Tage)
+                  </Label>
+                  <Input id="image-retention" type="number" className="mt-2" defaultValue="365" />
                 </div>
+                <div>
+                  <Label htmlFor="max-concurrent-builds" className="text-sm text-slate-600">
+                    Max. gleichzeitige Builds
+                  </Label>
+                  <Input id="max-concurrent-builds" type="number" className="mt-2" defaultValue="3" />
+                </div>
+              </div>
 
-                <Button variant="outline" className="w-full">
-                  <FileCode className="w-4 h-4 mr-2" />
-                  Automatisierungsskript testen
-                </Button>
-              </CardContent>
-            </Card>
-          </div>
+              <Button variant="outline" className="w-full">
+                <FileCode className="w-4 h-4 mr-2" />
+                Automatisierungsskript testen
+              </Button>
+            </CardContent>
+          </Card>
 
           <div className="flex gap-3">
             <Button className="bg-teal-500 hover:bg-teal-600 text-white">

--- a/src/pages/OpenStackSetup.tsx
+++ b/src/pages/OpenStackSetup.tsx
@@ -1,0 +1,306 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Eye, EyeOff, Server, FileText, FormInput } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { Textarea } from "../components/ui/textarea";
+import { createOpenstackProject, updateOpenstackProject, type OpenstackCredentialsCreate } from "../api/openstackProjects";
+
+function parseCloudsYaml(yaml: string): Partial<OpenstackCredentialsCreate> | string {
+  try {
+    // Extract the first cloud entry under clouds:
+    const cloudMatch = yaml.match(/clouds:\s*\n([\s\S]*)/);
+    if (!cloudMatch) return "Kein 'clouds:' Block gefunden.";
+
+    const body = cloudMatch[1];
+
+    const get = (key: string) => {
+      const m = body.match(new RegExp(`${key}:\\s*["']?([^"'\\n]+?)["']?\\s*$`, "m"));
+      return m ? m[1].trim() : "";
+    };
+
+    const result: Partial<OpenstackCredentialsCreate> = {
+      auth_url: get("auth_url"),
+      username: get("username"),
+      password: get("password"),
+      openstack_project_id: get("project_id"),
+      openstack_project_name: get("project_name"),
+      user_domain_name: get("user_domain_name") || "Default",
+      region_name: get("region_name"),
+    };
+
+    if (!result.auth_url) return "auth_url nicht gefunden.";
+    if (!result.username) return "username nicht gefunden.";
+
+    return result;
+  } catch {
+    return "Fehler beim Lesen der YAML-Datei.";
+  }
+}
+
+const emptyForm: OpenstackCredentialsCreate = {
+  auth_url: "",
+  username: "",
+  password: "",
+  user_domain_name: "Default",
+  region_name: "",
+  openstack_project_id: "",
+  openstack_project_name: "",
+};
+
+export function OpenStackSetup({ onSuccess }: { onSuccess?: () => void }) {
+  const navigate = useNavigate();
+  const [tab, setTab] = useState<"form" | "yaml">("yaml");
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [yamlInput, setYamlInput] = useState("");
+  const [form, setForm] = useState<OpenstackCredentialsCreate>(emptyForm);
+
+  const set = (field: keyof OpenstackCredentialsCreate) =>
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((prev) => ({ ...prev, [field]: e.target.value }));
+
+  const save = async (data: OpenstackCredentialsCreate) => {
+    setError(null);
+    setLoading(true);
+    try {
+      await createOpenstackProject(data);
+      onSuccess ? onSuccess() : navigate("/dashboard", { replace: true });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "";
+      const body = (err as any)?.body ?? "";
+      const existingId = (msg + body).match(/Use the existing project \(ID: ([^)]+)\)/)?.[1];
+      if (existingId) {
+        try {
+          await updateOpenstackProject(existingId, data);
+          onSuccess ? onSuccess() : navigate("/dashboard", { replace: true });
+          return;
+        } catch (updateErr) {
+          setError(updateErr instanceof Error ? updateErr.message : "Fehler beim Aktualisieren der Zugangsdaten");
+          return;
+        }
+      }
+      setError(msg || "Fehler beim Speichern der Zugangsdaten");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleYamlSubmit = () => {
+    setError(null);
+    const result = parseCloudsYaml(yamlInput);
+    if (typeof result === "string") {
+      setError(result);
+      return;
+    }
+    const merged = { ...emptyForm, ...result };
+    setForm(merged);
+    save(merged);
+  };
+
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    save(form);
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center p-6">
+      <div className="w-full max-w-lg">
+        <Card className="border-slate-200 shadow-sm">
+          <CardHeader>
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-lg bg-teal-50 flex items-center justify-center">
+                <Server className="w-5 h-5 text-teal-600" />
+              </div>
+              <div>
+                <CardTitle>OpenStack einrichten</CardTitle>
+                <CardDescription>
+                  Geben Sie Ihre Zugangsdaten ein oder fügen Sie eine clouds.yaml ein
+                </CardDescription>
+              </div>
+            </div>
+
+            {/* Tab toggle */}
+            <div className="flex gap-1 bg-slate-100 rounded-lg p-1 mt-4">
+              <button
+                type="button"
+                onClick={() => setTab("yaml")}
+                className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md text-sm transition-all ${
+                  tab === "yaml"
+                    ? "bg-white text-teal-600 shadow-sm"
+                    : "text-slate-600 hover:text-slate-900"
+                }`}
+              >
+                <FileText className="w-4 h-4" />
+                clouds.yaml
+              </button>
+              <button
+                type="button"
+                onClick={() => setTab("form")}
+                className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md text-sm transition-all ${
+                  tab === "form"
+                    ? "bg-white text-teal-600 shadow-sm"
+                    : "text-slate-600 hover:text-slate-900"
+                }`}
+              >
+                <FormInput className="w-4 h-4" />
+                Formular
+              </button>
+            </div>
+          </CardHeader>
+
+          <CardContent>
+            {error && (
+              <div className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            {/* YAML Tab */}
+            {tab === "yaml" && (
+              <div className="space-y-4">
+                <Textarea
+                  className="font-mono text-sm h-64 resize-none"
+                  placeholder={`clouds:\n  openstack:\n    auth:\n      auth_url: https://...\n      username: "user"\n      password: "pass"\n      project_id: abc123\n      project_name: "mein-projekt"\n      user_domain_name: "Default"\n    region_name: "RegionOne"`}
+                  value={yamlInput}
+                  onChange={(e) => setYamlInput(e.target.value)}
+                  spellCheck={false}
+                  disabled={loading}
+                />
+                {loading && (
+                  <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+                    <div className="h-full bg-teal-500 rounded-full animate-[progress_1.5s_ease-in-out_infinite]" style={{ width: '60%', animation: 'pulse 1s ease-in-out infinite' }} />
+                  </div>
+                )}
+                <Button
+                  type="button"
+                  className="w-full bg-teal-500 hover:bg-teal-600 text-white"
+                  onClick={handleYamlSubmit}
+                  disabled={!yamlInput.trim() || loading}
+                >
+                  {loading ? "Wird gespeichert..." : "Einlesen & speichern"}
+                </Button>
+              </div>
+            )}
+
+            {/* Form Tab */}
+            {tab === "form" && (
+              <form onSubmit={handleFormSubmit} className="space-y-4">
+                <div>
+                  <Label htmlFor="auth_url">Authentifizierungs-URL</Label>
+                  <Input
+                    id="auth_url"
+                    className="mt-2"
+                    placeholder="https://openstack.example.com:5000/v3"
+                    value={form.auth_url}
+                    onChange={set("auth_url")}
+                    required
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="openstack_project_id">Projekt-ID</Label>
+                    <Input
+                      id="openstack_project_id"
+                      className="mt-2"
+                      placeholder="abc123..."
+                      value={form.openstack_project_id}
+                      onChange={set("openstack_project_id")}
+                      required
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="openstack_project_name">Projektname</Label>
+                    <Input
+                      id="openstack_project_name"
+                      className="mt-2"
+                      placeholder="mein-projekt"
+                      value={form.openstack_project_name}
+                      onChange={set("openstack_project_name")}
+                      required
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="region_name">Region</Label>
+                    <Input
+                      id="region_name"
+                      className="mt-2"
+                      placeholder="RegionOne"
+                      value={form.region_name}
+                      onChange={set("region_name")}
+                      required
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="user_domain_name">User Domain</Label>
+                    <Input
+                      id="user_domain_name"
+                      className="mt-2"
+                      placeholder="Default"
+                      value={form.user_domain_name}
+                      onChange={set("user_domain_name")}
+                      required
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <Label htmlFor="username">Benutzername</Label>
+                  <Input
+                    id="username"
+                    className="mt-2"
+                    placeholder="OpenStack-Benutzername"
+                    value={form.username}
+                    onChange={set("username")}
+                    required
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="password">Passwort</Label>
+                  <div className="relative mt-2">
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      placeholder="OpenStack-Passwort"
+                      value={form.password}
+                      onChange={set("password")}
+                      required
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                    >
+                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                </div>
+
+                <Button
+                  type="submit"
+                  className="w-full bg-teal-500 hover:bg-teal-600 text-white"
+                  disabled={loading}
+                >
+                  {loading ? "Wird gespeichert..." : "Zugangsdaten speichern & fortfahren"}
+                </Button>
+                {loading && (
+                  <div className="w-full h-1.5 bg-slate-100 rounded-full overflow-hidden">
+                    <div className="h-full bg-teal-500 rounded-full" style={{ width: '60%', animation: 'pulse 1s ease-in-out infinite' }} />
+                  </div>
+                )}
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,77 +1,77 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
 
-  import { defineConfig } from 'vite';
-  import react from '@vitejs/plugin-react-swc';
-  import path from 'path';
-
-  export default defineConfig({
-    optimizeDeps: {
+export default defineConfig({
+  optimizeDeps: {
     include: [
-      'keycloak-js', 
+      'keycloak-js',
       '@react-keycloak/web',
       'lucide-react',
       'recharts',
       'axios'
     ],
   },
-    plugins: [react()],
-    resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
-      alias: {
-        'vaul@1.1.2': 'vaul',
-        'sonner@2.0.3': 'sonner',
-        'recharts@2.15.2': 'recharts',
-        'react-resizable-panels@2.1.7': 'react-resizable-panels',
-        'react-hook-form@7.55.0': 'react-hook-form',
-        'react-day-picker@8.10.1': 'react-day-picker',
-        'next-themes@0.4.6': 'next-themes',
-        'lucide-react@0.487.0': 'lucide-react',
-        'input-otp@1.4.2': 'input-otp',
-        'figma:asset/5c87f57a05de8f8018669c9004318908d006dcd5.png': path.resolve(__dirname, './src/assets/5c87f57a05de8f8018669c9004318908d006dcd5.png'),
-        'embla-carousel-react@8.6.0': 'embla-carousel-react',
-        'cmdk@1.1.1': 'cmdk',
-        'class-variance-authority@0.7.1': 'class-variance-authority',
-        '@radix-ui/react-tooltip@1.1.8': '@radix-ui/react-tooltip',
-        '@radix-ui/react-toggle@1.1.2': '@radix-ui/react-toggle',
-        '@radix-ui/react-toggle-group@1.1.2': '@radix-ui/react-toggle-group',
-        '@radix-ui/react-tabs@1.1.3': '@radix-ui/react-tabs',
-        '@radix-ui/react-switch@1.1.3': '@radix-ui/react-switch',
-        '@radix-ui/react-slot@1.1.2': '@radix-ui/react-slot',
-        '@radix-ui/react-slider@1.2.3': '@radix-ui/react-slider',
-        '@radix-ui/react-separator@1.1.2': '@radix-ui/react-separator',
-        '@radix-ui/react-select@2.1.6': '@radix-ui/react-select',
-        '@radix-ui/react-scroll-area@1.2.3': '@radix-ui/react-scroll-area',
-        '@radix-ui/react-radio-group@1.2.3': '@radix-ui/react-radio-group',
-        '@radix-ui/react-progress@1.1.2': '@radix-ui/react-progress',
-        '@radix-ui/react-popover@1.1.6': '@radix-ui/react-popover',
-        '@radix-ui/react-navigation-menu@1.2.5': '@radix-ui/react-navigation-menu',
-        '@radix-ui/react-menubar@1.1.6': '@radix-ui/react-menubar',
-        '@radix-ui/react-label@2.1.2': '@radix-ui/react-label',
-        '@radix-ui/react-hover-card@1.1.6': '@radix-ui/react-hover-card',
-        '@radix-ui/react-dropdown-menu@2.1.6': '@radix-ui/react-dropdown-menu',
-        '@radix-ui/react-dialog@1.1.6': '@radix-ui/react-dialog',
-        '@radix-ui/react-context-menu@2.2.6': '@radix-ui/react-context-menu',
-        '@radix-ui/react-collapsible@1.1.3': '@radix-ui/react-collapsible',
-        '@radix-ui/react-checkbox@1.1.4': '@radix-ui/react-checkbox',
-        '@radix-ui/react-avatar@1.1.3': '@radix-ui/react-avatar',
-        '@radix-ui/react-aspect-ratio@1.1.2': '@radix-ui/react-aspect-ratio',
-        '@radix-ui/react-alert-dialog@1.1.6': '@radix-ui/react-alert-dialog',
-        '@radix-ui/react-accordion@1.2.3': '@radix-ui/react-accordion',
-        '@': path.resolve(__dirname, './src'),
+  plugins: [react()],
+  resolve: {
+    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+    alias: {
+      'vaul@1.1.2': 'vaul',
+      'sonner@2.0.3': 'sonner',
+      'recharts@2.15.2': 'recharts',
+      'react-resizable-panels@2.1.7': 'react-resizable-panels',
+      'react-hook-form@7.55.0': 'react-hook-form',
+      'react-day-picker@8.10.1': 'react-day-picker',
+      'next-themes@0.4.6': 'next-themes',
+      'lucide-react@0.487.0': 'lucide-react',
+      'input-otp@1.4.2': 'input-otp',
+      'figma:asset/5c87f57a05de8f8018669c9004318908d006dcd5.png': path.resolve(__dirname, './src/assets/5c87f57a05de8f8018669c9004318908d006dcd5.png'),
+      'embla-carousel-react@8.6.0': 'embla-carousel-react',
+      'cmdk@1.1.1': 'cmdk',
+      'class-variance-authority@0.7.1': 'class-variance-authority',
+      '@radix-ui/react-tooltip@1.1.8': '@radix-ui/react-tooltip',
+      '@radix-ui/react-toggle@1.1.2': '@radix-ui/react-toggle',
+      '@radix-ui/react-toggle-group@1.1.2': '@radix-ui/react-toggle-group',
+      '@radix-ui/react-tabs@1.1.3': '@radix-ui/react-tabs',
+      '@radix-ui/react-switch@1.1.3': '@radix-ui/react-switch',
+      '@radix-ui/react-slot@1.1.2': '@radix-ui/react-slot',
+      '@radix-ui/react-slider@1.2.3': '@radix-ui/react-slider',
+      '@radix-ui/react-separator@1.1.2': '@radix-ui/react-separator',
+      '@radix-ui/react-select@2.1.6': '@radix-ui/react-select',
+      '@radix-ui/react-scroll-area@1.2.3': '@radix-ui/react-scroll-area',
+      '@radix-ui/react-radio-group@1.2.3': '@radix-ui/react-radio-group',
+      '@radix-ui/react-progress@1.1.2': '@radix-ui/react-progress',
+      '@radix-ui/react-popover@1.1.6': '@radix-ui/react-popover',
+      '@radix-ui/react-navigation-menu@1.2.5': '@radix-ui/react-navigation-menu',
+      '@radix-ui/react-menubar@1.1.6': '@radix-ui/react-menubar',
+      '@radix-ui/react-label@2.1.2': '@radix-ui/react-label',
+      '@radix-ui/react-hover-card@1.1.6': '@radix-ui/react-hover-card',
+      '@radix-ui/react-dropdown-menu@2.1.6': '@radix-ui/react-dropdown-menu',
+      '@radix-ui/react-dialog@1.1.6': '@radix-ui/react-dialog',
+      '@radix-ui/react-context-menu@2.2.6': '@radix-ui/react-context-menu',
+      '@radix-ui/react-collapsible@1.1.3': '@radix-ui/react-collapsible',
+      '@radix-ui/react-checkbox@1.1.4': '@radix-ui/react-checkbox',
+      '@radix-ui/react-avatar@1.1.3': '@radix-ui/react-avatar',
+      '@radix-ui/react-aspect-ratio@1.1.2': '@radix-ui/react-aspect-ratio',
+      '@radix-ui/react-alert-dialog@1.1.6': '@radix-ui/react-alert-dialog',
+      '@radix-ui/react-accordion@1.2.3': '@radix-ui/react-accordion',
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    target: 'esnext',
+    outDir: 'build',
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://141.72.176.109:8000",
+        changeOrigin: true,
+        secure: false,
       },
+
     },
-    build: {
-      target: 'esnext',
-      outDir: 'build',
-    },
-    server: {
-      proxy: {
-        "/api": {
-          target: "http://141.72.176.109:8000",
-          changeOrigin: true,
-          secure: false,
-        },
-      },
-      port: 3000,
-      open: true,
-    },
-  });
+    port: 3000,
+    open: true,
+  },
+});


### PR DESCRIPTION
- Add /setup page with clouds.yaml paste or manual form input
- Redirect new lecturers (no saved project) to /setup after login
- Save credentials via POST /api/v1/openstack-projects, auto-fallback to PUT on 409 conflict (project already exists)
- Load real credentials and live quotas in /config settings page
- Add "Projekt entfernen" button with AlertDialog confirmation
- Improve apiFetch error handling: parse JSON body and expose message