### PR TITLE
chore: merge staging into main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,10 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches: [ main, staging ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging ]
   workflow_dispatch:
 
 jobs:
@@ -32,7 +31,7 @@ jobs:
     name: Build & Push Staging Image
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/staging'
     permissions:
       contents: read
       packages: write
@@ -62,7 +61,7 @@ jobs:
     name: Build & Push Production Image
     runs-on: ubuntu-latest
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: write
@@ -80,9 +79,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/dozilab/appstore-frontend:latest
-            ghcr.io/dozilab/appstore-frontend:${{ github.ref_name }}
+          tags: ghcr.io/dozilab/appstore-frontend:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -95,7 +92,6 @@ jobs:
     needs: build-and-push-staging
     runs-on: self-hosted
     environment: staging
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -123,7 +119,6 @@ jobs:
     needs: build-and-push-prod
     runs-on: self-hosted
     environment: production
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,14 +11,21 @@ import { AppStorePage } from "./pages/AppStorePage";
 import { DeploymentWizardPage } from "./pages/DeploymentWizardPage";
 import { DeploymentDetailsPage } from "./pages/DeploymentDetailsPage";
 import { OpenStackSetup } from "./pages/OpenStackSetup";
-import { listOpenstackProjects } from "./api/openstackProjects";
+import { listOpenstackProjects, type OpenstackProjectResponse } from "./api/openstackProjects";
+import { OpenstackProjectProvider } from "./contexts/OpenstackProjectContext";
 import logo from "figma:asset/5c87f57a05de8f8018669c9004318908d006dcd5.png";
 
 export default function App() {
   const { keycloak, initialized } = useKeycloak();
   const [initTimedOut, setInitTimedOut] = useState(false);
   const [projectsChecked, setProjectsChecked] = useState(false);
-  const [hasProjects, setHasProjects] = useState(false);
+  // We hold the full project (not just a boolean): the authenticated routes
+  // need it via OpenstackProjectProvider so that any deployment-related
+  // request can attach ?openstack_project_id=<local-DB-id>.
+  const [activeProject, setActiveProject] = useState<OpenstackProjectResponse | null>(null);
+  // Admins don't need a project to use the app, so we don't push them into the
+  // OpenStack-setup route. We resolve this once after auth and keep it sticky.
+  const [isLecturer, setIsLecturer] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -33,17 +40,32 @@ export default function App() {
   useEffect(() => {
     if (!keycloak.authenticated) return;
     const roles: string[] = (keycloak.tokenParsed as Record<string, any>)?.realm_access?.roles ?? [];
-    const isLecturer = roles.includes("lecturer") || roles.includes("teacher");
-    if (!isLecturer) {
-      setHasProjects(true);
+    const lecturer = roles.includes("lecturer") || roles.includes("teacher");
+    setIsLecturer(lecturer);
+    if (!lecturer) {
+      // Admins don't need a project to use the app — keep activeProject null;
+      // the deployment endpoints accept admins without the query param.
+      setActiveProject(null);
       setProjectsChecked(true);
       return;
     }
     listOpenstackProjects()
-      .then((projects) => setHasProjects(projects.length > 0))
-      .catch(() => setHasProjects(false))
+      .then((projects) => setActiveProject(projects[0] ?? null))
+      .catch(() => setActiveProject(null))
       .finally(() => setProjectsChecked(true));
   }, [keycloak.authenticated]);
+
+  // Lecturer must have an OpenStack project before using the rest of the app.
+  // For admins this is always false (we never gate them on project setup).
+  const needsSetup = isLecturer && activeProject === null;
+
+  // Re-fetch the active project after the user finishes OpenStack setup.
+  // (Setup writes credentials and returns a fresh project row.)
+  const refreshActiveProject = () => {
+    listOpenstackProjects()
+      .then((projects) => setActiveProject(projects[0] ?? null))
+      .catch(() => setActiveProject(null));
+  };
 
   console.log("[Keycloak] initialized:", initialized, "authenticated:", keycloak?.authenticated);
 
@@ -89,31 +111,33 @@ export default function App() {
   }
 
   // Lecturer without projects → setup
-  if (!hasProjects) {
+  if (needsSetup) {
     return (
       <Routes>
-        <Route path="/setup" element={<OpenStackSetup onSuccess={() => { setHasProjects(true); }} />} />
+        <Route path="/setup" element={<OpenStackSetup onSuccess={refreshActiveProject} />} />
         <Route path="*" element={<Navigate to="/setup" replace />} />
       </Routes>
     );
   }
 
   return (
-    <div className="flex h-screen bg-slate-50">
-      <Sidebar logo={logo} />
-      <main className="flex-1 overflow-auto">
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/courses" element={<Courses />} />
-          <Route path="/appstore" element={<AppStorePage />} />
-          <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
-          <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
-          <Route path="/config" element={<OpenStackConfig />} />
-          <Route path="/admin" element={<AdminMonitoring />} />
-        </Routes>
-      </main>
-    </div>
+    <OpenstackProjectProvider project={activeProject}>
+      <div className="flex h-screen bg-slate-50">
+        <Sidebar logo={logo} />
+        <main className="flex-1 overflow-auto">
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/courses" element={<Courses />} />
+            <Route path="/appstore" element={<AppStorePage />} />
+            <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
+            <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
+            <Route path="/config" element={<OpenStackConfig />} />
+            <Route path="/admin" element={<AdminMonitoring />} />
+          </Routes>
+        </main>
+      </div>
+    </OpenstackProjectProvider>
   );
 }

--- a/src/api/courses.ts
+++ b/src/api/courses.ts
@@ -62,12 +62,17 @@ export async function getMyCourses(params?: {
   page_size?: number;
   search?: string;
   lecturer_id?: string;
+  // Active OpenStack project (local DB id). The backend requires this for
+  // non-admin callers; without it embedded `course.deployments` would leak
+  // across owners again. Pass `null` to omit (admin context only).
+  openstack_project_id?: string | null;
 }) {
   const sp = new URLSearchParams();
   if (params?.page) sp.set("page", String(params.page));
   if (params?.page_size) sp.set("page_size", String(params.page_size));
   if (params?.search) sp.set("search", params.search);
   if (params?.lecturer_id) sp.set("lecturer_id", params.lecturer_id);
+  if (params?.openstack_project_id) sp.set("openstack_project_id", params.openstack_project_id);
 
   const qs = sp.toString();
   return apiFetch<CoursesResponse>(`/api/v1/courses${qs ? `?${qs}` : ""}`);

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -31,6 +31,10 @@ export type DeploymentDto = {
     openstack_instance_id?: string | null;
     status?: string | null;
     ip_address?: string | null;
+    // Nova flavor name the Heat-Stack was created with. Nullable for legacy
+    // rows from before the per-instance flavor migration; new instances
+    // always have it. Resolve against /openstack/flavors for vCPU/RAM/disk.
+    flavor?: string | null;
     access_urls: Array<{
       id: string;
       access_type: string | null;

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -87,6 +87,10 @@ export type DeploymentCreateRequest = {
   name?: string;
   template_version_id: string;
   course_id: string;
+  // Local DB id of the active OpenstackProject (NOT the Keystone tenant UUID).
+  // Backend pins the deployment to this project so later restart/delete uses
+  // the right credentials even if the user later switches their clouds.yaml.
+  openstack_project_id: string;
   deployment_mode?: string;
   config_json?: string;
   parameters?: Record<string, any>;
@@ -132,11 +136,20 @@ export async function createDeployment(data: DeploymentCreateRequest) {
   });
 }
 
-export async function getDeployment(deploymentId: string) {
-  return apiFetch<DeploymentResponse>(`/api/v1/deployments/${deploymentId}`);
+// All deployment endpoints below take `openstackProjectId` (local DB id of
+// the active OpenstackProject). Lecturers MUST pass it — backend returns 400
+// otherwise. Admins may pass null to skip the filter and see everything.
+function projectQuery(openstackProjectId: string | null): string {
+  return openstackProjectId ? `?openstack_project_id=${encodeURIComponent(openstackProjectId)}` : "";
 }
 
-export async function getDeploymentCredentials(deploymentId: string) {
+export async function getDeployment(deploymentId: string, openstackProjectId: string | null) {
+  return apiFetch<DeploymentResponse>(
+    `/api/v1/deployments/${deploymentId}${projectQuery(openstackProjectId)}`,
+  );
+}
+
+export async function getDeploymentCredentials(deploymentId: string, openstackProjectId: string | null) {
   return apiFetch<{
     success: boolean;
     message?: string;
@@ -144,10 +157,10 @@ export async function getDeploymentCredentials(deploymentId: string) {
     errors: unknown;
     timestamp?: string;
     request_id?: string;
-  }>(`/api/v1/deployments/${deploymentId}/credentials`);
+  }>(`/api/v1/deployments/${deploymentId}/credentials${projectQuery(openstackProjectId)}`);
 }
 
-export async function getDeploymentLogs(deploymentId: string) {
+export async function getDeploymentLogs(deploymentId: string, openstackProjectId: string | null) {
   return apiFetch<{
     success: boolean;
     message: string;
@@ -155,7 +168,7 @@ export async function getDeploymentLogs(deploymentId: string) {
     errors: unknown;
     timestamp: string;
     request_id: string;
-  }>(`/api/v1/deployments/${deploymentId}/logs`);
+  }>(`/api/v1/deployments/${deploymentId}/logs${projectQuery(openstackProjectId)}`);
 }
 
 /**
@@ -166,6 +179,7 @@ export async function getDeploymentLogs(deploymentId: string) {
 export function streamDeploymentLogs(
   deploymentId: string,
   sinceId: string | undefined,
+  openstackProjectId: string | null,
   onLog: (log: DeploymentLogDto) => void,
   onDone: () => void,
 ): () => void {
@@ -175,7 +189,12 @@ export function streamDeploymentLogs(
     try {
       try { await keycloak.updateToken(30); } catch {}
       const token = keycloak.token;
-      const url = `/api/v1/deployments/${deploymentId}/logs/stream${sinceId ? `?since_id=${sinceId}` : ""}`;
+      // Build query string with both since_id (optional) and openstack_project_id (required for lecturers).
+      const params = new URLSearchParams();
+      if (sinceId) params.set("since_id", sinceId);
+      if (openstackProjectId) params.set("openstack_project_id", openstackProjectId);
+      const qs = params.toString();
+      const url = `/api/v1/deployments/${deploymentId}/logs/stream${qs ? `?${qs}` : ""}`;
 
       const res = await fetch(url, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
@@ -210,13 +229,16 @@ export function streamDeploymentLogs(
   return () => controller.abort();
 }
 
-export async function deleteDeployment(deploymentId: string) {
+export async function deleteDeployment(deploymentId: string, openstackProjectId: string | null) {
   // Backend returns 204 No Content — don't call res.json()
   await keycloak.updateToken(30).catch(() => {});
-  const res = await fetch(`/api/v1/deployments/${deploymentId}`, {
-    method: "DELETE",
-    headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
-  });
+  const res = await fetch(
+    `/api/v1/deployments/${deploymentId}${projectQuery(openstackProjectId)}`,
+    {
+      method: "DELETE",
+      headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
+    },
+  );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(text || res.statusText);
@@ -239,8 +261,10 @@ type DeploymentsListEnvelope = {
   request_id: string;
 };
 
-export async function getAllDeployments(): Promise<DeploymentDto[]> {
-  const resp = await apiFetch<DeploymentsListEnvelope | DeploymentDto[]>("/api/v1/deployments");
+export async function getAllDeployments(openstackProjectId: string | null): Promise<DeploymentDto[]> {
+  const resp = await apiFetch<DeploymentsListEnvelope | DeploymentDto[]>(
+    `/api/v1/deployments${projectQuery(openstackProjectId)}`,
+  );
   if (resp && typeof resp === "object" && "data" in resp) {
     return (resp as DeploymentsListEnvelope).data || [];
   }

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -12,6 +12,10 @@ export type DeploymentDto = {
   config_json?: string | null;
   deployment_parameters?: string | null;
   access_types_json: string;
+  // Lifecycle (B6). Both nullable for legacy rows from before the
+  // expires_at migration. UI: see src/utils/deployment.ts.
+  expires_at?: string | null;
+  expiry_warning_at?: string | null;
   created_at: string;
   updated_at: string;
   template_version?: {
@@ -87,6 +91,10 @@ export type DeploymentLogDto = {
   created_at: string;
 };
 
+// Allowed deployment runtimes in months. Must mirror the backend's
+// ALLOWED_RUNTIME_MONTHS — wizard <Select> options must stay in sync.
+export type RuntimeMonths = 1 | 3 | 4 | 6 | 12 | 24;
+
 export type DeploymentCreateRequest = {
   name?: string;
   template_version_id: string;
@@ -99,6 +107,8 @@ export type DeploymentCreateRequest = {
   config_json?: string;
   parameters?: Record<string, any>;
   user_files?: Record<string, string>;  // file_name -> base64-encoded content
+  // Optional — backend defaults to 4 months if omitted.
+  runtime_months?: RuntimeMonths;
   stack_assignments?: Array<{
     groups: Array<{
       group_name: string;
@@ -273,4 +283,41 @@ export async function getAllDeployments(openstackProjectId: string | null): Prom
     return (resp as DeploymentsListEnvelope).data || [];
   }
   return Array.isArray(resp) ? resp : [];
+}
+
+// ── Lifecycle: extend deployment ─────────────────────────────────────────────
+//
+// PATCH /api/v1/deployments/{id}/extend pushes expires_at and expiry_warning_at
+// into the future by `runtime_months`. Anchored on max(now, current_expires_at)
+// so a user clicking "+4 months" while the deployment still has 60 days left
+// stacks the extension; a user clicking after expiry but before the Beat sweep
+// gets a fresh window from now.
+
+export type DeploymentExtendResponse = {
+  deployment_id: string;
+  expires_at: string;
+  expiry_warning_at: string;
+  runtime_months_added: number;
+};
+
+export async function extendDeployment(
+  deploymentId: string,
+  runtimeMonths: RuntimeMonths,
+  openstackProjectId: string | null,
+): Promise<DeploymentExtendResponse> {
+  const resp = await apiFetch<{
+    success: boolean;
+    message: string;
+    data: DeploymentExtendResponse;
+    errors: unknown;
+    timestamp: string;
+    request_id: string;
+  }>(
+    `/api/v1/deployments/${deploymentId}/extend${projectQuery(openstackProjectId)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ runtime_months: runtimeMonths }),
+    },
+  );
+  return resp.data;
 }

--- a/src/api/openstack.ts
+++ b/src/api/openstack.ts
@@ -1,0 +1,53 @@
+import { apiFetch } from "./http";
+
+// Nova flavor as exposed by GET /api/v1/openstack/flavors. Mirrors the
+// backend's FlavorDto 1:1 — keep field names in sync if backend renames.
+export type FlavorDto = {
+  id: string;
+  name: string;
+  vcpus: number;
+  ram_mb: number;
+  disk_gb: number;
+  ephemeral_gb: number;
+  is_public: boolean;
+};
+
+export type FlavorsResponse = {
+  project_id: string;
+  project_name: string;
+  // Only set when an admin queries another user's project; null for lecturers.
+  owner_user_id: string | null;
+  // Pre-sorted by (vcpus ASC, ram_mb ASC) — no need to re-sort client-side.
+  flavors: FlavorDto[];
+  fetched_at: string;
+};
+
+type FlavorsEnvelope = { success?: boolean; data: FlavorsResponse } & Record<string, unknown>;
+
+/**
+ * Fetch the Nova flavors visible to a project.
+ *
+ * - No args → caller's own project (mirrors `getQuotas()` semantics).
+ * - `projectId` → admin queries a specific OpenStack project (local DB id).
+ * - `lecturerId` → admin queries the project owned by a lecturer; backend
+ *   resolves to that user's project. `lecturerId` takes precedence on the
+ *   backend if both are set, but we don't send both at once on purpose.
+ */
+export async function getFlavors(opts?: {
+  projectId?: string;
+  lecturerId?: string;
+}): Promise<FlavorsResponse> {
+  const params = new URLSearchParams();
+  if (opts?.projectId) params.set("project_id", opts.projectId);
+  if (opts?.lecturerId) params.set("lecturer_id", opts.lecturerId);
+
+  const qs = params.toString();
+  const path = `/api/v1/openstack/flavors${qs ? `?${qs}` : ""}`;
+  const resp = await apiFetch<FlavorsResponse | FlavorsEnvelope>(path);
+
+  // Normalize envelope → bare payload.
+  if (resp && typeof resp === "object" && "data" in resp) {
+    return (resp as FlavorsEnvelope).data;
+  }
+  return resp as FlavorsResponse;
+}

--- a/src/api/templates.ts
+++ b/src/api/templates.ts
@@ -42,6 +42,13 @@ export type TemplateDto = {
   name: string;
   description: string | null;
   owner_id: string;
+  // Cached display fields refreshed from the Keycloak token on the owner's
+  // last login. Null for service accounts or users who haven't logged in
+  // since the migration that introduced them — frontend should fall back
+  // through owner_name → owner_username → owner_id.
+  owner_name: string | null;
+  owner_email: string | null;
+  owner_username: string | null;
   repo_url: string;
   icon_url: string | null;
   visibility: string;

--- a/src/contexts/OpenstackProjectContext.tsx
+++ b/src/contexts/OpenstackProjectContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { OpenstackProjectResponse } from "../api/openstackProjects";
+
+/**
+ * Active OpenStack project context.
+ *
+ * The backend's deployment endpoints require the local DB id of the user's
+ * OpenStack project as `?openstack_project_id=...` (and inside the create
+ * body). Today the user has at most one project active at a time — switching
+ * happens by editing it in Settings — so we keep a single value here and
+ * read it from anywhere in the app via {@link useActiveOpenstackProject}.
+ *
+ * The project is loaded once in `App.tsx` (which already calls
+ * `listOpenstackProjects()` for the initial routing decision), and that
+ * value is passed in via the provider's `project` prop.
+ *
+ * IMPORTANT: `activeProjectId` is `OpenstackProjectResponse.id` — the local
+ * DB primary key — NOT `openstack_project_id` (which is the Keystone tenant
+ * UUID). Same naming pitfall as on the Bruno collection side.
+ */
+type OpenstackProjectContextValue = {
+  /** Local DB id of the active OpenstackProject row, or null if the user has none. */
+  activeProjectId: string | null;
+  /** Full project record, or null. Useful when components want the project name. */
+  project: OpenstackProjectResponse | null;
+};
+
+const OpenstackProjectContext = createContext<OpenstackProjectContextValue>({
+  activeProjectId: null,
+  project: null,
+});
+
+export function OpenstackProjectProvider({
+  project,
+  children,
+}: {
+  project: OpenstackProjectResponse | null;
+  children: ReactNode;
+}) {
+  const value = useMemo(
+    () => ({ activeProjectId: project?.id ?? null, project }),
+    [project]
+  );
+  return (
+    <OpenstackProjectContext.Provider value={value}>
+      {children}
+    </OpenstackProjectContext.Provider>
+  );
+}
+
+export function useActiveOpenstackProject(): OpenstackProjectContextValue {
+  return useContext(OpenstackProjectContext);
+}

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -712,8 +712,9 @@ export function AdminMonitoring() {
                         )}
                         <div className="flex items-center gap-4 text-sm text-slate-500">
                           <span>Eingereicht: {new Date(template.created_at).toLocaleString()}</span>
-                          {/* TODO: owner_id is available but not resolved to a display name.
-                              Needs GET /users/{id} or a user lookup endpoint from the backend. */}
+                          <span title={template.owner_email ?? undefined}>
+                            von {template.owner_name ?? template.owner_username ?? template.owner_id}
+                          </span>
                         </div>
                       </div>
                     </div>

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -38,6 +38,7 @@ import {
 } from '../api/deployments';
 import { getQuotas, QuotasResponse } from '../api/quotas';
 import { getTemplates, approveTemplate, rejectTemplate, TemplateDto } from '../api/templates';
+import { getFlavors, FlavorDto } from '../api/openstack';
 import React from 'react';
 
 
@@ -56,6 +57,11 @@ export function AdminMonitoring() {
 
   const [pendingTemplates, setPendingTemplates] = useState<TemplateDto[]>([]);
   const [templateActionError, setTemplateActionError] = useState<string | null>(null);
+
+  // Nova flavor catalog, keyed by flavor name (matches the value of the
+  // template's `flavor` parameter default). Used to render real vCPU/RAM/Disk
+  // numbers instead of hardcoded multipliers. Empty Map = not loaded yet.
+  const [flavorsByName, setFlavorsByName] = useState<Map<string, FlavorDto>>(new Map());
 
   const handleApprove = async (templateId: string) => {
     try {
@@ -109,6 +115,19 @@ export function AdminMonitoring() {
     getTemplates({ status: 'pending' })
       .then((res) => setPendingTemplates(res.data))
       .catch(console.error);
+  }, []);
+
+  // Load flavor catalog once. Pending templates have no per-lecturer context
+  // here, so we fetch from the admin's own project — flavors are typically
+  // OpenStack-cluster-wide, so this works for the cards' display purpose.
+  useEffect(() => {
+    getFlavors()
+      .then((resp) => {
+        setFlavorsByName(new Map(resp.flavors.map((f) => [f.name, f])));
+      })
+      .catch((err) => {
+        console.error('Failed to load flavors', err);
+      });
   }, []);
 
 
@@ -703,10 +722,16 @@ export function AdminMonitoring() {
                     {(() => {
                       const version = template.versions?.[0];
                       const flavorParam = version?.parameters?.find(p => p.name === 'flavor');
-                      // TODO (#73): flavor name (e.g. "gp1.medium") is available but vCPU/RAM/storage
-                      // numbers are not — requires GET /openstack/flavors from backend (Nova API).
-                      // TODO (#74): owner_id is available but not resolved to a display name —
-                      // requires GET /users/{id} or owner_name in TemplateResponse from backend.
+                      const flavorName = flavorParam?.default as string | undefined;
+                      // Resolve flavor name → real vCPU/RAM/Disk from the Nova
+                      // catalog loaded once at mount. If the template's flavor
+                      // default isn't in the catalog (private flavor, typo, or
+                      // catalog not loaded yet) we render '—' rather than
+                      // falling back to a hardcoded number.
+                      const flavor = flavorName ? flavorsByName.get(flavorName) : undefined;
+                      const cpuLabel = flavor ? `${flavor.vcpus} ${flavor.vcpus === 1 ? 'Kern' : 'Kerne'}` : '—';
+                      const ramLabel = flavor ? `${Math.round(flavor.ram_mb / 1024)} GB` : '—';
+                      const diskLabel = flavor ? `${flavor.disk_gb} GB` : '—';
                       return (
                         <div className="grid grid-cols-4 gap-4 mb-4">
                           <div className="p-3 bg-blue-50 rounded-lg">
@@ -714,16 +739,14 @@ export function AdminMonitoring() {
                               <Cpu className="w-4 h-4 text-blue-600" />
                               <span className="text-xs text-blue-600">CPU-Kerne</span>
                             </div>
-                            {/* TODO (#73): replace with vCPU count from flavor endpoint */}
-                            <p className="text-slate-900">8 Kerne</p>
+                            <p className="text-slate-900">{cpuLabel}</p>
                           </div>
                           <div className="p-3 bg-purple-50 rounded-lg">
                             <div className="flex items-center gap-2 mb-1">
                               <Database className="w-4 h-4 text-purple-600" />
                               <span className="text-xs text-purple-600">RAM</span>
                             </div>
-                            {/* TODO (#73): replace with RAM from flavor endpoint */}
-                            <p className="text-slate-900">16 GB</p>
+                            <p className="text-slate-900">{ramLabel}</p>
                           </div>
                           <div className="p-3 bg-teal-50 rounded-lg">
                             <div className="flex items-center gap-2 mb-1">
@@ -731,7 +754,7 @@ export function AdminMonitoring() {
                               <span className="text-xs text-teal-600">Flavor</span>
                             </div>
                             <p className="text-slate-900 text-sm">
-                              {flavorParam?.default ?? '—'}
+                              {flavorName ?? '—'}
                             </p>
                           </div>
                           <div className="p-3 bg-slate-50 rounded-lg">
@@ -739,8 +762,7 @@ export function AdminMonitoring() {
                               <HardDrive className="w-4 h-4 text-slate-600" />
                               <span className="text-xs text-slate-600">Speicher</span>
                             </div>
-                            {/* TODO (#73): replace with disk size from flavor endpoint */}
-                            <p className="text-slate-900">80 GB</p>
+                            <p className="text-slate-900">{diskLabel}</p>
                           </div>
                         </div>
                       );

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -82,7 +82,8 @@ export function AdminMonitoring() {
   };
 
   useEffect(() => {
-    getAllDeployments()
+    // Admin view: pass null → backend doesn't apply the project filter.
+    getAllDeployments(null)
       .then(setDeployments)
       .catch(console.error);
   }, []);
@@ -91,7 +92,8 @@ export function AdminMonitoring() {
     if (!selectedDeployment) return;
 
     setLogsLoading(true);
-    getDeploymentLogs(selectedDeployment.id)
+    // Same rationale: admin reads any deployment's logs regardless of project.
+    getDeploymentLogs(selectedDeployment.id, null)
       .then((resp) => setDeploymentLogs(resp.data ?? []))
       .catch(console.error)
       .finally(() => setLogsLoading(false));

--- a/src/pages/Courses.tsx
+++ b/src/pages/Courses.tsx
@@ -6,6 +6,7 @@ import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { getMyCourses, CourseDto } from "../api/courses";
 import { getKeycloakGroups, KeycloakGroup } from "../api/keycloak";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 type CourseUi = {
   id: string;
@@ -17,6 +18,7 @@ type CourseUi = {
 
 export function Courses() {
   const navigate = useNavigate();
+  const { activeProjectId } = useActiveOpenstackProject();
   const [items, setItems] = useState<CourseDto[]>([]);
   const [keycloakGroups, setKeycloakGroups] = useState<KeycloakGroup[]>([]);
   const [loading, setLoading] = useState(true);
@@ -30,11 +32,16 @@ export function Courses() {
         setLoading(true);
         setError(null);
 
+        // Pass the active OpenStack project to the courses API so the
+        // backend can scope each course's embedded `deployments` collection
+        // to (project = activeProjectId) AND (teacher.id = caller). Without
+        // this param the backend rejects non-admins with 400 — matches the
+        // contract introduced in PR #137 for /api/v1/deployments.
         const [coursesRes, groupsRes] = await Promise.all([
-          getMyCourses({ page: 1, page_size: 10}),
+          getMyCourses({ page: 1, page_size: 10, openstack_project_id: activeProjectId }),
           getKeycloakGroups(),
         ]);
-        
+
         if (!alive) return;
 
         setItems(coursesRes.data || []);
@@ -51,7 +58,7 @@ export function Courses() {
     return () => {
       alive = false;
     };
-  }, []);
+  }, [activeProjectId]);
 
   const courses: CourseUi[] = useMemo(() => {
     return items.map((c) => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Server, Cpu, HardDrive, Activity, AlertCircle, CheckCircle2, Clock } from 'lucide-react';
+import { Server, Cpu, HardDrive, Activity, AlertCircle, CheckCircle2, Clock, AlertTriangle, AlertOctagon } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { Progress } from '../components/ui/progress';
 import { Badge } from '../components/ui/badge';
 import { getQuotas, type QuotasResponse } from '../api/quotas';
 import { getAllDeployments, type DeploymentDto } from '../api/deployments';
+import { getExpiryState } from '../utils/deployment';
 import { useActiveOpenstackProject } from '../contexts/OpenstackProjectContext';
 
 interface DashboardProps {
@@ -19,7 +20,15 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
   const [activeDeployments, setActiveDeployments] = useState<number | null>(null);
   const [deploymentsError, setDeploymentsError] = useState<string | null>(null);
   const [deploymentsLoading, setDeploymentsLoading] = useState<boolean>(false);
-  const [recentDeployments, setRecentDeployments] = useState<Array<{ id: string; name: string; status: string; course?: string; updated: string }>>([]);
+  const [recentDeployments, setRecentDeployments] = useState<Array<{
+    id: string;
+    name: string;
+    status: string;
+    course?: string;
+    updated: string;
+    expires_at: string | null;
+    expiry_warning_at: string | null;
+  }>>([]);
 
   useEffect(() => {
     let mounted = true;
@@ -77,6 +86,11 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
           status: d.status,
           course: d.course?.name || undefined,
           updated: formatRelativeFromISO(d.updated_at || d.created_at),
+          // B6: thread expiry timestamps through so the row can render an
+          // expiry icon. getExpiryState() handles the null cases for legacy
+          // deployments — no need to filter here.
+          expires_at: d.expires_at ?? null,
+          expiry_warning_at: d.expiry_warning_at ?? null,
         }));
         setRecentDeployments(mapped);
       })
@@ -189,22 +203,41 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
               {deploymentsLoading && (
                 <div className="text-sm text-slate-500">Lädt...</div>
               )}
-              {!deploymentsLoading && recentDeployments.map((deployment, idx) => (
-                <div
-                  key={idx}
-                  onClick={() => onSelectDeployment?.(deployment.id)}
-                  className="flex items-center gap-4 p-4 rounded-lg bg-slate-50 border border-slate-100 hover:bg-slate-100 hover:border-slate-200 cursor-pointer transition-all"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-3 mb-1">
-                      <p className="text-slate-900 truncate">{deployment.name}</p>
-                      {getStatusBadge(deployment.status)}
+              {!deploymentsLoading && recentDeployments.map((deployment, idx) => {
+                const expiryState = getExpiryState(deployment);
+                const expiryDateLabel = deployment.expires_at
+                  ? new Date(deployment.expires_at).toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })
+                  : null;
+                return (
+                  <div
+                    key={idx}
+                    onClick={() => onSelectDeployment?.(deployment.id)}
+                    className="flex items-center gap-4 p-4 rounded-lg bg-slate-50 border border-slate-100 hover:bg-slate-100 hover:border-slate-200 cursor-pointer transition-all"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-3 mb-1">
+                        <p className="text-slate-900 truncate">{deployment.name}</p>
+                        {getStatusBadge(deployment.status)}
+                        {/* B6 expiry icon — only when warning/expired. Tooltip via
+                            native title attribute keeps the dependency footprint
+                            tiny on a hot list. */}
+                        {expiryState === 'warning' && (
+                          <span title={`Läuft am ${expiryDateLabel} ab`}>
+                            <AlertTriangle className="w-4 h-4 text-amber-500" />
+                          </span>
+                        )}
+                        {expiryState === 'expired' && (
+                          <span title="Wird in Kürze automatisch gelöscht">
+                            <AlertOctagon className="w-4 h-4 text-red-500" />
+                          </span>
+                        )}
+                      </div>
+                      {deployment.course && <p className="text-sm text-slate-500">{deployment.course}</p>}
+                      <p className="text-xs text-slate-400 mt-1">Aktualisiert {deployment.updated}</p>
                     </div>
-                    {deployment.course && <p className="text-sm text-slate-500">{deployment.course}</p>}
-                    <p className="text-xs text-slate-400 mt-1">Aktualisiert {deployment.updated}</p>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </CardContent>
         </Card>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,12 +5,14 @@ import { Progress } from '../components/ui/progress';
 import { Badge } from '../components/ui/badge';
 import { getQuotas, type QuotasResponse } from '../api/quotas';
 import { getAllDeployments, type DeploymentDto } from '../api/deployments';
+import { useActiveOpenstackProject } from '../contexts/OpenstackProjectContext';
 
 interface DashboardProps {
   onSelectDeployment?: (deploymentId: string) => void;
 }
 
 export function Dashboard({ onSelectDeployment }: DashboardProps) {
+  const { activeProjectId } = useActiveOpenstackProject();
   const [quotas, setQuotas] = useState<QuotasResponse | null>(null);
   const [quotasError, setQuotasError] = useState<string | null>(null);
   const [quotasLoading, setQuotasLoading] = useState<boolean>(false);
@@ -46,7 +48,7 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
     let mounted = true;
     // Show loading only if we don't already have data (e.g., after Fast Refresh)
     setDeploymentsLoading(recentDeployments.length === 0);
-    getAllDeployments()
+    getAllDeployments(activeProjectId)
       .then((items) => {
         if (!mounted) return;
         // Count all deployments using the length of the data
@@ -86,7 +88,7 @@ export function Dashboard({ onSelectDeployment }: DashboardProps) {
         if (mounted) setDeploymentsLoading(false);
       });
     return () => { mounted = false; };
-  }, []);
+  }, [activeProjectId]);
 
   const percent = (used?: number, limit?: number) => {
     if (!used || !limit || limit === 0) return 0;

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -342,6 +342,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
           </div>
           <div className="flex flex-col items-end gap-3">
             {getStatusBadge()}
+            <Calendar className="w-4 h-4 text-slate-400" />
             <p className="text-sm text-slate-500">
               Gestartet: {new Date(deployment.startedAt).toLocaleString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
             </p>
@@ -357,7 +358,6 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                   Verlängern
                 </Button>
                 <div className="flex items-center gap-1.5">
-                  <Calendar className="w-4 h-4 text-slate-400" />
                   <p className="text-sm text-slate-500">
                     Ablaufdatum: {new Date(deployment.expires_at).toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" })}
                   </p>

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -18,6 +18,7 @@ import {
   Flag,
   AlertTriangle,
   AlertOctagon,
+  Calendar,
 } from "lucide-react";
 import { toast } from "sonner@2.0.3";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
@@ -36,11 +37,18 @@ import {
   AlertDialogTrigger,
 } from "../components/ui/alert-dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../components/ui/dropdown-menu";
+import {
   AccessType,
   DeploymentCredentialsResponse,
   DeploymentLogDto,
   getDeploymentCredentials,
   extendDeployment,
+  type RuntimeMonths,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
 import { getExpiryState } from "../utils/deployment";
@@ -99,18 +107,19 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
   // request flies, error shown via toast, success refreshes the page so the
   // new expires_at lands in `deployment` via the parent's data loader.
   const [extendInFlight, setExtendInFlight] = useState(false);
+  const [extendDialogOpen, setExtendDialogOpen] = useState(false);
+  const [selectedExtendMonths, setSelectedExtendMonths] = useState<RuntimeMonths | null>(null);
 
   const expiryState = getExpiryState(deployment);
 
-  const handleExtend = useCallback(async () => {
-    if (extendInFlight) return;
+  const handleConfirmExtend = useCallback(async () => {
+    if (!selectedExtendMonths || extendInFlight) return;
     setExtendInFlight(true);
     try {
-      // Default extension matches the wizard default (4 months). If the UI
-      // ever offers a select for the extend amount, plumb the chosen value
-      // here instead of the hardcoded 4.
-      await extendDeployment(deployment.id, 4, activeProjectId);
-      toast.success("Deployment um 4 Monate verlängert.");
+      await extendDeployment(deployment.id, selectedExtendMonths, activeProjectId);
+      toast.success(`Deployment um ${selectedExtendMonths} Monat${selectedExtendMonths > 1 ? 'e' : ''} verlängert.`);
+      setExtendDialogOpen(false);
+      setSelectedExtendMonths(null);
       // Cheapest correct refresh — the parent route reloads the deployment
       // on mount, so we don't need a callback prop just for this case.
       window.location.reload();
@@ -123,7 +132,26 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
       }
       setExtendInFlight(false);
     }
-  }, [deployment.id, activeProjectId, extendInFlight]);
+  }, [deployment.id, activeProjectId, selectedExtendMonths, extendInFlight]);
+
+  // Calculate available months based on expires_at and today
+  const getAvailableExtendMonths = useCallback(() => {
+    if (!deployment.expires_at) return [1, 3, 4, 6, 12, 24];
+    
+    const today = new Date();
+    const expiresDate = new Date(deployment.expires_at);
+    
+    // Calculate months between today and expires_at
+    const monthsDiff = 
+      (expiresDate.getFullYear() - today.getFullYear()) * 12 + 
+      (expiresDate.getMonth() - today.getMonth());
+    
+    // Max extension is 24 months from today
+    const maxExtension = 24 - Math.max(0, monthsDiff);
+    
+    // Return only the months that don't exceed 24 months total
+    return [1, 3, 4, 6, 12, 24].filter(m => m <= maxExtension);
+  }, [deployment.expires_at]);
 
   const accessTypeLabels: Record<AccessType, string> = {
     ssh: "SSH",
@@ -312,11 +340,80 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
             <h1 className="text-slate-900 mb-2">{deployment.name}</h1>
             <p className="text-slate-600">{deployment.course}</p>
           </div>
-          <div className="flex flex-col items-end gap-2">
+          <div className="flex flex-col items-end gap-3">
             {getStatusBadge()}
             <p className="text-sm text-slate-500">
               Gestartet: {new Date(deployment.startedAt).toLocaleString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric", hour: "2-digit", minute: "2-digit" })}
             </p>
+            {deployment.expires_at && (
+              <div className="flex items-center gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-xs"
+                  disabled={extendInFlight}
+                  onClick={() => setExtendDialogOpen(true)}
+                >
+                  Verlängern
+                </Button>
+                <div className="flex items-center gap-1.5">
+                  <Calendar className="w-4 h-4 text-slate-400" />
+                  <p className="text-sm text-slate-500">
+                    Ablaufdatum: {new Date(deployment.expires_at).toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" })}
+                  </p>
+                </div>
+                
+              </div>
+            )}
+
+            {/* Extend Deployment Dialog */}
+            {deployment.expires_at && (
+              <AlertDialog open={extendDialogOpen} onOpenChange={setExtendDialogOpen}>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Deployment verlängern</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Wählen Sie aus, um wie viele Monate Sie das Deployment verlängern möchten. Maximal 24 Monate ab heute.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <div className="grid grid-cols-2 gap-2 py-4">
+                    {[1, 3, 4, 6, 12, 24].map((months) => {
+                      const availableMonths = getAvailableExtendMonths();
+                      const isAvailable = availableMonths.includes(months);
+                      return (
+                        <Button
+                          key={months}
+                          variant={selectedExtendMonths === months ? "default" : "outline"}
+                          size="sm"
+                          disabled={!isAvailable}
+                          onClick={() => setSelectedExtendMonths(months as RuntimeMonths)}
+                        >
+                          {months} Monat{months > 1 ? 'e' : ''}
+                        </Button>
+                      );
+                    })}
+                  </div>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel disabled={extendInFlight}>
+                      Abbrechen
+                    </AlertDialogCancel>
+                    <AlertDialogAction
+                      disabled={!selectedExtendMonths || extendInFlight}
+                      onClick={handleConfirmExtend}
+                    >
+                      {extendInFlight ? (
+                        <>
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                          Verlängere…
+                        </>
+                      ) : (
+                        "Verlängern"
+                      )}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
           </div>
         </div>
       </div>
@@ -370,7 +467,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                   size="sm"
                   variant={expiryState === "expired" ? "destructive" : "default"}
                   disabled={extendInFlight}
-                  onClick={handleExtend}
+                  onClick={() => setExtendDialogOpen(true)}
                 >
                   {extendInFlight ? (
                     <>
@@ -378,7 +475,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                       Verlängere…
                     </>
                   ) : (
-                    "Um 4 Monate verlängern"
+                    "Verlängern"
                   )}
                 </Button>
               </div>

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -957,7 +957,7 @@ function PhaseRow({ phase, isLive, defaultOpen }: { phase: LogPhase; isLive: boo
 
       {/* Log entries */}
       {open && (
-        <div style={{ borderTop: "1px solid #1e293b", backgroundColor: "#0f172a" }}>
+        <div style={{ borderTop: "1px solid #1e293b", backgroundColor: "#0f172a", maxHeight: "400px", overflowY: "auto" }}>
           {phase.logs.length === 0 ? (
             <p className="px-4 py-3 text-xs italic font-mono" style={{ color: "#475569" }}>
               {phase.status === "pending" ? "// Noch nicht gestartet" : "// Keine Einträge"}

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -16,6 +16,8 @@ import {
   Flame,
   Terminal,
   Flag,
+  AlertTriangle,
+  AlertOctagon,
 } from "lucide-react";
 import { toast } from "sonner@2.0.3";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
@@ -38,8 +40,10 @@ import {
   DeploymentCredentialsResponse,
   DeploymentLogDto,
   getDeploymentCredentials,
+  extendDeployment,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
+import { getExpiryState } from "../utils/deployment";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 interface DeploymentStep {
@@ -67,6 +71,10 @@ interface Deployment {
   phases?: LogPhase[];
   logs?: DeploymentLogDto[];
   error?: string;
+  // Lifecycle (B6) — null for legacy deployments without expiry tracking.
+  // Both passed through from the backend, used by the expiry banner.
+  expires_at?: string | null;
+  expiry_warning_at?: string | null;
   resources: {
     cpu: number;
     ram: number;
@@ -87,6 +95,35 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
   const [credentialsData, setCredentialsData] = useState<DeploymentCredentialsResponse | null>(null);
   const [passwordVisibility, setPasswordVisibility] = useState<Record<string, boolean>>({});
+  // Inline extend-action state (B6). Pessimistic: button disabled while
+  // request flies, error shown via toast, success refreshes the page so the
+  // new expires_at lands in `deployment` via the parent's data loader.
+  const [extendInFlight, setExtendInFlight] = useState(false);
+
+  const expiryState = getExpiryState(deployment);
+
+  const handleExtend = useCallback(async () => {
+    if (extendInFlight) return;
+    setExtendInFlight(true);
+    try {
+      // Default extension matches the wizard default (4 months). If the UI
+      // ever offers a select for the extend amount, plumb the chosen value
+      // here instead of the hardcoded 4.
+      await extendDeployment(deployment.id, 4, activeProjectId);
+      toast.success("Deployment um 4 Monate verlängert.");
+      // Cheapest correct refresh — the parent route reloads the deployment
+      // on mount, so we don't need a callback prop just for this case.
+      window.location.reload();
+    } catch (err) {
+      const error = err as Error & { status?: number };
+      if (error.status === 403) {
+        toast.error("Keine Berechtigung, dieses Deployment zu verlängern.");
+      } else {
+        toast.error("Verlängern fehlgeschlagen. Bitte später erneut versuchen.");
+      }
+      setExtendInFlight(false);
+    }
+  }, [deployment.id, activeProjectId, extendInFlight]);
 
   const accessTypeLabels: Record<AccessType, string> = {
     ssh: "SSH",
@@ -283,6 +320,72 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
           </div>
         </div>
       </div>
+
+      {/* Expiry banner (B6) — only shows when expires_at is set AND we're past
+          the warning threshold or already expired. Legacy deployments without
+          expiry tracking stay invisible here. */}
+      {expiryState !== "ok" && deployment.expires_at && (
+        <Card
+          className={
+            expiryState === "expired"
+              ? "border-red-200 shadow-sm bg-gradient-to-br from-red-50 to-white"
+              : "border-amber-200 shadow-sm bg-gradient-to-br from-amber-50 to-white"
+          }
+        >
+          <CardContent className="p-6">
+            <div className="flex items-start gap-4">
+              <div
+                className={`w-12 h-12 rounded-full flex items-center justify-center flex-shrink-0 ${
+                  expiryState === "expired" ? "bg-red-100" : "bg-amber-100"
+                }`}
+              >
+                {expiryState === "expired" ? (
+                  <AlertOctagon className="w-6 h-6 text-red-600" />
+                ) : (
+                  <AlertTriangle className="w-6 h-6 text-amber-600" />
+                )}
+              </div>
+              <div className="flex-1">
+                <h3
+                  className={
+                    expiryState === "expired" ? "text-red-900 mb-2" : "text-amber-900 mb-2"
+                  }
+                >
+                  {expiryState === "expired"
+                    ? "Dieses Deployment ist abgelaufen und wird in Kürze gelöscht."
+                    : `Läuft am ${new Date(deployment.expires_at).toLocaleDateString("de-DE", { day: "2-digit", month: "2-digit", year: "numeric" })} ab`}
+                </h3>
+                <p
+                  className={
+                    expiryState === "expired"
+                      ? "text-sm text-red-700 mb-3"
+                      : "text-sm text-amber-700 mb-3"
+                  }
+                >
+                  {expiryState === "expired"
+                    ? "Verlängern Sie es jetzt, falls die nächtliche Bereinigung noch nicht gelaufen ist."
+                    : "Verlängern Sie es, bevor der Cleanup-Job es entfernt."}
+                </p>
+                <Button
+                  size="sm"
+                  variant={expiryState === "expired" ? "destructive" : "default"}
+                  disabled={extendInFlight}
+                  onClick={handleExtend}
+                >
+                  {extendInFlight ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Verlängere…
+                    </>
+                  ) : (
+                    "Um 4 Monate verlängern"
+                  )}
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Progress Overview für aktive Deployments */}
       {deployment.status === 'deploying' && (

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -40,6 +40,7 @@ import {
   getDeploymentCredentials,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 interface DeploymentStep {
   id: string;
@@ -80,6 +81,7 @@ interface DeploymentDetailsProps {
 }
 
 export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDetailsProps) {
+  const { activeProjectId } = useActiveOpenstackProject();
   const [credentialsVisible, setCredentialsVisible] = useState(false);
   const [credentialsLoading, setCredentialsLoading] = useState(false);
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
@@ -127,7 +129,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
     setCredentialsError(null);
 
     try {
-      const response = await getDeploymentCredentials(deployment.id);
+      const response = await getDeploymentCredentials(deployment.id, activeProjectId);
       setCredentialsData(response.data);
     } catch (err) {
       const error = err as Error & { status?: number };
@@ -139,7 +141,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
     } finally {
       setCredentialsLoading(false);
     }
-  }, [credentialsLoading, deployment.id]);
+  }, [credentialsLoading, deployment.id, activeProjectId]);
 
   const handleToggleCredentials = () => {
     const nextVisible = !credentialsVisible;

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -296,6 +296,10 @@ export function DeploymentDetailsPage() {
         phases,
         logs,
         error: failedLog?.message || undefined,
+        // Lifecycle (B6) — passed through verbatim; presentational decisions
+        // (banner / icon / 'läuft ab in X Tagen') happen in DeploymentDetails.
+        expires_at: backendDeployment.expires_at ?? null,
+        expiry_warning_at: backendDeployment.expiry_warning_at ?? null,
         resources: { cpu, ram, storage },
       };
     },

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -266,18 +266,29 @@ export function DeploymentDetailsPage() {
       }
 
       let resolvedCourseName = "Unbekannter Kurs";
-      if (backendDeployment.course?.name) {
-        resolvedCourseName = backendDeployment.course.name;
-      } else if (backendDeployment.course_id) {
+      
+      // Try to resolve course name from course_id first
+      if (backendDeployment.course_id) {
         const course = coursesCacheRef.current.find(
           (c) => c.id === backendDeployment.course_id
         );
         if (course) {
-          const group = groupsCacheRef.current.find(
-            (g) => g.id === (course as any).keycloak_course_id
-          );
-          resolvedCourseName = group?.name || course.name || resolvedCourseName;
+          // If course has keycloak_course_id, try to resolve the Keycloak group name
+          if ((course as any).keycloak_course_id) {
+            const group = groupsCacheRef.current.find(
+              (g) => g.id === (course as any).keycloak_course_id
+            );
+            resolvedCourseName = group?.name || course.name || resolvedCourseName;
+          } else {
+            // Fall back to course name
+            resolvedCourseName = course.name || resolvedCourseName;
+          }
         }
+      }
+      
+      // Fall back to course.name from backend if available
+      if (resolvedCourseName === "Unbekannter Kurs" && backendDeployment.course?.name) {
+        resolvedCourseName = backendDeployment.course.name;
       }
 
       return {
@@ -315,7 +326,7 @@ export function DeploymentDetailsPage() {
     // Fetch reference data + initial deployment + existing logs in parallel.
     // Flavors are merged in even on partial failure (empty Map → fallback '—').
     Promise.all([
-      getMyCourses({ page: 1, page_size: 100 }).catch(() => ({ data: [] as CourseDto[] })),
+      getMyCourses({ page: 1, page_size: 100, openstack_project_id: activeProjectId }).catch(() => ({ data: [] as CourseDto[] })),
       getKeycloakGroups().catch(() => ({ data: [] as KeycloakGroup[] })),
       getDeployment(deploymentId, activeProjectId),
       getDeploymentLogs(deploymentId, activeProjectId).catch(() => ({ data: [] as DeploymentLogDto[] })),

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/deployments";
 import { getMyCourses, type CourseDto } from "../api/courses";
 import { getKeycloakGroups, type KeycloakGroup } from "../api/keycloak";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 // ── Phase definitions ─────────────────────────────────────────────────────────
 
@@ -169,6 +170,7 @@ const ACTIVE_STATUSES = new Set(["deploying"]);
 export function DeploymentDetailsPage() {
   const { deploymentId } = useParams<{ deploymentId: string }>();
   const navigate = useNavigate();
+  const { activeProjectId } = useActiveOpenstackProject();
   const [deploymentData, setDeploymentData] = useState<any>(null);
   const [loadingDeployment, setLoadingDeployment] = useState(false);
   const isDeletingRef = useRef(false);
@@ -189,7 +191,7 @@ export function DeploymentDetailsPage() {
     setDeploymentData((prev: any) => prev ? { ...prev, status: "deleting" } : prev);
 
     try {
-      await deleteDeployment(id);
+      await deleteDeployment(id, activeProjectId);
     } catch (err) {
       console.error("Failed to initiate delete", err);
     }
@@ -199,7 +201,7 @@ export function DeploymentDetailsPage() {
     const poll = async () => {
       attempts++;
       try {
-        const resp = await getDeployment(id);
+        const resp = await getDeployment(id, activeProjectId);
         const s = resp.data.status.toUpperCase();
         if (s === "DELETED" || s === "DELETE_COMPLETE") {
           navigate("/dashboard");
@@ -297,8 +299,8 @@ export function DeploymentDetailsPage() {
     Promise.all([
       getMyCourses({ page: 1, page_size: 100 }).catch(() => ({ data: [] as CourseDto[] })),
       getKeycloakGroups().catch(() => ({ data: [] as KeycloakGroup[] })),
-      getDeployment(deploymentId),
-      getDeploymentLogs(deploymentId).catch(() => ({ data: [] as DeploymentLogDto[] })),
+      getDeployment(deploymentId, activeProjectId),
+      getDeploymentLogs(deploymentId, activeProjectId).catch(() => ({ data: [] as DeploymentLogDto[] })),
     ]).then(([coursesResp, groupsResp, depResp, logsResp]) => {
       coursesCacheRef.current = (coursesResp as any)?.data || [];
       groupsCacheRef.current = (groupsResp as any)?.data || [];
@@ -315,6 +317,7 @@ export function DeploymentDetailsPage() {
       const stopStream = streamDeploymentLogs(
         deploymentId,
         lastLogId,
+        activeProjectId,
         (log) => {
           if (isDeletingRef.current) return;
           logsRef.current = [...logsRef.current, log];
@@ -324,7 +327,7 @@ export function DeploymentDetailsPage() {
         },
         () => {
           if (isDeletingRef.current) return;
-          getDeployment(deploymentId).then((depResp) => {
+          getDeployment(deploymentId, activeProjectId).then((depResp) => {
             backendDeploymentRef.current = depResp.data;
             setDeploymentData(buildDeploymentData(depResp.data, logsRef.current));
           }).catch(() => {});
@@ -334,7 +337,7 @@ export function DeploymentDetailsPage() {
     }).catch(() => setLoadingDeployment(false));
 
     return () => { stopStreamRef.current?.(); stopStreamRef.current = null; };
-  }, [deploymentId, buildDeploymentData]);
+  }, [deploymentId, activeProjectId, buildDeploymentData]);
 
   if (!deploymentId) return <Navigate to="/dashboard" replace />;
   if (loadingDeployment) return <div className="p-6">Lade Deployment...</div>;

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/deployments";
 import { getMyCourses, type CourseDto } from "../api/courses";
 import { getKeycloakGroups, type KeycloakGroup } from "../api/keycloak";
+import { getFlavors, type FlavorDto } from "../api/openstack";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 // ── Phase definitions ─────────────────────────────────────────────────────────
@@ -178,6 +179,11 @@ export function DeploymentDetailsPage() {
   // Stable reference data fetched once
   const coursesCacheRef = useRef<CourseDto[]>([]);
   const groupsCacheRef = useRef<KeycloakGroup[]>([]);
+  // Nova flavor catalog keyed by name. Loaded once at mount; used to turn
+  // each instance's `flavor` string into real vCPU/RAM/disk for the resource
+  // block. Empty Map until the request resolves — instances with unknown
+  // flavors fall back to '—' rather than a hardcoded multiplier.
+  const flavorsByNameRef = useRef<Map<string, FlavorDto>>(new Map());
   // Accumulate logs from SSE
   const logsRef = useRef<DeploymentLogDto[]>([]);
   const backendDeploymentRef = useRef<any>(null);
@@ -246,10 +252,17 @@ export function DeploymentDetailsPage() {
       }));
 
       let cpu = 0, ram = 0, storage = 0;
-      if (backendDeployment.instances?.length > 0) {
-        cpu = backendDeployment.instances.length * 2;
-        ram = backendDeployment.instances.length * 4;
-        storage = backendDeployment.instances.length * 20;
+      // Sum vCPU/RAM/disk from each instance's actual Nova flavor. Instances
+      // whose flavor isn't in the catalog (legacy rows with `flavor === null`,
+      // private flavors not visible to the caller) are silently skipped — we
+      // do NOT fall back to length*N multipliers, because that masks the gap.
+      const flavorsByName = flavorsByNameRef.current;
+      for (const inst of backendDeployment.instances ?? []) {
+        const f = inst.flavor ? flavorsByName.get(inst.flavor) : undefined;
+        if (!f) continue;
+        cpu += f.vcpus;
+        ram += Math.round(f.ram_mb / 1024);
+        storage += f.disk_gb;
       }
 
       let resolvedCourseName = "Unbekannter Kurs";
@@ -295,15 +308,20 @@ export function DeploymentDetailsPage() {
     setLoadingDeployment(true);
     logsRef.current = [];
 
-    // Fetch reference data + initial deployment + existing logs in parallel
+    // Fetch reference data + initial deployment + existing logs in parallel.
+    // Flavors are merged in even on partial failure (empty Map → fallback '—').
     Promise.all([
       getMyCourses({ page: 1, page_size: 100 }).catch(() => ({ data: [] as CourseDto[] })),
       getKeycloakGroups().catch(() => ({ data: [] as KeycloakGroup[] })),
       getDeployment(deploymentId, activeProjectId),
       getDeploymentLogs(deploymentId, activeProjectId).catch(() => ({ data: [] as DeploymentLogDto[] })),
-    ]).then(([coursesResp, groupsResp, depResp, logsResp]) => {
+      getFlavors().catch(() => ({ flavors: [] as FlavorDto[] })),
+    ]).then(([coursesResp, groupsResp, depResp, logsResp, flavorsResp]) => {
       coursesCacheRef.current = (coursesResp as any)?.data || [];
       groupsCacheRef.current = (groupsResp as any)?.data || [];
+      flavorsByNameRef.current = new Map(
+        ((flavorsResp as any)?.flavors ?? []).map((f: FlavorDto) => [f.name, f])
+      );
       backendDeploymentRef.current = depResp.data;
 
       const existingLogs: DeploymentLogDto[] = (logsResp as any).data || [];

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -105,7 +105,7 @@ export function DeploymentWizard({
   const [selectedKeycloakGroupId, setSelectedKeycloakGroupId] =
     useState<string>("");
   const [deploymentName, setDeploymentName] = useState<string>("");
-  const [runtime, setRuntime] = useState<string>("3");
+  const [runtime, setRuntime] = useState<string>("4");
   const [deploymentMode, setDeploymentMode] = useState<
     "per_group" | "per_student" | "per_course"
   >("per_group");
@@ -588,6 +588,10 @@ export function DeploymentWizard({
         template_version_id: selectedVersionId,
         course_id: selectedKeycloakGroupId,
         openstack_project_id: activeProjectId,
+        // Wizard runtime select holds a stringified value; backend expects an
+        // integer from ALLOWED_RUNTIME_MONTHS (1/3/4/6/12/24). Cast is safe
+        // because the <Select> options are constrained to those values.
+        runtime_months: parseInt(runtime, 10) as DeploymentCreateRequest["runtime_months"],
         parameters: heatParameters,
         ...(Object.keys(userFilesPayload).length > 0 && { user_files: userFilesPayload }),
         stack_assignments: groupStackAssignments.map((stack, stackIndex) => ({
@@ -1029,6 +1033,7 @@ export function DeploymentWizard({
               <SelectContent>
                 <SelectItem value="1">1 Monat</SelectItem>
                 <SelectItem value="3">3 Monate</SelectItem>
+                <SelectItem value="4">4 Monate (Standard)</SelectItem>
                 <SelectItem value="6">6 Monate</SelectItem>
                 <SelectItem value="12">1 Jahr</SelectItem>
                 <SelectItem value="24">2 Jahre</SelectItem>
@@ -1123,6 +1128,7 @@ export function DeploymentWizard({
       const runtimeLabels: Record<string, string> = {
         "1": "1 Monat",
         "3": "3 Monate",
+        "4": "4 Monate",
         "6": "6 Monate",
         "12": "1 Jahr",
         "24": "2 Jahre",

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -51,6 +51,7 @@ import {
 } from "../api/deployments";
 import { GroupManager, type StudentGroup } from "../components/GroupManager";
 import keycloak from "../auth/keycloak";
+import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 
 // GroupStackAssignment type (no UI component needed, auto-assignment in background)
 export interface GroupStackAssignment {
@@ -70,6 +71,7 @@ export function DeploymentWizard({
   onCancel,
   onComplete,
 }: DeploymentWizardProps) {
+  const { activeProjectId } = useActiveOpenstackProject();
   const [currentStep, setCurrentStep] = useState(0);
   const [isDeploying, setIsDeploying] = useState(false);
 
@@ -558,6 +560,16 @@ export function DeploymentWizard({
         return;
       }
 
+      // Backend pins the deployment to the user's active OpenStack project so
+      // later restart/delete uses the right credentials even if the user
+      // switches their clouds.yaml. Teachers must have one — the App-level
+      // setup gate normally prevents this branch, but be defensive.
+      if (!activeProjectId) {
+        setError("Kein aktives OpenStack-Projekt. Bitte richten Sie zuerst ein OpenStack-Projekt ein.");
+        setIsDeploying(false);
+        return;
+      }
+
       // Convert uploaded files to base64
       const userFilesPayload: Record<string, string> = {};
       for (const [name, file] of Object.entries(uploadedFiles)) {
@@ -575,6 +587,7 @@ export function DeploymentWizard({
         name: deploymentName.trim(),
         template_version_id: selectedVersionId,
         course_id: selectedKeycloakGroupId,
+        openstack_project_id: activeProjectId,
         parameters: heatParameters,
         ...(Object.keys(userFilesPayload).length > 0 && { user_files: userFilesPayload }),
         stack_assignments: groupStackAssignments.map((stack, stackIndex) => ({

--- a/src/utils/deployment.ts
+++ b/src/utils/deployment.ts
@@ -1,0 +1,26 @@
+import type { DeploymentDto } from "../api/deployments";
+
+/**
+ * Lifecycle state of a deployment based on its `expires_at` and
+ * `expiry_warning_at` timestamps (set by the backend at create-time).
+ *
+ * - "ok"      : not expiring soon — no banner, no icon
+ * - "warning" : within the warning window (e.g. ≤14 days before expiry)
+ * - "expired" : past expires_at, will be hard-deleted by the next Beat sweep
+ *
+ * Legacy deployments without expiry timestamps stay "ok" forever so the
+ * UI never warns about something the backend isn't actually tracking.
+ */
+export type ExpiryState = "ok" | "warning" | "expired";
+
+export function getExpiryState(
+  deployment: Pick<DeploymentDto, "expires_at" | "expiry_warning_at">
+): ExpiryState {
+  if (!deployment.expires_at || !deployment.expiry_warning_at) return "ok";
+  const now = Date.now();
+  const expiresAtMs = new Date(deployment.expires_at).getTime();
+  const warnAtMs = new Date(deployment.expiry_warning_at).getTime();
+  if (now >= expiresAtMs) return "expired";
+  if (now >= warnAtMs) return "warning";
+  return "ok";
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:8000",
+        target: "https://141.72.13.2",
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## Summary

This PR promotes the current `staging` branch into `main`, bringing all recently tested and validated frontend changes to production.

### Changes included

- **Deployment expiry UI**: Expiry banner on active deployments with an extend action; displays expiry date and allows selecting extension duration (up to 24 months)
- **Deployment overview UX**: Scrollable logs, improved deployment overview layout, icon adjustments
- **Unknown course handling**: Fixed 400 error when course is unknown
- **Resource display**: Aggregate real CPU/RAM/disk from per-instance flavor data
- **Admin enhancements**: Show template owner display name with username/id fallback; resolve flavor name to vCPU/RAM/disk in pending templates
- **Course-deployment filter**: Pass active OpenStack project to course listing
- **CI/CD**: Replace tag-based deploys with branch-based deploys (`staging`/`main`)

### Test plan

- [ ] All changes have been running on staging without issues
- [ ] Expiry banner and extension flow tested end-to-end
- [ ] Deployment overview rendering verified across different states
- [ ] Course filter confirmed working with active OpenStack projects