### PR TITLE
ci: Nur staging-Branch darf in main gemergt werden

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,13 +2,25 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches: [ main, staging ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging ]
   workflow_dispatch:
 
 jobs:
+  check-source-branch:
+    name: Only staging can merge into main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - name: Check source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "PRs to main are only allowed from 'staging' branch!"
+            echo "Current branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   test:
     name: Lint, Format & Build
     runs-on: ubuntu-latest
@@ -32,7 +44,7 @@ jobs:
     name: Build & Push Staging Image
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/staging'
     permissions:
       contents: read
       packages: write
@@ -62,7 +74,7 @@ jobs:
     name: Build & Push Production Image
     runs-on: ubuntu-latest
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -80,9 +92,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/dozilab/appstore-frontend:latest
-            ghcr.io/dozilab/appstore-frontend:${{ github.ref_name }}
+          tags: ghcr.io/dozilab/appstore-frontend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -95,7 +105,6 @@ jobs:
     needs: build-and-push-staging
     runs-on: self-hosted
     environment: staging
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -123,7 +132,6 @@ jobs:
     needs: build-and-push-prod
     runs-on: self-hosted
     environment: production
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
         with:


### PR DESCRIPTION
## Was ändert sich?

- **Neuer Job `check-source-branch`**: Schlägt fehl, wenn ein PR auf `main` nicht vom `staging` Branch kommt
- **Workflow zurück auf staging→main Modell**: Tag-basierter Production-Flow entfernt
  - Push auf `staging` → Deploy auf Staging
  - Push auf `main` → Deploy auf Production

## Warum?

Wir hatten den Vorfall, dass ein Feature direkt von einem Feature-Branch in `main` gemergt wurde, ohne vorher auf staging getestet zu werden. Dieser Check verhindert das.

## Nach dem Merge

In den GitHub Settings unter Branch Protection für `main` muss noch `Only staging can merge into main` als Required Status Check eingetragen werden, damit der Check tatsächlich blockierend wirkt.