### PR TITLE
feat: enable HTTPS with self-signed certificate and use env vars for …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,25 @@ RUN npm run build
 # ---------- Runtime Stage ----------
 FROM nginx:alpine
 
+# openssl für Zertifikat-Generierung
+RUN apk add --no-cache openssl
+
 # Default Config entfernen
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Eigene nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# ✅ Vite Output liegt bei euch in "build/"
+# Vite Output
 COPY --from=build /app/build /usr/share/nginx/html
 
-EXPOSE 80
+# Selbstsigniertes Zertifikat generieren
+RUN mkdir -p /etc/nginx/certs && \
+    openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+      -keyout /etc/nginx/certs/selfsigned.key \
+      -out /etc/nginx/certs/selfsigned.crt \
+      -subj "/CN=appstore"
+
+EXPOSE 80 443
 CMD ["nginx", "-g", "daemon off;"]
+

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,20 +1,28 @@
 server {
     listen 80;
     server_name _;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate     /etc/nginx/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
 
     root /usr/share/nginx/html;
     index index.html;
 
-    # Re-resolve upstream DNS on every request (prevents stale IP after container restart)
     resolver 127.0.0.11 valid=5s;
     set $upstream http://api:8000;
 
-    # React Router / SPA
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    # Backend API Proxy
     location /api {
         proxy_pass $upstream;
         proxy_http_version 1.1;
@@ -26,5 +34,5 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
     }
-
 }
+

--- a/src/auth/keycloak.ts
+++ b/src/auth/keycloak.ts
@@ -1,9 +1,9 @@
 import Keycloak from "keycloak-js";
 
 const keycloakConfig = {
-  url: "http://141.72.176.136:8080/",
-  realm: "Dozilab",
-  clientId: "appstore-frontend",
+  url: import.meta.env.VITE_KEYCLOAK_URL,
+  realm: import.meta.env.VITE_KEYCLOAK_REALM,
+  clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID,
 };
 
 const keycloak = new Keycloak(keycloakConfig);


### PR DESCRIPTION
- Nginx listens on port 443 with a self-signed certificate generated at build time
- HTTP redirects to HTTPS to enable Web Crypto API in the browser
- Keycloak config reads from VITE_* environment variables instead of hardcoded values