### PR TITLE
feat: hardcoded values cleanup — flavors, template owner, deployment lifecycle

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -31,6 +31,10 @@ export type DeploymentDto = {
     openstack_instance_id?: string | null;
     status?: string | null;
     ip_address?: string | null;
+    // Nova flavor name the Heat-Stack was created with. Nullable for legacy
+    // rows from before the per-instance flavor migration; new instances
+    // always have it. Resolve against /openstack/flavors for vCPU/RAM/disk.
+    flavor?: string | null;
     access_urls: Array<{
       id: string;
       access_type: string | null;

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -12,6 +12,10 @@ export type DeploymentDto = {
   config_json?: string | null;
   deployment_parameters?: string | null;
   access_types_json: string;
+  // Lifecycle (B6). Both nullable for legacy rows from before the
+  // expires_at migration. UI: see src/utils/deployment.ts.
+  expires_at?: string | null;
+  expiry_warning_at?: string | null;
   created_at: string;
   updated_at: string;
   template_version?: {
@@ -87,6 +91,10 @@ export type DeploymentLogDto = {
   created_at: string;
 };
 
+// Allowed deployment runtimes in months. Must mirror the backend's
+// ALLOWED_RUNTIME_MONTHS — wizard <Select> options must stay in sync.
+export type RuntimeMonths = 1 | 3 | 4 | 6 | 12 | 24;
+
 export type DeploymentCreateRequest = {
   name?: string;
   template_version_id: string;
@@ -99,6 +107,8 @@ export type DeploymentCreateRequest = {
   config_json?: string;
   parameters?: Record<string, any>;
   user_files?: Record<string, string>;  // file_name -> base64-encoded content
+  // Optional — backend defaults to 4 months if omitted.
+  runtime_months?: RuntimeMonths;
   stack_assignments?: Array<{
     groups: Array<{
       group_name: string;
@@ -273,4 +283,41 @@ export async function getAllDeployments(openstackProjectId: string | null): Prom
     return (resp as DeploymentsListEnvelope).data || [];
   }
   return Array.isArray(resp) ? resp : [];
+}
+
+// ── Lifecycle: extend deployment ─────────────────────────────────────────────
+//
+// PATCH /api/v1/deployments/{id}/extend pushes expires_at and expiry_warning_at
+// into the future by `runtime_months`. Anchored on max(now, current_expires_at)
+// so a user clicking "+4 months" while the deployment still has 60 days left
+// stacks the extension; a user clicking after expiry but before the Beat sweep
+// gets a fresh window from now.
+
+export type DeploymentExtendResponse = {
+  deployment_id: string;
+  expires_at: string;
+  expiry_warning_at: string;
+  runtime_months_added: number;
+};
+
+export async function extendDeployment(
+  deploymentId: string,
+  runtimeMonths: RuntimeMonths,
+  openstackProjectId: string | null,
+): Promise<DeploymentExtendResponse> {
+  const resp = await apiFetch<{
+    success: boolean;
+    message: string;
+    data: DeploymentExtendResponse;
+    errors: unknown;
+    timestamp: string;
+    request_id: string;
+  }>(
+    `/api/v1/deployments/${deploymentId}/extend${projectQuery(openstackProjectId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ runtime_months: runtimeMonths }),
+    },
+  );
+  return resp.data;
 }

--- a/src/api/openstack.ts
+++ b/src/api/openstack.ts
@@ -1,0 +1,53 @@
+import { apiFetch } from "./http";
+
+// Nova flavor as exposed by GET /api/v1/openstack/flavors. Mirrors the
+// backend's FlavorDto 1:1 — keep field names in sync if backend renames.
+export type FlavorDto = {
+  id: string;
+  name: string;
+  vcpus: number;
+  ram_mb: number;
+  disk_gb: number;
+  ephemeral_gb: number;
+  is_public: boolean;
+};
+
+export type FlavorsResponse = {
+  project_id: string;
+  project_name: string;
+  // Only set when an admin queries another user's project; null for lecturers.
+  owner_user_id: string | null;
+  // Pre-sorted by (vcpus ASC, ram_mb ASC) — no need to re-sort client-side.
+  flavors: FlavorDto[];
+  fetched_at: string;
+};
+
+type FlavorsEnvelope = { success?: boolean; data: FlavorsResponse } & Record<string, unknown>;
+
+/**
+ * Fetch the Nova flavors visible to a project.
+ *
+ * - No args → caller's own project (mirrors `getQuotas()` semantics).
+ * - `projectId` → admin queries a specific OpenStack project (local DB id).
+ * - `lecturerId` → admin queries the project owned by a lecturer; backend
+ *   resolves to that user's project. `lecturerId` takes precedence on the
+ *   backend if both are set, but we don't send both at once on purpose.
+ */
+export async function getFlavors(opts?: {
+  projectId?: string;
+  lecturerId?: string;
+}): Promise<FlavorsResponse> {
+  const params = new URLSearchParams();
+  if (opts?.projectId) params.set("project_id", opts.projectId);
+  if (opts?.lecturerId) params.set("lecturer_id", opts.lecturerId);
+
+  const qs = params.toString();
+  const path = `/api/v1/openstack/flavors${qs ? `?${qs}` : ""}`;
+  const resp = await apiFetch<FlavorsResponse | FlavorsEnvelope>(path);
+
+  // Normalize envelope → bare payload.
+  if (resp && typeof resp === "object" && "data" in resp) {
+    return (resp as FlavorsEnvelope).data;
+  }
+  return resp as FlavorsResponse;
+}

--- a/src/api/templates.ts
+++ b/src/api/templates.ts
@@ -42,6 +42,13 @@ export type TemplateDto = {
   name: string;
   description: string | null;
   owner_id: string;
+  // Cached display fields refreshed from the Keycloak token on the owner's
+  // last login. Null for service accounts or users who haven't logged in
+  // since the migration that introduced them — frontend should fall back
+  // through owner_name → owner_username → owner_id.
+  owner_name: string | null;
+  owner_email: string | null;
+  owner_username: string | null;
   repo_url: string;
   icon_url: string | null;
   visibility: string;

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -712,8 +712,9 @@ export function AdminMonitoring() {
                         )}
                         <div className="flex items-center gap-4 text-sm text-slate-500">
                           <span>Eingereicht: {new Date(template.created_at).toLocaleString()}</span>
-                          {/* TODO: owner_id is available but not resolved to a display name.
-                              Needs GET /users/{id} or a user lookup endpoint from the backend. */}
+                          <span title={template.owner_email ?? undefined}>
+                            von {template.owner_name ?? template.owner_username ?? template.owner_id}
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -38,6 +38,7 @@ import {
 } from '../api/deployments';
 import { getQuotas, QuotasResponse } from '../api/quotas';
 import { getTemplates, approveTemplate, rejectTemplate, TemplateDto } from '../api/templates';
+import { getFlavors, FlavorDto } from '../api/openstack';
 import React from 'react';
 
 
@@ -56,6 +57,11 @@ export function AdminMonitoring() {
 
   const [pendingTemplates, setPendingTemplates] = useState<TemplateDto[]>([]);
   const [templateActionError, setTemplateActionError] = useState<string | null>(null);
+
+  // Nova flavor catalog, keyed by flavor name (matches the value of the
+  // template's `flavor` parameter default). Used to render real vCPU/RAM/Disk
+  // numbers instead of hardcoded multipliers. Empty Map = not loaded yet.
+  const [flavorsByName, setFlavorsByName] = useState<Map<string, FlavorDto>>(new Map());
 
   const handleApprove = async (templateId: string) => {
     try {
@@ -109,6 +115,19 @@ export function AdminMonitoring() {
     getTemplates({ status: 'pending' })
       .then((res) => setPendingTemplates(res.data))
       .catch(console.error);
+  }, []);
+
+  // Load flavor catalog once. Pending templates have no per-lecturer context
+  // here, so we fetch from the admin's own project — flavors are typically
+  // OpenStack-cluster-wide, so this works for the cards' display purpose.
+  useEffect(() => {
+    getFlavors()
+      .then((resp) => {
+        setFlavorsByName(new Map(resp.flavors.map((f) => [f.name, f])));
+      })
+      .catch((err) => {
+        console.error('Failed to load flavors', err);
+      });
   }, []);
 
 
@@ -703,10 +722,16 @@ export function AdminMonitoring() {
                     {(() => {
                       const version = template.versions?.[0];
                       const flavorParam = version?.parameters?.find(p => p.name === 'flavor');
-                      // TODO (#73): flavor name (e.g. "gp1.medium") is available but vCPU/RAM/storage
-                      // numbers are not — requires GET /openstack/flavors from backend (Nova API).
-                      // TODO (#74): owner_id is available but not resolved to a display name —
-                      // requires GET /users/{id} or owner_name in TemplateResponse from backend.
+                      const flavorName = flavorParam?.default as string | undefined;
+                      // Resolve flavor name → real vCPU/RAM/Disk from the Nova
+                      // catalog loaded once at mount. If the template's flavor
+                      // default isn't in the catalog (private flavor, typo, or
+                      // catalog not loaded yet) we render '—' rather than
+                      // falling back to a hardcoded number.
+                      const flavor = flavorName ? flavorsByName.get(flavorName) : undefined;
+                      const cpuLabel = flavor ? `${flavor.vcpus} ${flavor.vcpus === 1 ? 'Kern' : 'Kerne'}` : '—';
+                      const ramLabel = flavor ? `${Math.round(flavor.ram_mb / 1024)} GB` : '—';
+                      const diskLabel = flavor ? `${flavor.disk_gb} GB` : '—';
                       return (
                         <div className="grid grid-cols-4 gap-4 mb-4">
                           <div className="p-3 bg-blue-50 rounded-lg">
@@ -714,16 +739,14 @@ export function AdminMonitoring() {
                               <Cpu className="w-4 h-4 text-blue-600" />
                               <span className="text-xs text-blue-600">CPU-Kerne</span>
                             </div>
-                            {/* TODO (#73): replace with vCPU count from flavor endpoint */}
-                            <p className="text-slate-900">8 Kerne</p>
+                            <p className="text-slate-900">{cpuLabel}</p>
                           </div>
                           <div className="p-3 bg-purple-50 rounded-lg">
                             <div className="flex items-center gap-2 mb-1">
                               <Database className="w-4 h-4 text-purple-600" />
                               <span className="text-xs text-purple-600">RAM</span>
                             </div>
-                            {/* TODO (#73): replace with RAM from flavor endpoint */}
-                            <p className="text-slate-900">16 GB</p>
+                            <p className="text-slate-900">{ramLabel}</p>
                           </div>
                           <div className="p-3 bg-teal-50 rounded-lg">
                             <div className="flex items-center gap-2 mb-1">
@@ -731,7 +754,7 @@ export function AdminMonitoring() {
                               <span className="text-xs text-teal-600">Flavor</span>
                             </div>
                             <p className="text-slate-900 text-sm">
-                              {flavorParam?.default ?? '—'}
+                              {flavorName ?? '—'}
                             </p>
                           </div>
                           <div className="p-3 bg-slate-50 rounded-lg">
@@ -739,8 +762,7 @@ export function AdminMonitoring() {
                               <HardDrive className="w-4 h-4 text-slate-600" />
                               <span className="text-xs text-slate-600">Speicher</span>
                             </div>
-                            {/* TODO (#73): replace with disk size from flavor endpoint */}
-                            <p className="text-slate-900">80 GB</p>
+                            <p className="text-slate-900">{diskLabel}</p>
                           </div>
                         </div>
                       );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Server, Cpu, HardDrive, Activity, AlertCircle, CheckCircle2, Clock } from 'lucide-react';
+import { Server, Cpu, HardDrive, Activity, AlertCircle, CheckCircle2, Clock, AlertTriangle, AlertOctagon } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { Progress } from '../components/ui/progress';
 import { Badge } from '../components/ui/badge';
 import { getQuotas, type QuotasResponse } from '../api/quotas';
 import { getAllDeployments, type DeploymentDto } from '../api/deployments';
+import { getExpiryState } from '../utils/deployment';
 import { useActiveOpenstackProject } from '../contexts/OpenstackProjectContext';
 
 interface DashboardProps {
@@ -19,7 +20,15 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
   const [activeDeployments, setActiveDeployments] = useState<number | null>(null);
   const [deploymentsError, setDeploymentsError] = useState<string | null>(null);
   const [deploymentsLoading, setDeploymentsLoading] = useState<boolean>(false);
-  const [recentDeployments, setRecentDeployments] = useState<Array<{ id: string; name: string; status: string; course?: string; updated: string }>>([]);
+  const [recentDeployments, setRecentDeployments] = useState<Array<{
+    id: string;
+    name: string;
+    status: string;
+    course?: string;
+    updated: string;
+    expires_at: string | null;
+    expiry_warning_at: string | null;
+  }>>([]);
 
   useEffect(() => {
     let mounted = true;
@@ -77,6 +86,11 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
           status: d.status,
           course: d.course?.name || undefined,
           updated: formatRelativeFromISO(d.updated_at || d.created_at),
+          // B6: thread expiry timestamps through so the row can render an
+          // expiry icon. getExpiryState() handles the null cases for legacy
+          // deployments — no need to filter here.
+          expires_at: d.expires_at ?? null,
+          expiry_warning_at: d.expiry_warning_at ?? null,
         }));
         setRecentDeployments(mapped);
       })
@@ -189,22 +203,41 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
               {deploymentsLoading && (
                 <div className="text-sm text-slate-500">Lädt...</div>
               )}
-              {!deploymentsLoading && recentDeployments.map((deployment, idx) => (
-                <div
-                  key={idx}
-                  onClick={() => onSelectDeployment?.(deployment.id)}
-                  className="flex items-center gap-4 p-4 rounded-lg bg-slate-50 border border-slate-100 hover:bg-slate-100 hover:border-slate-200 cursor-pointer transition-all"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-3 mb-1">
-                      <p className="text-slate-900 truncate">{deployment.name}</p>
-                      {getStatusBadge(deployment.status)}
+              {!deploymentsLoading && recentDeployments.map((deployment, idx) => {
+                const expiryState = getExpiryState(deployment);
+                const expiryDateLabel = deployment.expires_at
+                  ? new Date(deployment.expires_at).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })
+                  : null;
+                return (
+                  <div
+                    key={idx}
+                    onClick={() => onSelectDeployment?.(deployment.id)}
+                    className="flex items-center gap-4 p-4 rounded-lg bg-slate-50 border border-slate-100 hover:bg-slate-100 hover:border-slate-200 cursor-pointer transition-all"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-3 mb-1">
+                        <p className="text-slate-900 truncate">{deployment.name}</p>
+                        {getStatusBadge(deployment.status)}
+                        {/* B6 expiry icon — only when warning/expired. Tooltip via
+                            native title attribute keeps the dependency footprint
+                            tiny on a hot list. */}
+                        {expiryState === 'warning' && (
+                          <span title={`Läuft am ${expiryDateLabel} ab`}>
+                            <AlertTriangle className="w-4 h-4 text-amber-500" />
+                          </span>
+                        )}
+                        {expiryState === 'expired' && (
+                          <span title="Wird in Kürze automatisch gelöscht">
+                            <AlertOctagon className="w-4 h-4 text-red-500" />
+                          </span>
+                        )}
+                      </div>
+                      {deployment.course && <p className="text-sm text-slate-500">{deployment.course}</p>}
+                      <p className="text-xs text-slate-400 mt-1">Aktualisiert {deployment.updated}</p>
                     </div>
-                    {deployment.course && <p className="text-sm text-slate-500">{deployment.course}</p>}
-                    <p className="text-xs text-slate-400 mt-1">Aktualisiert {deployment.updated}</p>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </CardContent>
         </Card>

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -16,6 +16,8 @@ import {
   Flame,
   Terminal,
   Flag,
+  AlertTriangle,
+  AlertOctagon,
 } from "lucide-react";
 import { toast } from "sonner@2.0.3";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
@@ -38,8 +40,10 @@ import {
   DeploymentCredentialsResponse,
   DeploymentLogDto,
   getDeploymentCredentials,
+  extendDeployment,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
+import { getExpiryState } from "../utils/deployment";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 interface DeploymentStep {
@@ -67,6 +71,10 @@ interface Deployment {
   phases?: LogPhase[];
   logs?: DeploymentLogDto[];
   error?: string;
+  // Lifecycle (B6) — null for legacy deployments without expiry tracking.
+  // Both passed through from the backend, used by the expiry banner.
+  expires_at?: string | null;
+  expiry_warning_at?: string | null;
   resources: {
     cpu: number;
     ram: number;
@@ -87,6 +95,35 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
   const [credentialsData, setCredentialsData] = useState<DeploymentCredentialsResponse | null>(null);
   const [passwordVisibility, setPasswordVisibility] = useState<Record<string, boolean>>({});
+  // Inline extend-action state (B6). Pessimistic: button disabled while
+  // request flies, error shown via toast, success refreshes the page so the
+  // new expires_at lands in `deployment` via the parent's data loader.
+  const [extendInFlight, setExtendInFlight] = useState(false);
+
+  const expiryState = getExpiryState(deployment);
+
+  const handleExtend = useCallback(async () => {
+    if (extendInFlight) return;
+    setExtendInFlight(true);
+    try {
+      // Default extension matches the wizard default (4 months). If the UI
+      // ever offers a select for the extend amount, plumb the chosen value
+      // here instead of the hardcoded 4.
+      await extendDeployment(deployment.id, 4, activeProjectId);
+      toast.success("Deployment um 4 Monate verlängert.");
+      // Cheapest correct refresh — the parent route reloads the deployment
+      // on mount, so we don't need a callback prop just for this case.
+      window.location.reload();
+    } catch (err) {
+      const error = err as Error & { status?: number };
+      if (error.status === 403) {
+        toast.error("Keine Berechtigung, dieses Deployment zu verlängern.");
+      } else {
+        toast.error("Verlängern fehlgeschlagen. Bitte später erneut versuchen.");
+      }
+      setExtendInFlight(false);
+    }
+  }, [deployment.id, activeProjectId, extendInFlight]);
 
   const accessTypeLabels: Record<AccessType, string> = {
     ssh: "SSH",
@@ -283,6 +320,72 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
           </div>
         </div>
       </div>
+
+      {/* Expiry banner (B6) — only shows when expires_at is set AND we're past
+          the warning threshold or already expired. Legacy deployments without
+          expiry tracking stay invisible here. */}
+      {expiryState !== "ok" && deployment.expires_at && (
+        <Card
+          className={
+            expiryState === "expired"
+              ? "border-red-200 shadow-sm bg-gradient-to-br from-red-50 to-white"
+              : "border-amber-200 shadow-sm bg-gradient-to-br from-amber-50 to-white"
+          }
+        >
+          <CardContent className="p-6">
+            <div className="flex items-start gap-4">
+              <div
+                className={`w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  expiryState === "expired" ? "bg-red-100" : "bg-amber-100"
+                }`}
+              >
+                {expiryState === "expired" ? (
+                  <AlertOctagon className="w-6 h-6 text-red-600" />
+                ) : (
+                  <AlertTriangle className="w-6 h-6 text-amber-600" />
+                )}
+              </div>
+              <div className="flex-1">
+                <h3
+                  className={
+                    expiryState === "expired" ? "text-red-900 mb-2" : "text-amber-900 mb-2"
+                  }
+                >
+                  {expiryState === "expired"
+                    ? "Dieses Deployment ist abgelaufen und wird in Kürze gelöscht."
+                    : `Läuft am ${new Date(deployment.expires_at).toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" })} ab`}
+                </h3>
+                <p
+                  className={
+                    expiryState === "expired"
+                      ? "text-sm text-red-700 mb-3"
+                      : "text-sm text-amber-700 mb-3"
+                  }
+                >
+                  {expiryState === "expired"
+                    ? "Verlängern Sie es jetzt, falls die nächtliche Bereinigung noch nicht gelaufen ist."
+                    : "Verlängern Sie es, bevor der Cleanup-Job es entfernt."}
+                </p>
+                <Button
+                  size="sm"
+                  variant={expiryState === "expired" ? "destructive" : "default"}
+                  disabled={extendInFlight}
+                  onClick={handleExtend}
+                >
+                  {extendInFlight ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Verlängere…
+                    </>
+                  ) : (
+                    "Um 4 Monate verlängern"
+                  )}
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Progress Overview für aktive Deployments */}
       {deployment.status === 'deploying' && (

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -296,6 +296,10 @@ export function DeploymentDetailsPage() {
         phases,
         logs,
         error: failedLog?.message || undefined,
+        // Lifecycle (B6) — passed through verbatim; presentational decisions
+        // (banner / icon / 'läuft ab in X Tagen') happen in DeploymentDetails.
+        expires_at: backendDeployment.expires_at ?? null,
+        expiry_warning_at: backendDeployment.expiry_warning_at ?? null,
         resources: { cpu, ram, storage },
       };
     },

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/deployments";
 import { getMyCourses, type CourseDto } from "../api/courses";
 import { getKeycloakGroups, type KeycloakGroup } from "../api/keycloak";
+import { getFlavors, type FlavorDto } from "../api/openstack";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 // ── Phase definitions ─────────────────────────────────────────────────────────
@@ -178,6 +179,11 @@ export function DeploymentDetailsPage() {
   // Stable reference data fetched once
   const coursesCacheRef = useRef<CourseDto[]>([]);
   const groupsCacheRef = useRef<KeycloakGroup[]>([]);
+  // Nova flavor catalog keyed by name. Loaded once at mount; used to turn
+  // each instance's `flavor` string into real vCPU/RAM/disk for the resource
+  // block. Empty Map until the request resolves — instances with unknown
+  // flavors fall back to '—' rather than a hardcoded multiplier.
+  const flavorsByNameRef = useRef<Map<string, FlavorDto>>(new Map());
   // Accumulate logs from SSE
   const logsRef = useRef<DeploymentLogDto[]>([]);
   const backendDeploymentRef = useRef<any>(null);
@@ -246,10 +252,17 @@ export function DeploymentDetailsPage() {
       }));
 
       let cpu = 0, ram = 0, storage = 0;
-      if (backendDeployment.instances?.length > 0) {
-        cpu = backendDeployment.instances.length * 2;
-        ram = backendDeployment.instances.length * 4;
-        storage = backendDeployment.instances.length * 20;
+      // Sum vCPU/RAM/disk from each instance's actual Nova flavor. Instances
+      // whose flavor isn't in the catalog (legacy rows with `flavor === null`,
+      // private flavors not visible to the caller) are silently skipped — we
+      // do NOT fall back to length*N multipliers, because that masks the gap.
+      const flavorsByName = flavorsByNameRef.current;
+      for (const inst of backendDeployment.instances ?? []) {
+        const f = inst.flavor ? flavorsByName.get(inst.flavor) : undefined;
+        if (!f) continue;
+        cpu += f.vcpus;
+        ram += Math.round(f.ram_mb / 1024);
+        storage += f.disk_gb;
       }
 
       let resolvedCourseName = "Unbekannter Kurs";
@@ -295,15 +308,20 @@ export function DeploymentDetailsPage() {
     setLoadingDeployment(true);
     logsRef.current = [];
 
-    // Fetch reference data + initial deployment + existing logs in parallel
+    // Fetch reference data + initial deployment + existing logs in parallel.
+    // Flavors are merged in even on partial failure (empty Map → fallback '—').
     Promise.all([
       getMyCourses({ page: 1, page_size: 100 }).catch(() => ({ data: [] as CourseDto[] })),
       getKeycloakGroups().catch(() => ({ data: [] as KeycloakGroup[] })),
       getDeployment(deploymentId, activeProjectId),
       getDeploymentLogs(deploymentId, activeProjectId).catch(() => ({ data: [] as DeploymentLogDto[] })),
-    ]).then(([coursesResp, groupsResp, depResp, logsResp]) => {
+      getFlavors().catch(() => ({ flavors: [] as FlavorDto[] })),
+    ]).then(([coursesResp, groupsResp, depResp, logsResp, flavorsResp]) => {
       coursesCacheRef.current = (coursesResp as any)?.data || [];
       groupsCacheRef.current = (groupsResp as any)?.data || [];
+      flavorsByNameRef.current = new Map(
+        ((flavorsResp as any)?.flavors ?? []).map((f: FlavorDto) => [f.name, f])
+      );
       backendDeploymentRef.current = depResp.data;
 
       const existingLogs: DeploymentLogDto[] = (logsResp as any).data || [];

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -105,7 +105,7 @@ export function DeploymentWizard({
   const [selectedKeycloakGroupId, setSelectedKeycloakGroupId] =
     useState<string>("");
   const [deploymentName, setDeploymentName] = useState<string>("");
-  const [runtime, setRuntime] = useState<string>("3");
+  const [runtime, setRuntime] = useState<string>("4");
   const [deploymentMode, setDeploymentMode] = useState<
     "per_group" | "per_student" | "per_course"
   >("per_group");
@@ -588,6 +588,10 @@ export function DeploymentWizard({
         template_version_id: selectedVersionId,
         course_id: selectedKeycloakGroupId,
         openstack_project_id: activeProjectId,
+        // Wizard runtime select holds a stringified value; backend expects an
+        // integer from ALLOWED_RUNTIME_MONTHS (1/3/4/6/12/24). Cast is safe
+        // because the <Select> options are constrained to those values.
+        runtime_months: parseInt(runtime, 10) as DeploymentCreateRequest["runtime_months"],
         parameters: heatParameters,
         ...(Object.keys(userFilesPayload).length > 0 && { user_files: userFilesPayload }),
         stack_assignments: groupStackAssignments.map((stack, stackIndex) => ({
@@ -1029,6 +1033,7 @@ export function DeploymentWizard({
               <SelectContent>
                 <SelectItem value="1">1 Monat</SelectItem>
                 <SelectItem value="3">3 Monate</SelectItem>
+                <SelectItem value="4">4 Monate (Standard)</SelectItem>
                 <SelectItem value="6">6 Monate</SelectItem>
                 <SelectItem value="12">1 Jahr</SelectItem>
                 <SelectItem value="24">2 Jahre</SelectItem>
@@ -1123,6 +1128,7 @@ export function DeploymentWizard({
       const runtimeLabels: Record<string, string> = {
         "1": "1 Monat",
         "3": "3 Monate",
+        "4": "4 Monate",
         "6": "6 Monate",
         "12": "1 Jahr",
         "24": "2 Jahre",

--- a/src/utils/deployment.ts
+++ b/src/utils/deployment.ts
@@ -1,0 +1,26 @@
+import type { DeploymentDto } from "../api/deployments";
+
+/**
+ * Lifecycle state of a deployment based on its `expires_at` and
+ * `expiry_warning_at` timestamps (set by the backend at create-time).
+ *
+ * - "ok"      : not expiring soon — no banner, no icon
+ * - "warning" : within the warning window (e.g. ≤14 days before expiry)
+ * - "expired" : past expires_at, will be hard-deleted by the next Beat sweep
+ *
+ * Legacy deployments without expiry timestamps stay "ok" forever so the
+ * UI never warns about something the backend isn't actually tracking.
+ */
+export type ExpiryState = "ok" | "warning" | "expired";
+
+export function getExpiryState(
+  deployment: Pick<DeploymentDto, "expires_at" | "expiry_warning_at">
+): ExpiryState {
+  if (!deployment.expires_at || !deployment.expiry_warning_at) return "ok";
+  const now = Date.now();
+  const expiresAtMs = new Date(deployment.expires_at).getTime();
+  const warnAtMs = new Date(deployment.expiry_warning_at).getTime();
+  if (now >= expiresAtMs) return "expired";
+  if (now >= warnAtMs) return "warning";
+  return "ok";
+}


### PR DESCRIPTION
Setzt die vier Backend-Fixes B1, B1.5, B2, B6 (siehe lokale Adaption-Dokus in `Documentation/Frontend/Hardcoded-Fixes/` im Repo-Root) auf der Frontend-Seite um. Jeder Fix in einem eigenen Commit, exakt analog zum Backend-PR.

## Commits

| SHA | Fix | Was geändert wird |
|---|---|---|
| `fed80e1` | **B1** | `getFlavors()` API-Wrapper + AdminMonitoring Pending-Templates-Karten lösen jetzt vCPU/RAM/Disk aus dem Nova-Flavor-Katalog auf statt Hardcode `8 Kerne / 16 GB / 80 GB`. Schließt Frontend-Seite von Issue #73. |
| `56bac64` | **B1.5** | `DeploymentDto.instances[].flavor` durchgereicht, DeploymentDetailsPage summiert echte vCPU/RAM/Disk aus jedem Instance-Flavor statt `length * 2/4/20`. Hardcoded-Multiplier komplett weg. |
| `34f13b1` | **B2** | `TemplateDto` um `owner_name`/`owner_email`/`owner_username` erweitert; AdminMonitoring zeigt „Eingereicht von …" mit Fallback-Kette `name → username → id` und Email als Hover-Tooltip. Schließt Frontend-Seite von Issue #74. |
| `75a6d5e` | **B6** | Deployment-Lifecycle: Wizard-Default `3` → `4` Monate, neuer SelectItem „4 Monate (Standard)", `runtime_months` ins POST-Payload, neue `extendDeployment()`, Expiry-Banner mit „Um 4 Monate verlängern"-Button auf der Detail-Seite, Icon-Indikator in der Dashboard-Liste. |

## Verifikation

- `npx vite build` → grün, keine Type-/Syntax-Fehler.
- ESLint kann lokal aktuell wegen einer ESM-Konfig-Inkompatibilität nicht laufen (`SyntaxError: Cannot use import statement outside a module` in `eslint.config.js`) — eigenständiges Repo-Issue, nicht durch diesen PR ausgelöst. CI sollte das korrekt resolven.
- Der Hard-Reload nach `extendDeployment` ist bewusst pragmatisch — die Detail-Route lädt das Deployment beim Mount sowieso neu, wir müssten sonst eine eigene Refetch-Prop durchziehen.

## Backend-Bezug

PR #143 im `appstore-backend`-Repo (gleicher feature/hardcoded-fixes Branch) liefert die zugehörigen Endpoints und Schema-Änderungen. Beide PRs müssen zusammen merged werden, damit die neuen Felder im Wire-Format sind.

## Was bewusst nicht hier ist

- **B3** (admin lecturer-usage endpoint) — backend-seitig vertagt.
- **B7** (template app versions) — backend-seitig komplett geskippt.
- **F1**/**F2** — die ursprünglichen reinen Frontend-env-Migrationen aus Issue #83. Nicht Teil dieses Tickets.
- Mock-Email-Domains (B8) — backend-seitig noch nicht geprüft.