### PR TITLE
feat: deployment UX — live logs, SSE streaming, file upload, credenti…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Re-resolve upstream DNS on every request (prevents stale IP after container restart)
+    resolver 127.0.0.11 valid=5s;
+    set $upstream http://api:8000;
+
     # React Router / SPA
     location / {
         try_files $uri $uri/ /index.html;
@@ -12,7 +16,7 @@ server {
 
     # Backend API Proxy
     location /api {
-        proxy_pass http://api:8000;
+        proxy_pass $upstream;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./http";
+import keycloak from "../auth/keycloak";
 
 export type DeploymentDto = {
   id: string;
@@ -85,10 +86,11 @@ export type DeploymentLogDto = {
 export type DeploymentCreateRequest = {
   name?: string;
   template_version_id: string;
-  course_id: string;  // Keycloak Group ID
+  course_id: string;
   deployment_mode?: string;
   config_json?: string;
-  heat_parameters?: Record<string, any>;
+  parameters?: Record<string, any>;
+  user_files?: Record<string, string>;  // file_name -> base64-encoded content
   stack_assignments?: Array<{
     groups: Array<{
       group_name: string;
@@ -156,15 +158,69 @@ export async function getDeploymentLogs(deploymentId: string) {
   }>(`/api/v1/deployments/${deploymentId}/logs`);
 }
 
+/**
+ * Stream deployment logs via SSE (fetch-based, supports Bearer auth).
+ * Calls onLog for each new log entry, onDone when stream closes.
+ * Returns a cleanup function to abort the stream.
+ */
+export function streamDeploymentLogs(
+  deploymentId: string,
+  sinceId: string | undefined,
+  onLog: (log: DeploymentLogDto) => void,
+  onDone: () => void,
+): () => void {
+  const controller = new AbortController();
+
+  (async () => {
+    try {
+      try { await keycloak.updateToken(30); } catch {}
+      const token = keycloak.token;
+      const url = `/api/v1/deployments/${deploymentId}/logs/stream${sinceId ? `?since_id=${sinceId}` : ""}`;
+
+      const res = await fetch(url, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: controller.signal,
+      });
+
+      if (!res.ok || !res.body) { onDone(); return; }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const line of lines) {
+          if (line.startsWith("event: done")) { onDone(); return; }
+          if (line.startsWith("data: ")) {
+            try { onLog(JSON.parse(line.slice(6))); } catch {}
+          }
+        }
+      }
+    } catch (e: any) {
+      if (e?.name !== "AbortError") console.error("SSE error", e);
+    }
+    onDone();
+  })();
+
+  return () => controller.abort();
+}
+
 export async function deleteDeployment(deploymentId: string) {
-  return apiFetch<{
-    success: boolean;
-    message: string;
-    data?: any;
-    errors: unknown;
-    timestamp: string;
-    request_id: string;
-  }>(`/api/v1/deployments/${deploymentId}` , { method: "DELETE" });
+  // Backend returns 204 No Content — don't call res.json()
+  await keycloak.updateToken(30).catch(() => {});
+  const res = await fetch(`/api/v1/deployments/${deploymentId}`, {
+    method: "DELETE",
+    headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(text || res.statusText);
+  }
 }
 
 // List deployments (stacks) from OpenStack view

--- a/src/api/templates.ts
+++ b/src/api/templates.ts
@@ -15,6 +15,16 @@ export type TemplateParameter = {
   max?: number;
 };
 
+export type UserFileDefinition = {
+  name: string;
+  label?: string;
+  description?: string;
+  required?: boolean;
+  accept?: string;
+  destination?: string;
+  mode?: "all_stacks" | "per_group";
+};
+
 export type TemplateVersionDto = {
   id: string;
   template_id: string;
@@ -23,6 +33,8 @@ export type TemplateVersionDto = {
   is_active: boolean;
   created_at: string;
   parameters?: TemplateParameter[];
+  user_files?: UserFileDefinition[];
+  allow_user_files?: boolean;
 };
 
 export type TemplateDto = {

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -1,15 +1,21 @@
 import { useCallback, useState } from "react";
-import { 
-  CheckCircle2, 
-  Clock, 
-  AlertCircle, 
-  XCircle, 
+import React from "react";
+import {
+  CheckCircle2,
+  Clock,
+  AlertCircle,
+  XCircle,
   ArrowLeft,
   Eye,
   EyeOff,
   Copy,
   Download,
-  Loader2
+  Loader2,
+  ChevronDown,
+  ChevronRight,
+  Flame,
+  Terminal,
+  Flag,
 } from "lucide-react";
 import { toast } from "sonner@2.0.3";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
@@ -30,8 +36,10 @@ import {
 import {
   AccessType,
   DeploymentCredentialsResponse,
+  DeploymentLogDto,
   getDeploymentCredentials,
 } from "../api/deployments";
+import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
 
 interface DeploymentStep {
   id: string;
@@ -47,7 +55,7 @@ interface DeploymentStep {
 interface Deployment {
   id: string;
   name: string;
-  status: 'deploying' | 'running' | 'failed' | 'cancelled' | 'stopped';
+  status: 'deploying' | 'running' | 'failed' | 'cancelled' | 'stopped' | 'deleting' | 'delete_failed';
   course: string;
   startedAt: string;
   completedAt?: string;
@@ -55,6 +63,8 @@ interface Deployment {
   progress: number;
   currentStep?: string;
   steps: DeploymentStep[];
+  phases?: LogPhase[];
+  logs?: DeploymentLogDto[];
   error?: string;
   resources: {
     cpu: number;
@@ -184,8 +194,17 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
     URL.revokeObjectURL(url);
   };
   const getStatusBadge = () => {
+    const hasFailedPhase = deployment.phases?.some(p => p.status === 'failed');
     switch (deployment.status) {
       case 'running':
+        if (hasFailedPhase) {
+          return (
+            <Badge className="bg-red-100 text-red-700 hover:bg-red-100">
+              <XCircle className="w-4 h-4 mr-2" />
+              Fehlgeschlagen
+            </Badge>
+          );
+        }
         return (
           <Badge className="bg-green-100 text-green-700 hover:bg-green-100">
             <CheckCircle2 className="w-4 h-4 mr-2" />
@@ -213,56 +232,26 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
             Abgebrochen
           </Badge>
         );
+      case 'deleting':
+        return (
+          <Badge className="bg-red-100 text-red-700 hover:bg-red-100">
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+            Wird gelöscht…
+          </Badge>
+        );
+      case 'delete_failed':
+        return (
+          <Badge className="bg-orange-100 text-orange-700 hover:bg-orange-100">
+            <AlertCircle className="w-4 h-4 mr-2" />
+            Löschen fehlgeschlagen
+          </Badge>
+        );
       case 'stopped':
         return (
           <Badge className="bg-slate-100 text-slate-700 hover:bg-slate-100">
             Gestoppt
           </Badge>
         );
-    }
-  };
-
-  const getStepIcon = (step: DeploymentStep) => {
-    const Icon = step.icon;
-    
-    switch (step.status) {
-      case 'completed':
-        return (
-          <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
-            <CheckCircle2 className="w-5 h-5 text-green-600" />
-          </div>
-        );
-      case 'in-progress':
-        return (
-          <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
-            <Loader2 className="w-5 h-5 text-blue-600 animate-spin" />
-          </div>
-        );
-      case 'failed':
-        return (
-          <div className="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
-            <XCircle className="w-5 h-5 text-red-600" />
-          </div>
-        );
-      case 'pending':
-        return (
-          <div className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center">
-            <Icon className="w-5 h-5 text-slate-400" />
-          </div>
-        );
-    }
-  };
-
-  const getStepStatusBadge = (status: string) => {
-    switch (status) {
-      case 'completed':
-        return <Badge className="bg-green-100 text-green-700 hover:bg-green-100">Abgeschlossen</Badge>;
-      case 'in-progress':
-        return <Badge className="bg-blue-100 text-blue-700 hover:bg-blue-100">In Bearbeitung</Badge>;
-      case 'failed':
-        return <Badge className="bg-red-100 text-red-700 hover:bg-red-100">Fehlgeschlagen</Badge>;
-      case 'pending':
-        return <Badge className="bg-slate-100 text-slate-700 hover:bg-slate-100">Ausstehend</Badge>;
     }
   };
 
@@ -287,7 +276,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
           <div className="flex flex-col items-end gap-2">
             {getStatusBadge()}
             <p className="text-sm text-slate-500">
-              Gestartet: {deployment.startedAt}
+              Gestartet: {new Date(deployment.startedAt).toLocaleString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
             </p>
           </div>
         </div>
@@ -306,10 +295,6 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
               </div>
               <div className="text-right">
                 <p className="text-2xl text-blue-600 mb-1">{deployment.progress}%</p>
-                <p className="text-sm text-slate-500">
-                  <Clock className="w-3 h-3 inline mr-1" />
-                  Ca. {deployment.estimatedTimeRemaining} verbleibend
-                </p>
               </div>
             </div>
             <Progress value={deployment.progress} className="h-3" />
@@ -318,7 +303,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
       )}
 
       {/* Success Message für abgeschlossene Deployments */}
-      {deployment.status === 'running' && (
+      {deployment.status === 'running' && !deployment.phases?.some(p => p.status === 'failed') && (
         <Card className="border-green-200 shadow-sm bg-gradient-to-br from-green-50 to-white">
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
@@ -331,8 +316,34 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                   Ihre Anwendung wurde erfolgreich bereitgestellt und ist jetzt für Ihre Kursteilnehmer verfügbar.
                 </p>
                 <p className="text-sm text-green-600">
-                  Abgeschlossen am: {deployment.completedAt}
+                  Abgeschlossen am: {deployment.completedAt ? new Date(deployment.completedAt).toLocaleString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" }) : "-"}
                 </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Partial failure: Heat OK but a phase failed — show as full error */}
+      {deployment.status === 'running' && deployment.phases?.some(p => p.status === 'failed') && (
+        <Card className="border-red-200 shadow-sm bg-gradient-to-br from-red-50 to-white">
+          <CardContent className="p-6">
+            <div className="flex items-start gap-4">
+              <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center flex-shrink-0">
+                <XCircle className="w-6 h-6 text-red-600" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-red-900 mb-2">Deployment fehlgeschlagen</h3>
+                <p className="text-sm text-red-700 mb-3">
+                  Bei der Bereitstellung ist ein Fehler aufgetreten. Bitte überprüfen Sie die Details unten.
+                </p>
+                {deployment.error && (
+                  <div className="p-3 bg-red-100 rounded-lg">
+                    <p className="text-sm text-red-900">
+                      <strong>Fehlermeldung:</strong> {deployment.error}
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </CardContent>
@@ -382,56 +393,78 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
         </Card>
       )}
 
+      {/* Delete failed — show retry */}
+      {deployment.status === 'delete_failed' && (
+        <Card className="border-orange-200 shadow-sm bg-gradient-to-br from-orange-50 to-white">
+          <CardContent className="p-6">
+            <div className="flex items-start gap-4">
+              <div className="w-12 h-12 rounded-full bg-orange-100 flex items-center justify-center flex-shrink-0">
+                <AlertCircle className="w-6 h-6 text-orange-600" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-orange-900 mb-2">Löschen fehlgeschlagen</h3>
+                <p className="text-sm text-orange-700 mb-3">
+                  Das Deployment konnte nicht vollständig gelöscht werden. Bitte versuchen Sie es erneut.
+                </p>
+                <Button
+                  variant="outline"
+                  className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                  onClick={() => onDelete?.(deployment.id)}
+                >
+                  Erneut versuchen
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Deleting Message */}
+      {deployment.status === 'deleting' && (
+        <Card className="border-red-200 shadow-sm bg-gradient-to-br from-red-50 to-white">
+          <CardContent className="p-6">
+            <div className="flex items-start gap-4">
+              <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center flex-shrink-0">
+                <Loader2 className="w-6 h-6 text-red-600 animate-spin" />
+              </div>
+              <div className="flex-1">
+                <h3 className="text-red-900 mb-2">Deployment wird gelöscht…</h3>
+                <p className="text-sm text-red-700">
+                  Die Ressourcen werden gerade abgebaut. Sie werden automatisch zum Dashboard weitergeleitet.
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Deployment Steps */}
         <Card className="lg:col-span-2 border-slate-200 shadow-sm">
           <CardHeader>
-            <CardTitle>Deployment-Schritte</CardTitle>
-            <CardDescription>
-              Detaillierter Ablauf der Bereitstellung
-            </CardDescription>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Deployment-Schritte</CardTitle>
+                <CardDescription>Detaillierter Ablauf der Bereitstellung</CardDescription>
+              </div>
+              {deployment.status === "deploying" && (
+                <span className="flex items-center gap-1.5 text-xs text-teal-600 font-medium">
+                  <span className="w-2 h-2 rounded-full bg-teal-500 animate-pulse" />
+                  Live
+                </span>
+              )}
+            </div>
+            {/* Overall progress bar */}
+            <div className="mt-3 space-y-1">
+              <div className="flex justify-between text-xs text-slate-500">
+                <span>{deployment.currentStep ?? (deployment.status === "running" ? "Abgeschlossen" : "Warte auf Start…")}</span>
+                <span>{deployment.progress}%</span>
+              </div>
+              <Progress value={deployment.progress} className="h-2" />
+            </div>
           </CardHeader>
           <CardContent>
-            <div className="space-y-6">
-              {deployment.steps.map((step, index) => (
-                <div key={step.id} className="relative">
-                  {/* Connecting Line */}
-                  {index < deployment.steps.length - 1 && (
-                    <div 
-                      className={`absolute left-5 top-10 w-0.5 h-full ${
-                        step.status === 'completed' ? 'bg-green-200' : 'bg-slate-200'
-                      }`}
-                    />
-                  )}
-                  
-                  <div className="flex gap-4">
-                    {getStepIcon(step)}
-                    
-                    <div className="flex-1 pb-2">
-                      <div className="flex items-start justify-between mb-2">
-                        <div>
-                          <h4 className="text-slate-900 mb-1">{step.name}</h4>
-                          <p className="text-sm text-slate-600">{step.description}</p>
-                        </div>
-                        {getStepStatusBadge(step.status)}
-                      </div>
-                      
-                      <div className="flex items-center gap-4 text-xs text-slate-500 mt-2">
-                        {step.startTime && (
-                          <span>Gestartet: {step.startTime}</span>
-                        )}
-                        {step.endTime && (
-                          <span>· Beendet: {step.endTime}</span>
-                        )}
-                        {step.duration && (
-                          <span>· Dauer: {step.duration}</span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
+            <DeploymentPhaseList phases={deployment.phases ?? []} isLive={deployment.status === "deploying"} />
           </CardContent>
         </Card>
 
@@ -469,9 +502,6 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                 <>
                   <Button variant="outline" className="w-full opacity-50 cursor-not-allowed" disabled>
                     VM starten
-                  </Button>
-                  <Button variant="outline" className="w-full" disabled>
-                    Logs anzeigen
                   </Button>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
@@ -655,15 +685,32 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                                 </div>
 
                                 <div className="flex flex-wrap items-center justify-between gap-2">
-                                  <span className="text-xs text-slate-500">Connection URL</span>
+                                  <span className="text-xs text-slate-500">
+                                    {access.access_type === "ssh" ? "SSH-Befehl" : access.access_type === "web_url" ? "URL" : "Connection URL"}
+                                  </span>
                                   <div className="flex items-center gap-2">
-                                    <span className="text-sm text-slate-900 break-all">
-                                      {access.connection_url ?? "-"}
-                                    </span>
+                                    {access.connection_url ? (
+                                      access.access_type === "web_url" ? (
+                                        <a
+                                          href={access.connection_url}
+                                          target="_blank"
+                                          rel="noopener noreferrer"
+                                          className="text-sm text-blue-600 hover:underline break-all"
+                                        >
+                                          {access.connection_url}
+                                        </a>
+                                      ) : (
+                                        <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono">
+                                          {access.connection_url}
+                                        </code>
+                                      )
+                                    ) : (
+                                      <span className="text-sm text-slate-400">-</span>
+                                    )}
                                     <Button
                                       variant="outline"
                                       size="sm"
-                                      onClick={() => handleCopy(access.connection_url, "Connection URL")}
+                                      onClick={() => handleCopy(access.connection_url, access.access_type === "ssh" ? "SSH-Befehl" : "URL")}
                                       disabled={!access.connection_url}
                                     >
                                       <Copy className="w-4 h-4" />
@@ -689,6 +736,161 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
             </CardContent>
           )}
         </Card>
+    </div>
+  );
+}
+
+// ── Phase helpers ─────────────────────────────────────────────────────────────
+
+const PHASE_ICONS: Record<string, React.ReactNode> = {
+  heat: <Flame className="w-4 h-4" />,
+  ansible: <Terminal className="w-4 h-4" />,
+  done: <Flag className="w-4 h-4" />,
+};
+
+function fmtTime(iso: string) {
+  try {
+    return new Date(iso).toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  } catch {
+    return iso;
+  }
+}
+
+function phaseBadge(status: PhaseStatus) {
+  switch (status) {
+    case "completed":
+      return <Badge className="bg-green-100 text-green-800 border-green-200">Fertig</Badge>;
+    case "running":
+      return <Badge className="bg-teal-100 text-teal-800 border-teal-200">Läuft</Badge>;
+    case "failed":
+      return <Badge className="bg-red-100 text-red-800 border-red-200">Fehler</Badge>;
+    default:
+      return <Badge variant="outline" className="text-slate-400">Ausstehend</Badge>;
+  }
+}
+
+function LogRow({ log }: { log: DeploymentLogDto }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetails = log.details && Object.keys(log.details).length > 0;
+
+  const lvl = log.level.toUpperCase();
+
+  const levelColor =
+    lvl === "ERROR"   ? "#f87171" :
+    lvl === "WARNING" ? "#facc15" :
+    lvl === "DEBUG"   ? "#64748b" :
+    "#4ade80";
+
+  const msgColor =
+    lvl === "ERROR"   ? "#fca5a5" :
+    lvl === "WARNING" ? "#fde047" :
+    lvl === "DEBUG"   ? "#64748b" :
+    "#e2e8f0";
+
+  return (
+    <div
+      style={{
+        fontFamily: "monospace",
+        fontSize: "12px",
+        borderBottom: "1px solid #1e293b",
+        cursor: hasDetails ? "pointer" : "default",
+        backgroundColor: "transparent",
+      }}
+      onMouseEnter={e => { if (hasDetails) (e.currentTarget as HTMLElement).style.backgroundColor = "#1e293b"; }}
+      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.backgroundColor = "transparent"; }}
+      onClick={() => hasDetails && setExpanded(e => !e)}
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "16px 72px 72px 1fr", gap: "8px", padding: "6px 16px", alignItems: "baseline" }}>
+        <span style={{ color: "#94a3b8" }}>{hasDetails ? (expanded ? "▾" : "▸") : ""}</span>
+        <span style={{ color: "#94a3b8" }}>{fmtTime(log.created_at)}</span>
+        <span style={{ color: levelColor, fontWeight: "bold" }}>[{log.level.toLowerCase()}]</span>
+        <span style={{ color: msgColor, wordBreak: "break-word" }}>{log.message}</span>
+      </div>
+      {expanded && hasDetails && (
+        <pre style={{ margin: "0 16px 8px 40px", color: "#94a3b8", whiteSpace: "pre-wrap", wordBreak: "break-all", fontSize: "11px" }}>
+          {JSON.stringify(log.details, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function PhaseRow({ phase, isLive, defaultOpen }: { phase: LogPhase; isLive: boolean; defaultOpen: boolean }) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  const phaseIcon = PHASE_ICONS[phase.id] ?? <CheckCircle2 className="w-4 h-4" />;
+
+  const dotClass =
+    phase.status === "completed"
+      ? "bg-green-500"
+      : phase.status === "running"
+      ? "bg-teal-500 animate-pulse"
+      : phase.status === "failed"
+      ? "bg-red-500"
+      : "bg-slate-300";
+
+  return (
+    <div className="border border-slate-200 rounded-lg overflow-hidden">
+      {/* Phase header */}
+      <button
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-slate-50 transition-colors"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${dotClass}`} />
+        <span className="text-slate-500 flex-shrink-0">{phaseIcon}</span>
+        <span className="flex-1 font-medium text-slate-900 text-sm">{phase.label}</span>
+        {phase.logs.length > 0 && (
+          <span className="text-xs text-slate-400 mr-2">{phase.logs.length} Einträge</span>
+        )}
+        {phaseBadge(phase.status)}
+        {open ? (
+          <ChevronDown className="w-4 h-4 text-slate-400 flex-shrink-0" />
+        ) : (
+          <ChevronRight className="w-4 h-4 text-slate-400 flex-shrink-0" />
+        )}
+      </button>
+
+      {/* Log entries */}
+      {open && (
+        <div style={{ borderTop: "1px solid #1e293b", backgroundColor: "#0f172a" }}>
+          {phase.logs.length === 0 ? (
+            <p className="px-4 py-3 text-xs italic font-mono" style={{ color: "#475569" }}>
+              {phase.status === "pending" ? "// Noch nicht gestartet" : "// Keine Einträge"}
+            </p>
+          ) : (
+            phase.logs.map((log) => <LogRow key={log.id} log={log} />)
+          )}
+          {phase.status === "running" && isLive && (
+            <div className="flex items-center gap-2 px-4 py-2 text-xs font-mono" style={{ color: "#2dd4bf" }}>
+              <Loader2 className="w-3 h-3 animate-spin" />
+              warte auf neue logs…
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DeploymentPhaseList({ phases, isLive }: { phases: LogPhase[]; isLive: boolean }) {
+  if (phases.length === 0) {
+    return (
+      <p className="text-sm text-slate-400 text-center py-8">
+        Noch keine Logs vorhanden.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {phases.map((phase) => (
+        <PhaseRow
+          key={phase.id}
+          phase={phase}
+          isLive={isLive}
+          defaultOpen={phase.status === "running" || phase.status === "failed"}
+        />
+      ))}
     </div>
   );
 }

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -1,182 +1,357 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate, Navigate } from "react-router-dom";
-import { Server } from "lucide-react";
 import { DeploymentDetails } from "./DeploymentDetails";
 import { mockDeployments } from "./mockDeployments";
-import { getDeployment, getDeploymentLogs, deleteDeployment } from "../api/deployments";
+import {
+  getDeployment,
+  getDeploymentLogs,
+  streamDeploymentLogs,
+  deleteDeployment,
+  type DeploymentLogDto,
+} from "../api/deployments";
 import { getMyCourses, type CourseDto } from "../api/courses";
 import { getKeycloakGroups, type KeycloakGroup } from "../api/keycloak";
+
+// ── Phase definitions ─────────────────────────────────────────────────────────
+
+export type PhaseStatus = "pending" | "running" | "completed" | "failed";
+
+export interface LogPhase {
+  id: string;        // e.g. "heat", "ansible", "done"
+  label: string;
+  status: PhaseStatus;
+  logs: DeploymentLogDto[];
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+const HEAT_EVENTS = new Set([
+  "DEPLOYMENT_STARTED",
+  "STACK_CREATE",
+  "SSH_WAIT",
+  "VM_READY",
+]);
+
+const ANSIBLE_EVENTS = new Set([
+  "ANSIBLE_STARTED",
+  "ANSIBLE_TASK",
+  "ANSIBLE_OK",
+  "ANSIBLE_FAILED",
+  "ANSIBLE_COMPLETED",
+]);
+
+function buildPhases(logs: DeploymentLogDto[]): LogPhase[] {
+  const heat: DeploymentLogDto[] = [];
+  const ansible: DeploymentLogDto[] = [];
+  const done: DeploymentLogDto[] = [];
+
+  let ansibleStarted = false;
+
+  for (const log of logs) {
+    const et = log.event_type.toUpperCase();
+    if (ANSIBLE_EVENTS.has(et)) {
+      ansibleStarted = true;
+      ansible.push(log);
+    } else if (et === "DEPLOYMENT_DELETED" || et === "DEPLOYMENT_DELETION_REQUESTED") {
+      done.push(log);
+    } else if (et === "FAILED" && ansibleStarted) {
+      // FAILED after Ansible started belongs to Ansible phase
+      ansible.push(log);
+    } else {
+      heat.push(log);
+    }
+  }
+
+  // Heat is complete when VM_READY appears (regardless of Ansible outcome)
+  const vmReady = heat.some((l) => l.event_type.toUpperCase() === "VM_READY");
+  // Heat failed only if a FAILED/ERROR log exists and no stacks were created
+  const heatError = heat.some(
+    (l) => (l.event_type.toUpperCase() === "FAILED" || l.level === "ERROR") && !vmReady
+  );
+
+  let heatStatus: PhaseStatus = "pending";
+  if (heat.length === 0) heatStatus = "pending";
+  else if (heatError) heatStatus = "failed";
+  else if (vmReady || ansible.length > 0) heatStatus = "completed";
+  else heatStatus = "running";
+
+  // Ansible status
+  const ansibleFailed = ansible.some(
+    (l) => l.event_type.toUpperCase() === "ANSIBLE_FAILED" || l.level === "ERROR"
+  );
+  const ansibleCompleted = ansible.some(
+    (l) => l.event_type.toUpperCase() === "ANSIBLE_COMPLETED"
+  );
+
+  let ansibleStatus: PhaseStatus = "pending";
+  if (ansible.length === 0) {
+    ansibleStatus = heatStatus === "completed" ? "running" : "pending";
+  } else if (ansibleFailed) {
+    ansibleStatus = "failed";
+  } else if (ansibleCompleted) {
+    ansibleStatus = "completed";
+  } else {
+    ansibleStatus = "running";
+  }
+
+  const doneStatus: PhaseStatus = done.length > 0 ? "completed" : "pending";
+
+  const ts = (arr: DeploymentLogDto[]) => arr[0]?.created_at;
+  const te = (arr: DeploymentLogDto[]) => arr[arr.length - 1]?.created_at;
+
+  return [
+    {
+      id: "heat",
+      label: "Infrastruktur (Heat)",
+      status: heatStatus,
+      logs: heat,
+      startedAt: ts(heat),
+      finishedAt: heatStatus === "completed" || heatStatus === "failed" ? te(heat) : undefined,
+    },
+    {
+      id: "ansible",
+      label: "Konfiguration (Ansible)",
+      status: ansibleStatus,
+      logs: ansible,
+      startedAt: ts(ansible),
+      finishedAt: ansibleStatus === "completed" || ansibleStatus === "failed" ? te(ansible) : undefined,
+    },
+    ...(done.length > 0 ? [{
+      id: "done",
+      label: "Abgeschlossen",
+      status: "completed" as PhaseStatus,
+      logs: done,
+      startedAt: ts(done),
+    }] : []),
+  ];
+}
+
+function calcProgress(phases: LogPhase[], overallStatus: string): number {
+  if (overallStatus === "running") return 100;
+  if (overallStatus === "failed") {
+    const completedCount = phases.filter((p) => p.status === "completed").length;
+    return Math.round((completedCount / phases.length) * 100);
+  }
+  const weights = [40, 60]; // heat, ansible
+  let progress = 0;
+  phases.forEach((phase, i) => {
+    if (phase.status === "completed") progress += weights[i];
+    else if (phase.status === "running") {
+      // partial credit based on log count within this phase
+      const phaseLogs = phase.logs.length;
+      progress += Math.min(weights[i] * 0.6, weights[i] * (phaseLogs / 10));
+    }
+  });
+  return Math.min(99, Math.round(progress));
+}
+
+// ── Status mapping ─────────────────────────────────────────────────────────────
+
+const STATUS_MAP: Record<string, "deploying" | "running" | "failed" | "cancelled" | "stopped" | "deleting"> = {
+  QUEUED: "deploying",
+  CREATING: "deploying",
+  PROCESSING: "deploying",
+  DEPLOYING: "deploying",
+  ACTIVE: "running",
+  RUNNING: "running",
+  CREATE_COMPLETE: "running",
+  FAILED: "failed",
+  CREATE_FAILED: "failed",
+  DELETE_COMPLETE: "stopped",
+  DELETING: "deleting",
+  CANCELLED: "cancelled",
+  DELETED: "stopped",
+};
+
+const ACTIVE_STATUSES = new Set(["deploying"]);
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 export function DeploymentDetailsPage() {
   const { deploymentId } = useParams<{ deploymentId: string }>();
   const navigate = useNavigate();
   const [deploymentData, setDeploymentData] = useState<any>(null);
   const [loadingDeployment, setLoadingDeployment] = useState(false);
-  const [deletingDeployment, setDeletingDeployment] = useState(false);
+  const isDeletingRef = useRef(false);
 
-  const handleBackToDashboard = () => {
-    navigate("/dashboard");
-  };
+  // Stable reference data fetched once
+  const coursesCacheRef = useRef<CourseDto[]>([]);
+  const groupsCacheRef = useRef<KeycloakGroup[]>([]);
+  // Accumulate logs from SSE
+  const logsRef = useRef<DeploymentLogDto[]>([]);
+  const backendDeploymentRef = useRef<any>(null);
+  const stopStreamRef = useRef<(() => void) | null>(null);
+
+  const handleBackToDashboard = () => navigate("/dashboard");
 
   const handleDeleteDeployment = async (id: string) => {
+    isDeletingRef.current = true;
+    stopStreamRef.current?.();
+    setDeploymentData((prev: any) => prev ? { ...prev, status: "deleting" } : prev);
+
     try {
-      setDeletingDeployment(true);
-      const resp = await deleteDeployment(id);
-      if (resp && typeof resp === 'object' && 'success' in resp && (resp as any).success) {
-        navigate('/dashboard');
-      } else {
-        navigate('/dashboard');
-      }
+      await deleteDeployment(id);
     } catch (err) {
-      console.error('Failed to delete deployment', err);
-      navigate('/dashboard');
-    } finally {
-      setDeletingDeployment(false);
+      console.error("Failed to initiate delete", err);
     }
+
+    // Poll for max 60s, then give up and show retry
+    let attempts = 0;
+    const poll = async () => {
+      attempts++;
+      try {
+        const resp = await getDeployment(id);
+        const s = resp.data.status.toUpperCase();
+        if (s === "DELETED" || s === "DELETE_COMPLETE") {
+          navigate("/dashboard");
+        } else if (attempts < 30) {
+          setTimeout(poll, 2000);
+        } else {
+          // Timeout — let user retry
+          isDeletingRef.current = false;
+          setDeploymentData((prev: any) => prev ? { ...prev, status: "delete_failed" } : prev);
+        }
+      } catch {
+        navigate("/dashboard");
+      }
+    };
+    poll();
   };
 
-  // Load deployment when deploymentId changes
+  const buildDeploymentData = useCallback(
+    (backendDeployment: any, logs: DeploymentLogDto[]) => {
+      const mappedStatus =
+        STATUS_MAP[backendDeployment.status.toUpperCase()] || "deploying";
+
+      const phases = buildPhases(logs);
+      const progress = calcProgress(phases, mappedStatus);
+
+      const failedLog = logs.find(
+        (l) =>
+          l.event_type.toLowerCase().includes("failed") ||
+          l.level === "ERROR"
+      );
+
+      const steps = logs.map((log) => ({
+        id: log.id,
+        name: log.event_type.replace(/_/g, " "),
+        status:
+          log.event_type.toUpperCase().includes("FAILED") || log.level === "ERROR"
+            ? ("failed" as const)
+            : ("completed" as const),
+        startTime: log.created_at,
+        description: log.message,
+        icon: null,
+      }));
+
+      let cpu = 0, ram = 0, storage = 0;
+      if (backendDeployment.instances?.length > 0) {
+        cpu = backendDeployment.instances.length * 2;
+        ram = backendDeployment.instances.length * 4;
+        storage = backendDeployment.instances.length * 20;
+      }
+
+      let resolvedCourseName = "Unbekannter Kurs";
+      if (backendDeployment.course?.name) {
+        resolvedCourseName = backendDeployment.course.name;
+      } else if (backendDeployment.course_id) {
+        const course = coursesCacheRef.current.find(
+          (c) => c.id === backendDeployment.course_id
+        );
+        if (course) {
+          const group = groupsCacheRef.current.find(
+            (g) => g.id === (course as any).keycloak_course_id
+          );
+          resolvedCourseName = group?.name || course.name || resolvedCourseName;
+        }
+      }
+
+      return {
+        id: backendDeployment.id,
+        name: backendDeployment.name || "Unnamed Deployment",
+        status: mappedStatus,
+        course: resolvedCourseName,
+        startedAt: backendDeployment.created_at,
+        completedAt:
+          mappedStatus === "running" || mappedStatus === "failed"
+            ? backendDeployment.updated_at
+            : undefined,
+        progress,
+        currentStep: phases.find((p) => p.status === "running")?.label,
+        steps,
+        phases,
+        logs,
+        error: failedLog?.message || undefined,
+        resources: { cpu, ram, storage },
+      };
+    },
+    []
+  );
+
   useEffect(() => {
     if (!deploymentId) return;
 
-    // Check if it's a mock deployment first
     const mockDeployment = mockDeployments[deploymentId as keyof typeof mockDeployments];
     if (mockDeployment) {
       setDeploymentData(mockDeployment);
       return;
     }
 
-    // Otherwise load from API
     setLoadingDeployment(true);
-    
-    // Load deployment and logs in parallel
+    logsRef.current = [];
+
+    // Fetch reference data + initial deployment + existing logs in parallel
     Promise.all([
-      getDeployment(deploymentId),
-      getDeploymentLogs(deploymentId).catch(() => ({ data: [] })), // Logs are optional
       getMyCourses({ page: 1, page_size: 100 }).catch(() => ({ data: [] as CourseDto[] })),
       getKeycloakGroups().catch(() => ({ data: [] as KeycloakGroup[] })),
-    ])
-      .then(([deploymentResponse, logsResponse, coursesResponse, groupsResponse]) => {
-        // Convert backend deployment format to DeploymentDetails format
-        const backendDeployment = deploymentResponse.data;
-        const logs = logsResponse.data || [];
-        const courses: CourseDto[] = coursesResponse?.data || [];
-        const groups: KeycloakGroup[] = groupsResponse?.data || [];
-        
-        // Map status from backend to frontend format
-        const statusMap: Record<string, 'deploying' | 'running' | 'failed' | 'cancelled' | 'stopped'> = {
-          'QUEUED': 'deploying',
-          'PROCESSING': 'deploying',
-          'DEPLOYING': 'deploying',
-          'ACTIVE': 'running',
-          'RUNNING': 'running',
-          'CREATE_COMPLETE': 'running',
-          'FAILED': 'failed',
-          'CREATE_FAILED': 'failed',
-          'DELETE_COMPLETE': 'stopped',
-          'CANCELLED': 'cancelled',
-          'DELETED': 'stopped',
-        };
-        
-        const mappedStatus = statusMap[backendDeployment.status.toUpperCase()] || 'deploying';
-        
-        // Reverse logs to show newest first, then convert to steps format
-        const reversedLogs = [...logs].reverse();
-        
-        // Find failed log to extract error message
-        const failedLog = logs.find(log => 
-          log.event_type.toLowerCase().includes('failed') || log.level === 'ERROR'
-        );
-        
-        // Convert logs to steps format (newest first)
-        const steps = reversedLogs.map((log, index) => {
-          // Determine status: check if event_type contains "failed" or level is ERROR
-          const isFailed = log.event_type.toLowerCase().includes('failed') || log.level === 'ERROR';
-          const isWarning = log.level === 'WARNING';
-          
-          return {
-            id: log.id,
-            name: log.event_type.replace(/_/g, ' '),
-            status: isFailed ? 'failed' as const : 
-                   isWarning ? 'in-progress' as const : 
-                   'completed' as const,
-            startTime: log.created_at,
-            endTime: index < reversedLogs.length - 1 ? reversedLogs[index + 1].created_at : undefined,
-            description: log.message,
-            icon: Server, // Default icon
-          };
-        });
-        
-        // Calculate progress based on status
-        let progress = 0;
-        if (mappedStatus === 'running') progress = 100;
-        else if (mappedStatus === 'failed' || mappedStatus === 'cancelled') progress = 0;
-        else if (mappedStatus === 'deploying') {
-          // Calculate progress based on number of completed steps
-          const completedSteps = steps.filter(s => s.status === 'completed').length;
-          progress = steps.length > 0 ? Math.round((completedSteps / steps.length) * 100) : 50;
-        }
-        
-        // Calculate resources from instances if available
-        let cpu = 0, ram = 0, storage = 0;
-        if (backendDeployment.instances && backendDeployment.instances.length > 0) {
-          // Try to extract resource info from deployment_parameters or instances
-          // This is a simplified calculation - adjust based on actual data structure
-          cpu = backendDeployment.instances.length * 2; // Assume 2 cores per instance
-          ram = backendDeployment.instances.length * 4; // Assume 4GB per instance
-          storage = backendDeployment.instances.length * 20; // Assume 20GB per instance
-        }
-        
-        // Resolve course name using courses + keycloak groups mapping
-        let resolvedCourseName = "Unknown Course";
-        if (backendDeployment.course && backendDeployment.course.name) {
-          resolvedCourseName = backendDeployment.course.name;
-        } else if (backendDeployment.course_id) {
-          const course = courses.find(c => c.id === backendDeployment.course_id);
-          if (course) {
-            const group = groups.find(g => g.id === course.keycloak_course_id);
-            resolvedCourseName = group?.name || course.name || resolvedCourseName;
+      getDeployment(deploymentId),
+      getDeploymentLogs(deploymentId).catch(() => ({ data: [] as DeploymentLogDto[] })),
+    ]).then(([coursesResp, groupsResp, depResp, logsResp]) => {
+      coursesCacheRef.current = (coursesResp as any)?.data || [];
+      groupsCacheRef.current = (groupsResp as any)?.data || [];
+      backendDeploymentRef.current = depResp.data;
+
+      const existingLogs: DeploymentLogDto[] = (logsResp as any).data || [];
+      logsRef.current = existingLogs;
+
+      setDeploymentData(buildDeploymentData(depResp.data, existingLogs));
+      setLoadingDeployment(false);
+
+      // Start SSE stream from the last known log (avoids duplicates)
+      const lastLogId = existingLogs.length > 0 ? existingLogs[existingLogs.length - 1].id : undefined;
+      const stopStream = streamDeploymentLogs(
+        deploymentId,
+        lastLogId,
+        (log) => {
+          if (isDeletingRef.current) return;
+          logsRef.current = [...logsRef.current, log];
+          if (backendDeploymentRef.current) {
+            setDeploymentData(buildDeploymentData(backendDeploymentRef.current, logsRef.current));
           }
-        }
+        },
+        () => {
+          if (isDeletingRef.current) return;
+          getDeployment(deploymentId).then((depResp) => {
+            backendDeploymentRef.current = depResp.data;
+            setDeploymentData(buildDeploymentData(depResp.data, logsRef.current));
+          }).catch(() => {});
+        },
+      );
+      stopStreamRef.current = stopStream;
+    }).catch(() => setLoadingDeployment(false));
 
-        const convertedDeployment = {
-          id: backendDeployment.id,
-          name: backendDeployment.name || "Unnamed Deployment",
-          status: mappedStatus,
-          course: resolvedCourseName,
-          startedAt: backendDeployment.created_at,
-          completedAt: mappedStatus === 'running' || mappedStatus === 'failed' ? backendDeployment.updated_at : undefined,
-          progress,
-          currentStep: steps.find(s => s.status === 'in-progress')?.name,
-          steps,
-          error: failedLog?.message || undefined,
-          resources: {
-            cpu,
-            ram,
-            storage,
-          },
-        };
-        
-        setDeploymentData(convertedDeployment);
-        setLoadingDeployment(false);
-      })
-      .catch((error) => {
-        console.error("Failed to load deployment:", error);
-        setLoadingDeployment(false);
-      });
-  }, [deploymentId]);
+    return () => { stopStreamRef.current?.(); stopStreamRef.current = null; };
+  }, [deploymentId, buildDeploymentData]);
 
-  if (!deploymentId) {
-    return <Navigate to="/dashboard" replace />;
-  }
+  if (!deploymentId) return <Navigate to="/dashboard" replace />;
+  if (loadingDeployment) return <div className="p-6">Lade Deployment...</div>;
+  if (!deploymentData) return <div className="p-6">Deployment nicht gefunden</div>;
 
-  if (loadingDeployment) {
-    return <div className="p-6">Lade Deployment...</div>;
-  }
-
-  if (!deploymentData) {
-    return <div className="p-6">Deployment nicht gefunden</div>;
-  }
-
-  return <DeploymentDetails deployment={deploymentData} onBack={handleBackToDashboard} onDelete={handleDeleteDeployment} />;
+  return (
+    <DeploymentDetails
+      deployment={deploymentData}
+      onBack={handleBackToDashboard}
+      onDelete={handleDeleteDeployment}
+    />
+  );
 }

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle2,
   Clock,
   AlertCircle,
+  Upload,
 } from "lucide-react";
 import {
   Card,
@@ -36,6 +37,7 @@ import {
   type TemplateDto,
   type TemplateVersionDto,
   type TemplateParameter,
+  type UserFileDefinition,
 } from "../api/templates";
 import {
   getKeycloakGroups,
@@ -108,6 +110,9 @@ export function DeploymentWizard({
 
   // Form values - stores all parameter values
   const [formValues, setFormValues] = useState<Record<string, any>>({});
+
+  // Uploaded files - stores File objects keyed by user_file name
+  const [uploadedFiles, setUploadedFiles] = useState<Record<string, File>>({});
 
   // Load template and Keycloak groups on mount
   useEffect(() => {
@@ -402,6 +407,16 @@ export function DeploymentWizard({
       });
     }
 
+    // Add file upload step if template supports user files
+    if (templateVersionData?.allow_user_files && templateVersionData?.user_files?.length) {
+      baseSteps.push({
+        name: "Dateien",
+        stepKey: "dateien",
+        description: "Laden Sie optionale Dateien für die Gruppen hoch",
+        icon: Upload,
+      });
+    }
+
     // Always add overview step
     baseSteps.push({
       name: "Übersicht",
@@ -543,12 +558,25 @@ export function DeploymentWizard({
         return;
       }
 
+      // Convert uploaded files to base64
+      const userFilesPayload: Record<string, string> = {};
+      for (const [name, file] of Object.entries(uploadedFiles)) {
+        const base64 = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve((reader.result as string).split(",")[1]);
+          reader.onerror = reject;
+          reader.readAsDataURL(file);
+        });
+        userFilesPayload[name] = base64;
+      }
+
       // Build deployment request with stack assignments
-      const deploymentData = {
+      const deploymentData: DeploymentCreateRequest = {
         name: deploymentName.trim(),
         template_version_id: selectedVersionId,
         course_id: selectedKeycloakGroupId,
-        heat_parameters: heatParameters,
+        parameters: heatParameters,
+        ...(Object.keys(userFilesPayload).length > 0 && { user_files: userFilesPayload }),
         stack_assignments: groupStackAssignments.map((stack, stackIndex) => ({
           groups: stack.assignedGroups.map((group) => ({
             group_name: group.groupName,
@@ -1005,6 +1033,71 @@ export function DeploymentWizard({
               <span className="text-sm">Lade Template-Version...</span>
             </div>
           )}
+        </div>
+      );
+    }
+
+    // File upload step
+    if (currentStepData.stepKey === "dateien") {
+      const userFiles: UserFileDefinition[] = templateVersionData?.user_files ?? [];
+      return (
+        <div className="space-y-6">
+          <p className="text-sm text-slate-500">
+            Alle Felder sind optional. Dateien werden beim Deployment auf die VMs kopiert.
+          </p>
+          {userFiles.map((fileDef) => {
+            const uploaded = uploadedFiles[fileDef.name];
+            return (
+              <div key={fileDef.name} className="space-y-2">
+                <Label htmlFor={`file-${fileDef.name}`}>
+                  {fileDef.label ?? fileDef.name}
+                  {fileDef.required && <span className="text-red-500 ml-1">*</span>}
+                  {fileDef.mode === "per_group" && (
+                    <span className="ml-2 text-xs text-slate-400">(pro Gruppe)</span>
+                  )}
+                </Label>
+                {fileDef.description && (
+                  <p className="text-xs text-slate-500">{fileDef.description}</p>
+                )}
+                <div className="flex items-center gap-3">
+                  <label
+                    htmlFor={`file-${fileDef.name}`}
+                    className="flex items-center gap-2 px-3 py-2 border border-slate-200 rounded-md cursor-pointer hover:bg-slate-50 text-sm"
+                  >
+                    <Upload className="w-4 h-4 text-slate-400" />
+                    {uploaded ? uploaded.name : "Datei auswählen…"}
+                  </label>
+                  <input
+                    id={`file-${fileDef.name}`}
+                    type="file"
+                    accept={fileDef.accept}
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) {
+                        setUploadedFiles((prev) => ({ ...prev, [fileDef.name]: file }));
+                      }
+                    }}
+                  />
+                  {uploaded && (
+                    <button
+                      type="button"
+                      className="text-xs text-red-400 hover:text-red-600"
+                      onClick={() =>
+                        setUploadedFiles((prev) => {
+                          const next = { ...prev };
+                          delete next[fileDef.name];
+                          return next;
+                        })
+                      }
+                    >
+                      Entfernen
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })}
         </div>
       );
     }


### PR DESCRIPTION

- DeploymentDetailsPage: replace polling with SSE stream (fetch-based, Bearer auth)
  - loads existing logs on mount, streams new logs via since_id parameter
  - stops stream on delete; polls until 404 then navigates to dashboard
- DeploymentDetails: grouped log phases (Heat / Ansible) with dark terminal UI
  - color-coded log levels via inline styles (bypasses Tailwind purge)
  - click-to-expand log entries with details JSON
  - live pulse indicator, phase status badges
  - deleting/delete_failed states with retry button
- DeploymentWizard: file upload step for templates with allow_user_files=true
  - base64-encodes files, sends as user_files in deployment request
  - fix: heat_parameters → parameters (field name mismatch with backend schema)
- api/templates.ts: add UserFileDefinition type, extend TemplateVersionDto
- api/deployments.ts: add streamDeploymentLogs(), fix deleteDeployment() for 204
- nginx.conf: add resolver 127.0.0.11 to re-resolve upstream DNS after restarts
- Format timestamps as locale German (dd.MM.yyyy, HH:mm)