### PR TITLE
feat(deployments): thread active OpenStack project through deployment API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,21 @@ import { AppStorePage } from "./pages/AppStorePage";
 import { DeploymentWizardPage } from "./pages/DeploymentWizardPage";
 import { DeploymentDetailsPage } from "./pages/DeploymentDetailsPage";
 import { OpenStackSetup } from "./pages/OpenStackSetup";
-import { listOpenstackProjects } from "./api/openstackProjects";
+import { listOpenstackProjects, type OpenstackProjectResponse } from "./api/openstackProjects";
+import { OpenstackProjectProvider } from "./contexts/OpenstackProjectContext";
 import logo from "figma:asset/5c87f57a05de8f8018669c9004318908d006dcd5.png";
 
 export default function App() {
   const { keycloak, initialized } = useKeycloak();
   const [initTimedOut, setInitTimedOut] = useState(false);
   const [projectsChecked, setProjectsChecked] = useState(false);
-  const [hasProjects, setHasProjects] = useState(false);
+  // We hold the full project (not just a boolean): the authenticated routes
+  // need it via OpenstackProjectProvider so that any deployment-related
+  // request can attach ?openstack_project_id=<local-DB-id>.
+  const [activeProject, setActiveProject] = useState<OpenstackProjectResponse | null>(null);
+  // Admins don't need a project to use the app, so we don't push them into the
+  // OpenStack-setup route. We resolve this once after auth and keep it sticky.
+  const [isLecturer, setIsLecturer] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -33,17 +40,32 @@ export default function App() {
   useEffect(() => {
     if (!keycloak.authenticated) return;
     const roles: string[] = (keycloak.tokenParsed as Record<string, any>)?.realm_access?.roles ?? [];
-    const isLecturer = roles.includes("lecturer") || roles.includes("teacher");
-    if (!isLecturer) {
-      setHasProjects(true);
+    const lecturer = roles.includes("lecturer") || roles.includes("teacher");
+    setIsLecturer(lecturer);
+    if (!lecturer) {
+      // Admins don't need a project to use the app — keep activeProject null;
+      // the deployment endpoints accept admins without the query param.
+      setActiveProject(null);
       setProjectsChecked(true);
       return;
     }
     listOpenstackProjects()
-      .then((projects) => setHasProjects(projects.length > 0))
-      .catch(() => setHasProjects(false))
+      .then((projects) => setActiveProject(projects[0] ?? null))
+      .catch(() => setActiveProject(null))
       .finally(() => setProjectsChecked(true));
   }, [keycloak.authenticated]);
+
+  // Lecturer must have an OpenStack project before using the rest of the app.
+  // For admins this is always false (we never gate them on project setup).
+  const needsSetup = isLecturer && activeProject === null;
+
+  // Re-fetch the active project after the user finishes OpenStack setup.
+  // (Setup writes credentials and returns a fresh project row.)
+  const refreshActiveProject = () => {
+    listOpenstackProjects()
+      .then((projects) => setActiveProject(projects[0] ?? null))
+      .catch(() => setActiveProject(null));
+  };
 
   console.log("[Keycloak] initialized:", initialized, "authenticated:", keycloak?.authenticated);
 
@@ -89,31 +111,33 @@ export default function App() {
   }
 
   // Lecturer without projects → setup
-  if (!hasProjects) {
+  if (needsSetup) {
     return (
       <Routes>
-        <Route path="/setup" element={<OpenStackSetup onSuccess={() => { setHasProjects(true); }} />} />
+        <Route path="/setup" element={<OpenStackSetup onSuccess={refreshActiveProject} />} />
         <Route path="*" element={<Navigate to="/setup" replace />} />
       </Routes>
     );
   }
 
   return (
-    <div className="flex h-screen bg-slate-50">
-      <Sidebar logo={logo} />
-      <main className="flex-1 overflow-auto">
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/courses" element={<Courses />} />
-          <Route path="/appstore" element={<AppStorePage />} />
-          <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
-          <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
-          <Route path="/config" element={<OpenStackConfig />} />
-          <Route path="/admin" element={<AdminMonitoring />} />
-        </Routes>
-      </main>
-    </div>
+    <OpenstackProjectProvider project={activeProject}>
+      <div className="flex h-screen bg-slate-50">
+        <Sidebar logo={logo} />
+        <main className="flex-1 overflow-auto">
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/courses" element={<Courses />} />
+            <Route path="/appstore" element={<AppStorePage />} />
+            <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
+            <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
+            <Route path="/config" element={<OpenStackConfig />} />
+            <Route path="/admin" element={<AdminMonitoring />} />
+          </Routes>
+        </main>
+      </div>
+    </OpenstackProjectProvider>
   );
 }

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -87,6 +87,10 @@ export type DeploymentCreateRequest = {
   name?: string;
   template_version_id: string;
   course_id: string;
+  // Local DB id of the active OpenstackProject (NOT the Keystone tenant UUID).
+  // Backend pins the deployment to this project so later restart/delete uses
+  // the right credentials even if the user later switches their clouds.yaml.
+  openstack_project_id: string;
   deployment_mode?: string;
   config_json?: string;
   parameters?: Record<string, any>;
@@ -132,11 +136,20 @@ export async function createDeployment(data: DeploymentCreateRequest) {
   });
 }
 
-export async function getDeployment(deploymentId: string) {
-  return apiFetch<DeploymentResponse>(`/api/v1/deployments/${deploymentId}`);
+// All deployment endpoints below take `openstackProjectId` (local DB id of
+// the active OpenstackProject). Lecturers MUST pass it — backend returns 400
+// otherwise. Admins may pass null to skip the filter and see everything.
+function projectQuery(openstackProjectId: string | null): string {
+  return openstackProjectId ? `?openstack_project_id=${encodeURIComponent(openstackProjectId)}` : "";
 }
 
-export async function getDeploymentCredentials(deploymentId: string) {
+export async function getDeployment(deploymentId: string, openstackProjectId: string | null) {
+  return apiFetch<DeploymentResponse>(
+    `/api/v1/deployments/${deploymentId}${projectQuery(openstackProjectId)}`,
+  );
+}
+
+export async function getDeploymentCredentials(deploymentId: string, openstackProjectId: string | null) {
   return apiFetch<{
     success: boolean;
     message?: string;
@@ -144,10 +157,10 @@ export async function getDeploymentCredentials(deploymentId: string) {
     errors: unknown;
     timestamp?: string;
     request_id?: string;
-  }>(`/api/v1/deployments/${deploymentId}/credentials`);
+  }>(`/api/v1/deployments/${deploymentId}/credentials${projectQuery(openstackProjectId)}`);
 }
 
-export async function getDeploymentLogs(deploymentId: string) {
+export async function getDeploymentLogs(deploymentId: string, openstackProjectId: string | null) {
   return apiFetch<{
     success: boolean;
     message: string;
@@ -155,7 +168,7 @@ export async function getDeploymentLogs(deploymentId: string) {
     errors: unknown;
     timestamp: string;
     request_id: string;
-  }>(`/api/v1/deployments/${deploymentId}/logs`);
+  }>(`/api/v1/deployments/${deploymentId}/logs${projectQuery(openstackProjectId)}`);
 }
 
 /**
@@ -166,6 +179,7 @@ export async function getDeploymentLogs(deploymentId: string) {
 export function streamDeploymentLogs(
   deploymentId: string,
   sinceId: string | undefined,
+  openstackProjectId: string | null,
   onLog: (log: DeploymentLogDto) => void,
   onDone: () => void,
 ): () => void {
@@ -175,7 +189,12 @@ export function streamDeploymentLogs(
     try {
       try { await keycloak.updateToken(30); } catch {}
       const token = keycloak.token;
-      const url = `/api/v1/deployments/${deploymentId}/logs/stream${sinceId ? `?since_id=${sinceId}` : ""}`;
+      // Build query string with both since_id (optional) and openstack_project_id (required for lecturers).
+      const params = new URLSearchParams();
+      if (sinceId) params.set("since_id", sinceId);
+      if (openstackProjectId) params.set("openstack_project_id", openstackProjectId);
+      const qs = params.toString();
+      const url = `/api/v1/deployments/${deploymentId}/logs/stream${qs ? `?${qs}` : ""}`;
 
       const res = await fetch(url, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
@@ -210,13 +229,16 @@ export function streamDeploymentLogs(
   return () => controller.abort();
 }
 
-export async function deleteDeployment(deploymentId: string) {
+export async function deleteDeployment(deploymentId: string, openstackProjectId: string | null) {
   // Backend returns 204 No Content — don't call res.json()
   await keycloak.updateToken(30).catch(() => {});
-  const res = await fetch(`/api/v1/deployments/${deploymentId}`, {
-    method: "DELETE",
-    headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
-  });
+  const res = await fetch(
+    `/api/v1/deployments/${deploymentId}${projectQuery(openstackProjectId)}`,
+    {
+      method: "DELETE",
+      headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
+    },
+  );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(text || res.statusText);
@@ -239,8 +261,10 @@ type DeploymentsListEnvelope = {
   request_id: string;
 };
 
-export async function getAllDeployments(): Promise<DeploymentDto[]> {
-  const resp = await apiFetch<DeploymentsListEnvelope | DeploymentDto[]>("/api/v1/deployments");
+export async function getAllDeployments(openstackProjectId: string | null): Promise<DeploymentDto[]> {
+  const resp = await apiFetch<DeploymentsListEnvelope | DeploymentDto[]>(
+    `/api/v1/deployments${projectQuery(openstackProjectId)}`,
+  );
   if (resp && typeof resp === "object" && "data" in resp) {
     return (resp as DeploymentsListEnvelope).data || [];
   }

--- a/src/contexts/OpenstackProjectContext.tsx
+++ b/src/contexts/OpenstackProjectContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { OpenstackProjectResponse } from "../api/openstackProjects";
+
+/**
+ * Active OpenStack project context.
+ *
+ * The backend's deployment endpoints require the local DB id of the user's
+ * OpenStack project as `?openstack_project_id=...` (and inside the create
+ * body). Today the user has at most one project active at a time — switching
+ * happens by editing it in Settings — so we keep a single value here and
+ * read it from anywhere in the app via {@link useActiveOpenstackProject}.
+ *
+ * The project is loaded once in `App.tsx` (which already calls
+ * `listOpenstackProjects()` for the initial routing decision), and that
+ * value is passed in via the provider's `project` prop.
+ *
+ * IMPORTANT: `activeProjectId` is `OpenstackProjectResponse.id` — the local
+ * DB primary key — NOT `openstack_project_id` (which is the Keystone tenant
+ * UUID). Same naming pitfall as on the Bruno collection side.
+ */
+type OpenstackProjectContextValue = {
+  /** Local DB id of the active OpenstackProject row, or null if the user has none. */
+  activeProjectId: string | null;
+  /** Full project record, or null. Useful when components want the project name. */
+  project: OpenstackProjectResponse | null;
+};
+
+const OpenstackProjectContext = createContext<OpenstackProjectContextValue>({
+  activeProjectId: null,
+  project: null,
+});
+
+export function OpenstackProjectProvider({
+  project,
+  children,
+}: {
+  project: OpenstackProjectResponse | null;
+  children: ReactNode;
+}) {
+  const value = useMemo(
+    () => ({ activeProjectId: project?.id ?? null, project }),
+    [project]
+  );
+  return (
+    <OpenstackProjectContext.Provider value={value}>
+      {children}
+    </OpenstackProjectContext.Provider>
+  );
+}
+
+export function useActiveOpenstackProject(): OpenstackProjectContextValue {
+  return useContext(OpenstackProjectContext);
+}

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -82,7 +82,8 @@ export function AdminMonitoring() {
   };
 
   useEffect(() => {
-    getAllDeployments()
+    // Admin view: pass null → backend doesn't apply the project filter.
+    getAllDeployments(null)
       .then(setDeployments)
       .catch(console.error);
   }, []);
@@ -91,7 +92,8 @@ export function AdminMonitoring() {
     if (!selectedDeployment) return;
 
     setLogsLoading(true);
-    getDeploymentLogs(selectedDeployment.id)
+    // Same rationale: admin reads any deployment's logs regardless of project.
+    getDeploymentLogs(selectedDeployment.id, null)
       .then((resp) => setDeploymentLogs(resp.data ?? []))
       .catch(console.error)
       .finally(() => setLogsLoading(false));

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,12 +5,14 @@ import { Progress } from '../components/ui/progress';
 import { Badge } from '../components/ui/badge';
 import { getQuotas, type QuotasResponse } from '../api/quotas';
 import { getAllDeployments, type DeploymentDto } from '../api/deployments';
+import { useActiveOpenstackProject } from '../contexts/OpenstackProjectContext';
 
 interface DashboardProps {
   onSelectDeployment?: (deploymentId: string) => void;
 }
 
 export function Dashboard({ onSelectDeployment }: DashboardProps) {
+  const { activeProjectId } = useActiveOpenstackProject();
   const [quotas, setQuotas] = useState<QuotasResponse | null>(null);
   const [quotasError, setQuotasError] = useState<string | null>(null);
   const [quotasLoading, setQuotasLoading] = useState<boolean>(false);
@@ -46,7 +48,7 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
     let mounted = true;
     // Show loading only if we don't already have data (e.g., after Fast Refresh)
     setDeploymentsLoading(recentDeployments.length === 0);
-    getAllDeployments()
+    getAllDeployments(activeProjectId)
       .then((items) => {
         if (!mounted) return;
         // Count all deployments using the length of the data
@@ -86,7 +88,7 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
         if (mounted) setDeploymentsLoading(false);
       });
     return () => { mounted = false; };
-  }, []);
+  }, [activeProjectId]);
 
   const percent = (used?: number, limit?: number) => {
     if (!used || !limit || limit === 0) return 0;

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -40,6 +40,7 @@ import {
   getDeploymentCredentials,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 interface DeploymentStep {
   id: string;
@@ -80,6 +81,7 @@ interface DeploymentDetailsProps {
 }
 
 export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDetailsProps) {
+  const { activeProjectId } = useActiveOpenstackProject();
   const [credentialsVisible, setCredentialsVisible] = useState(false);
   const [credentialsLoading, setCredentialsLoading] = useState(false);
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
@@ -127,7 +129,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
     setCredentialsError(null);
 
     try {
-      const response = await getDeploymentCredentials(deployment.id);
+      const response = await getDeploymentCredentials(deployment.id, activeProjectId);
       setCredentialsData(response.data);
     } catch (err) {
       const error = err as Error & { status?: number };
@@ -139,7 +141,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
     } finally {
       setCredentialsLoading(false);
     }
-  }, [credentialsLoading, deployment.id]);
+  }, [credentialsLoading, deployment.id, activeProjectId]);
 
   const handleToggleCredentials = () => {
     const nextVisible = !credentialsVisible;

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/deployments";
 import { getMyCourses, type CourseDto } from "../api/courses";
 import { getKeycloakGroups, type KeycloakGroup } from "../api/keycloak";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 // ── Phase definitions ─────────────────────────────────────────────────────────
 
@@ -169,6 +170,7 @@ const ACTIVE_STATUSES = new Set(["deploying"]);
 export function DeploymentDetailsPage() {
   const { deploymentId } = useParams<{ deploymentId: string }>();
   const navigate = useNavigate();
+  const { activeProjectId } = useActiveOpenstackProject();
   const [deploymentData, setDeploymentData] = useState<any>(null);
   const [loadingDeployment, setLoadingDeployment] = useState(false);
   const isDeletingRef = useRef(false);
@@ -189,7 +191,7 @@ export function DeploymentDetailsPage() {
     setDeploymentData((prev: any) => prev ? { ...prev, status: "deleting" } : prev);
 
     try {
-      await deleteDeployment(id);
+      await deleteDeployment(id, activeProjectId);
     } catch (err) {
       console.error("Failed to initiate delete", err);
     }
@@ -199,7 +201,7 @@ export function DeploymentDetailsPage() {
     const poll = async () => {
       attempts++;
       try {
-        const resp = await getDeployment(id);
+        const resp = await getDeployment(id, activeProjectId);
         const s = resp.data.status.toUpperCase();
         if (s === "DELETED" || s === "DELETE_COMPLETE") {
           navigate("/dashboard");
@@ -297,8 +299,8 @@ export function DeploymentDetailsPage() {
     Promise.all([
       getMyCourses({ page: 1, page_size: 100 }).catch(() => ({ data: [] as CourseDto[] })),
       getKeycloakGroups().catch(() => ({ data: [] as KeycloakGroup[] })),
-      getDeployment(deploymentId),
-      getDeploymentLogs(deploymentId).catch(() => ({ data: [] as DeploymentLogDto[] })),
+      getDeployment(deploymentId, activeProjectId),
+      getDeploymentLogs(deploymentId, activeProjectId).catch(() => ({ data: [] as DeploymentLogDto[] })),
     ]).then(([coursesResp, groupsResp, depResp, logsResp]) => {
       coursesCacheRef.current = (coursesResp as any)?.data || [];
       groupsCacheRef.current = (groupsResp as any)?.data || [];
@@ -315,6 +317,7 @@ export function DeploymentDetailsPage() {
       const stopStream = streamDeploymentLogs(
         deploymentId,
         lastLogId,
+        activeProjectId,
         (log) => {
           if (isDeletingRef.current) return;
           logsRef.current = [...logsRef.current, log];
@@ -324,7 +327,7 @@ export function DeploymentDetailsPage() {
         },
         () => {
           if (isDeletingRef.current) return;
-          getDeployment(deploymentId).then((depResp) => {
+          getDeployment(deploymentId, activeProjectId).then((depResp) => {
             backendDeploymentRef.current = depResp.data;
             setDeploymentData(buildDeploymentData(depResp.data, logsRef.current));
           }).catch(() => {});
@@ -334,7 +337,7 @@ export function DeploymentDetailsPage() {
     }).catch(() => setLoadingDeployment(false));
 
     return () => { stopStreamRef.current?.(); stopStreamRef.current = null; };
-  }, [deploymentId, buildDeploymentData]);
+  }, [deploymentId, activeProjectId, buildDeploymentData]);
 
   if (!deploymentId) return <Navigate to="/dashboard" replace />;
   if (loadingDeployment) return <div className="p-6">Lade Deployment...</div>;

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -51,6 +51,7 @@ import {
 } from "../api/deployments";
 import { GroupManager, type StudentGroup } from "../components/GroupManager";
 import keycloak from "../auth/keycloak";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 // GroupStackAssignment type (no UI component needed, auto-assignment in background)
 export interface GroupStackAssignment {
@@ -70,6 +71,7 @@ export function DeploymentWizard({
   onCancel,
   onComplete,
 }: DeploymentWizardProps) {
+  const { activeProjectId } = useActiveOpenstackProject();
   const [currentStep, setCurrentStep] = useState(0);
   const [isDeploying, setIsDeploying] = useState(false);
 
@@ -558,6 +560,16 @@ export function DeploymentWizard({
         return;
       }
 
+      // Backend pins the deployment to the user's active OpenStack project so
+      // later restart/delete uses the right credentials even if the user
+      // switches their clouds.yaml. Teachers must have one — the App-level
+      // setup gate normally prevents this branch, but be defensive.
+      if (!activeProjectId) {
+        setError("Kein aktives OpenStack-Projekt. Bitte richten Sie zuerst ein OpenStack-Projekt ein.");
+        setIsDeploying(false);
+        return;
+      }
+
       // Convert uploaded files to base64
       const userFilesPayload: Record<string, string> = {};
       for (const [name, file] of Object.entries(uploadedFiles)) {
@@ -575,6 +587,7 @@ export function DeploymentWizard({
         name: deploymentName.trim(),
         template_version_id: selectedVersionId,
         course_id: selectedKeycloakGroupId,
+        openstack_project_id: activeProjectId,
         parameters: heatParameters,
         ...(Object.keys(userFilesPayload).length > 0 && { user_files: userFilesPayload }),
         stack_assignments: groupStackAssignments.map((stack, stackIndex) => ({


### PR DESCRIPTION
## Why

The backend PR ([appstore-backend#137](https://github.com/DoziLab/appstore-backend/pull/137)) makes `openstack_project_id` (the local DB id of the user's active OpenStack project) a required input on every deployment endpoint:

- Query parameter on read/restart/delete — lecturers get 400 without it.
- Required field in the create body — schema rejects payloads without it.
- Cross-project access returns 403, not 200.

Without matching frontend changes, every page that lists or opens a deployment would 400 immediately for lecturers. This PR threads the active project through the deployment API surface.

## What changes

* **New `OpenstackProjectContext` + `useActiveOpenstackProject` hook** ([src/contexts/OpenstackProjectContext.tsx](src/contexts/OpenstackProjectContext.tsx)). Holds the local id of the user's currently-active project; project switching is still settings-only, but every page that touches deployments reads it from this context instead of refetching.
* **[App.tsx](src/App.tsx)** keeps the full `OpenstackProjectResponse` (not just a `hasProjects` boolean) and wraps the authenticated routes in `<OpenstackProjectProvider>`. The setup gate is identical for lecturers; admins skip it and the provider yields `null`.
* **[api/deployments.ts](src/api/deployments.ts)**: `getAllDeployments` / `getDeployment` / `getDeploymentCredentials` / `getDeploymentLogs` / `streamDeploymentLogs` / `deleteDeployment` all take `openstackProjectId: string | null` and append `?openstack_project_id=…` via a tiny `projectQuery` helper. `DeploymentCreateRequest` gets the new required field.
* **Page wiring**: [Dashboard](src/pages/Dashboard.tsx), [DeploymentDetailsPage](src/pages/DeploymentDetailsPage.tsx), [DeploymentDetails (credentials sub-component)](src/pages/DeploymentDetails.tsx), and [DeploymentWizard](src/pages/DeploymentWizard.tsx) pull `activeProjectId` from the hook and pass it through. The wizard guards a missing project with a friendly setup prompt rather than letting the request fail.
* **[AdminMonitoring](src/pages/AdminMonitoring.tsx)** passes `null` explicitly — admin scope is "all projects", and the backend skips the filter when the param is absent.

## Out of scope (separate PR coming)

The Courses page reads deployments via `/api/v1/courses`, where the server-side eager-load has the same owner/project leak as the old `/deployments` endpoint. That's a backend change (`course_repository.list_with_filters`), not frontend.

## Verification

* `npm run build` is clean — no TypeScript or import errors after merging in the latest `main`.
* Manual flow via the browser: as a lecturer, dashboard / detail / restart / delete all hit the endpoint with the query param attached; as an admin, the same paths fire without the param and return everything.
* Tied to the backend PR — needs both merged together.