### PR TITLE
ci: restrict main merges to staging branch only

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-source-branch:
+    name: Only staging can merge into main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    steps:
+      - name: Check source branch
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "PRs to main are only allowed from 'staging' branch!"
+            echo "Current branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   test:
     name: Lint, Format & Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

Bring the new `check-source-branch` job into `staging` so that future `staging → main` PRs already include the check.

## What changes?

Adds a single new job `check-source-branch` that fails any PR targeting `main` whose source branch is not `staging`.

Diff: 1 file changed, 13 insertions(+).

## Why only the check?

The full CI rewrite from PR #94 (which also reverted the tag-based production flow back to staging→main) is not needed here — `staging` already uses the staging→main model. Only the new `check-source-branch` job is missing, so we add just that.