### PR TITLE
feat(courses): pass active OpenStack project to course listing

### DIFF
--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -62,12 +62,17 @@ export async function getMyCourses(params?: {
   page_size?: number;
   search?: string;
   lecturer_id?: string;
+  // Active OpenStack project (local DB id). The backend requires this for
+  // non-admin callers; without it embedded `course.deployments` would leak
+  // across owners again. Pass `null` to omit (admin context only).
+  openstack_project_id?: string | null;
 }) {
   const sp = new URLSearchParams();
   if (params?.page) sp.set("page", String(params.page));
   if (params?.page_size) sp.set("page_size", String(params.page_size));
   if (params?.search) sp.set("search", params.search);
   if (params?.lecturer_id) sp.set("lecturer_id", params.lecturer_id);
+  if (params?.openstack_project_id) sp.set("openstack_project_id", params.openstack_project_id);
 
   const qs = sp.toString();
   return apiFetch<CoursesResponse>(`/api/v1/courses${qs ? `?${qs}` : ""}`);

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { getMyCourses, CourseDto } from "../api/courses";
 import { getKeycloakGroups, KeycloakGroup } from "../api/keycloak";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 type CourseUi = {
   id: string;
@@ -17,6 +18,7 @@ type CourseUi = {
 
 export function Courses() {
   const navigate = useNavigate();
+  const { activeProjectId } = useActiveOpenstackProject();
   const [items, setItems] = useState<CourseDto[]>([]);
   const [keycloakGroups, setKeycloakGroups] = useState<KeycloakGroup[]>([]);
   const [loading, setLoading] = useState(true);
@@ -30,11 +32,16 @@ export function Courses() {
         setLoading(true);
         setError(null);
 
+        // Pass the active OpenStack project to the courses API so the
+        // backend can scope each course's embedded `deployments` collection
+        // to (project = activeProjectId) AND (teacher.id = caller). Without
+        // this param the backend rejects non-admins with 400 — matches the
+        // contract introduced in PR #137 for /api/v1/deployments.
         const [coursesRes, groupsRes] = await Promise.all([
-          getMyCourses({ page: 1, page_size: 10}),
+          getMyCourses({ page: 1, page_size: 10, openstack_project_id: activeProjectId }),
           getKeycloakGroups(),
         ]);
-        
+
         if (!alive) return;
 
         setItems(coursesRes.data || []);
@@ -51,7 +58,7 @@ export function Courses() {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [activeProjectId]);
 
   const courses: CourseUi[] = useMemo(() => {
     return items.map((c) => {


### PR DESCRIPTION
## Why

The Courses page used to call `getMyCourses()` without a project param. The backend (PRs #91 / #137) only filters `/api/v1/deployments` by owner + active project; the courses endpoint was eager-loading deployments **unfiltered**, so `course.deployments` still leaked across owners — and the Courses page renders that array directly, so the leak was visible.

The companion backend PR ([appstore-backend#139](https://github.com/DoziLab/appstore-backend/pull/139)) adds a required `openstack_project_id` query param to `GET /courses` (and `/courses/{id}`) for non-admins. This PR wires the existing `useActiveOpenstackProject` context (introduced in PR #91) into the Courses page and threads the active project id through.

## What

- [`src/api/courses.ts`](src/api/courses.ts): `getMyCourses()` accepts an optional `openstack_project_id: string | null` and appends it to the query string when set. Pattern matches the deployments client.
- [`src/pages/Courses.tsx`](src/pages/Courses.tsx): consumes `useActiveOpenstackProject()`, passes `activeProjectId` to `getMyCourses`, and adds `activeProjectId` to the effect's dependency list so the page refetches on project switch (same shape as `Dashboard.tsx`).

## Verification

- `npm run build` → clean (preexisting bundle-size warning unchanged).
- Manual: as Lecturer A, visiting `/courses` should now show only A's deployments under each course; previously B's deployments were also visible. As Lecturer B, only B's. Admin sees the unfiltered view (backend behaviour).

## Companion

- Backend: [appstore-backend#139](https://github.com/DoziLab/appstore-backend/pull/139). Without the matching backend, the page gets 400s; merge together.

## CI note

`.github/workflows/ci-cd.yml` only triggers PR-builds against `main`, not `staging`. Local `npm run build` is the substitute check.

## Out-of-scope

- Course-Owner concept itself (every lecturer sees every course today) — separate audit.
- `getMyCourses` despite its name doesn't filter by membership today — separate audit.