### PR TITLE
feat(deployment-details): credential tabs, SSE log streaming, auto-scroll

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -60,18 +60,23 @@ export type AccessType =
   | "vnc"
   | "database";
 
-export type OwnerKind = "teacher" | "group";
-
 export type CredentialAccess = {
   access_type: AccessType;
   username: string | null;
   password: string | null;
   connection_url: string | null;
   port: number | null;
-  /** "teacher" or "group". Drives the Dozent/Gruppen tab split. */
-  owner_kind: OwnerKind | null;
-  /** Display label like "Dozent" or "Gruppe 1". Null on legacy rows. */
-  owner_label: string | null;
+  /**
+   * course_groups.id this credential belongs to. NULL = lecturer/admin
+   * credential (not tied to a student group). Drives the Dozent/Gruppen
+   * split in the UI.
+   */
+  group_id: string | null;
+  /**
+   * Display name of the course group (joined from course_groups.name).
+   * NULL when group_id is NULL.
+   */
+  group_name: string | null;
 };
 
 export type CredentialInstance = {

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -60,12 +60,18 @@ export type AccessType =
   | "vnc"
   | "database";
 
+export type OwnerKind = "teacher" | "group";
+
 export type CredentialAccess = {
   access_type: AccessType;
   username: string | null;
   password: string | null;
   connection_url: string | null;
   port: number | null;
+  /** "teacher" or "group". Drives the Dozent/Gruppen tab split. */
+  owner_kind: OwnerKind | null;
+  /** Display label like "Dozent" or "Gruppe 1". Null on legacy rows. */
+  owner_label: string | null;
 };
 
 export type CredentialInstance = {

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import React from "react";
 import {
   CheckCircle2,
@@ -25,6 +25,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../co
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Progress } from "../components/ui/progress";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "../components/ui/tabs";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "../components/ui/accordion";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -854,87 +856,313 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
               </div>
             )}
 
-            {!credentialsLoading && !credentialsError && credentialsData && (
-              <div className="space-y-6">
-                {credentialsData.instances.map((instance) => (
-                  <Card key={instance.instance_id} className="border-slate-200">
-                    <CardHeader>
-                      <CardTitle className="text-base">{instance.vm_name || "VM"}</CardTitle>
-                      <CardDescription>Stack ID: {instance.openstack_stack_id || "-"}</CardDescription>
-                    </CardHeader>
-                    <CardContent className="space-y-4">
-                      {instance.accesses.map((access, index) => {
-                        const accessKey = `${instance.instance_id}-${access.access_type}-${index}`;
-                        const isVisible = passwordVisibility[accessKey] === true;
-                        return (
-                          <div key={accessKey} className="rounded-lg border border-slate-200 p-4 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <h4 className="text-sm font-medium text-slate-900">
-                                {accessTypeLabels[access.access_type] || access.access_type}
-                              </h4>
-                              <Badge variant="outline">{access.access_type}</Badge>
-                            </div>
-                            <div className="grid gap-3">
-                              <div className="flex flex-wrap items-center justify-between gap-2">
-                                <span className="text-xs text-slate-500">Username</span>
-                                <div className="flex items-center gap-2">
-                                  <span className="text-sm text-slate-900">{access.username ?? "-"}</span>
-                                  <Button variant="outline" size="sm" onClick={() => handleCopy(access.username, "Username")} disabled={!access.username}>
-                                    <Copy className="w-4 h-4" />
-                                  </Button>
-                                </div>
-                              </div>
-                              <div className="flex flex-wrap items-center justify-between gap-2">
-                                <span className="text-xs text-slate-500">Password</span>
-                                <div className="flex items-center gap-2">
-                                  <span className="text-sm text-slate-900">
-                                    {isVisible ? access.password ?? "-" : getMaskedPassword(access.password)}
-                                  </span>
-                                  <Button variant="outline" size="sm" onClick={() => togglePasswordVisibility(accessKey)} disabled={!access.password}>
-                                    {isVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                                  </Button>
-                                  <Button variant="outline" size="sm" onClick={() => handleCopy(access.password, "Password")} disabled={!access.password}>
-                                    <Copy className="w-4 h-4" />
-                                  </Button>
-                                </div>
-                              </div>
-                              <div className="flex flex-wrap items-center justify-between gap-2">
-                                <span className="text-xs text-slate-500">
-                                  {access.access_type === "ssh" ? "SSH-Befehl" : access.access_type === "web_url" ? "URL" : "Connection URL"}
-                                </span>
-                                <div className="flex items-center gap-2">
-                                  {access.connection_url ? (
-                                    access.access_type === "web_url" ? (
-                                      <a href={access.connection_url} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 hover:underline break-all">
-                                        {access.connection_url}
-                                      </a>
-                                    ) : (
-                                      <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono">{access.connection_url}</code>
-                                    )
-                                  ) : (
-                                    <span className="text-sm text-slate-400">-</span>
-                                  )}
-                                  <Button variant="outline" size="sm" onClick={() => handleCopy(access.connection_url, access.access_type === "ssh" ? "SSH-Befehl" : "URL")} disabled={!access.connection_url}>
-                                    <Copy className="w-4 h-4" />
-                                  </Button>
-                                </div>
-                              </div>
-                              <div className="flex flex-wrap items-center justify-between gap-2">
-                                <span className="text-xs text-slate-500">Port</span>
-                                <span className="text-sm text-slate-900">{access.port ?? "-"}</span>
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
+              {!credentialsLoading && credentialsError && (
+                <div className="space-y-3">
+                  <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+                    <span className="text-sm text-red-700">{credentialsError}</span>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={loadCredentials}>
+                    Erneut versuchen
+                  </Button>
+                </div>
+              )}
+
+              {!credentialsLoading && !credentialsError && credentialsData && (
+                <div className="space-y-6">
+                  {credentialsData.instances.map((instance) => (
+                    <CredentialInstanceCard
+                      key={instance.instance_id}
+                      instance={instance}
+                      passwordVisibility={passwordVisibility}
+                      togglePasswordVisibility={togglePasswordVisibility}
+                      handleCopy={handleCopy}
+                      getMaskedPassword={getMaskedPassword}
+                    />
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          )}
+        </Card>
+    </div>
+  );
+}
+
+// ── Credentials helpers ───────────────────────────────────────────────────────
+
+type AccessLike = {
+  access_type: string;
+  username: string | null;
+  password: string | null;
+  connection_url: string | null;
+  port: number | null;
+  owner_kind: "teacher" | "group" | null;
+  owner_label: string | null;
+};
+
+type CredentialInstanceLike = {
+  instance_id: string;
+  vm_name: string | null;
+  openstack_stack_id: string | null;
+  accesses: AccessLike[];
+};
+
+function CredentialInstanceCard({
+  instance,
+  passwordVisibility,
+  togglePasswordVisibility,
+  handleCopy,
+  getMaskedPassword,
+}: {
+  instance: CredentialInstanceLike;
+  passwordVisibility: Record<string, boolean>;
+  togglePasswordVisibility: (key: string) => void;
+  handleCopy: (value: string | null | undefined, label: string) => void;
+  getMaskedPassword: (pw: string | null | undefined) => string;
+}) {
+  // Split accesses by owner. Legacy rows (owner_kind == null) fall into
+  // a third "Sonstige" bucket so they're still visible but don't pollute
+  // the teacher tab.
+  const teacherAccesses = instance.accesses.filter((a) => a.owner_kind === "teacher");
+  const groupAccesses = instance.accesses.filter((a) => a.owner_kind === "group");
+  const otherAccesses = instance.accesses.filter((a) => a.owner_kind == null);
+
+  // Group the group-accesses by their owner_label so each group becomes
+  // one collapsible accordion row.
+  const groupsByLabel = new Map<string, AccessLike[]>();
+  for (const a of groupAccesses) {
+    const key = a.owner_label || a.username || "Gruppe";
+    const list = groupsByLabel.get(key) ?? [];
+    list.push(a);
+    groupsByLabel.set(key, list);
+  }
+
+  // Default tab: prefer "dozent" if there are teacher entries, else "gruppen".
+  const defaultTab =
+    teacherAccesses.length > 0 ? "dozent" : groupsByLabel.size > 0 ? "gruppen" : "sonstige";
+
+  return (
+    <Card className="border-slate-200">
+      <CardHeader>
+        <CardTitle className="text-base">{instance.vm_name || "VM"}</CardTitle>
+        <CardDescription>Stack ID: {instance.openstack_stack_id || "-"}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue={defaultTab} className="w-full">
+          <TabsList className="mb-4">
+            {teacherAccesses.length > 0 && (
+              <TabsTrigger value="dozent">
+                Dozent
+                <Badge variant="secondary" className="ml-2">{teacherAccesses.length}</Badge>
+              </TabsTrigger>
             )}
-          </CardContent>
-        )}
-      </Card>
+            {groupsByLabel.size > 0 && (
+              <TabsTrigger value="gruppen">
+                Gruppen
+                <Badge variant="secondary" className="ml-2">{groupsByLabel.size}</Badge>
+              </TabsTrigger>
+            )}
+            {otherAccesses.length > 0 && (
+              <TabsTrigger value="sonstige">
+                Sonstige
+                <Badge variant="secondary" className="ml-2">{otherAccesses.length}</Badge>
+              </TabsTrigger>
+            )}
+          </TabsList>
+
+          {teacherAccesses.length > 0 && (
+            <TabsContent value="dozent" className="space-y-3">
+              {teacherAccesses.map((access, idx) => (
+                <AccessRow
+                  key={`teacher-${idx}`}
+                  accessKey={`${instance.instance_id}-teacher-${access.access_type}-${idx}`}
+                  access={access}
+                  passwordVisibility={passwordVisibility}
+                  togglePasswordVisibility={togglePasswordVisibility}
+                  handleCopy={handleCopy}
+                  getMaskedPassword={getMaskedPassword}
+                />
+              ))}
+            </TabsContent>
+          )}
+
+          {groupsByLabel.size > 0 && (
+            <TabsContent value="gruppen">
+              <Accordion
+                type="multiple"
+                defaultValue={Array.from(groupsByLabel.keys()).slice(0, 1)}
+                className="space-y-2"
+              >
+                {Array.from(groupsByLabel.entries()).map(([label, accesses]) => (
+                  <AccordionItem
+                    key={label}
+                    value={label}
+                    className="border border-slate-200 rounded-lg px-3"
+                  >
+                    <AccordionTrigger className="hover:no-underline">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-slate-900">{label}</span>
+                        <Badge variant="outline" className="text-xs">
+                          {accesses.length} {accesses.length === 1 ? "Zugang" : "Zugänge"}
+                        </Badge>
+                      </div>
+                    </AccordionTrigger>
+                    <AccordionContent className="space-y-3 pt-2">
+                      {accesses.map((access, idx) => (
+                        <AccessRow
+                          key={`${label}-${idx}`}
+                          accessKey={`${instance.instance_id}-${label}-${access.access_type}-${idx}`}
+                          access={access}
+                          passwordVisibility={passwordVisibility}
+                          togglePasswordVisibility={togglePasswordVisibility}
+                          handleCopy={handleCopy}
+                          getMaskedPassword={getMaskedPassword}
+                        />
+                      ))}
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </TabsContent>
+          )}
+
+          {otherAccesses.length > 0 && (
+            <TabsContent value="sonstige" className="space-y-3">
+              {otherAccesses.map((access, idx) => (
+                <AccessRow
+                  key={`other-${idx}`}
+                  accessKey={`${instance.instance_id}-other-${access.access_type}-${idx}`}
+                  access={access}
+                  passwordVisibility={passwordVisibility}
+                  togglePasswordVisibility={togglePasswordVisibility}
+                  handleCopy={handleCopy}
+                  getMaskedPassword={getMaskedPassword}
+                />
+              ))}
+            </TabsContent>
+          )}
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AccessRow({
+  accessKey,
+  access,
+  passwordVisibility,
+  togglePasswordVisibility,
+  handleCopy,
+  getMaskedPassword,
+}: {
+  accessKey: string;
+  access: AccessLike;
+  passwordVisibility: Record<string, boolean>;
+  togglePasswordVisibility: (key: string) => void;
+  handleCopy: (value: string | null | undefined, label: string) => void;
+  getMaskedPassword: (pw: string | null | undefined) => string;
+}) {
+  const accessTypeLabels: Record<string, string> = {
+    ssh: "SSH",
+    web_url: "Web URL",
+    guacamole: "Guacamole",
+    rdp: "RDP",
+    vnc: "VNC",
+    database: "Database",
+  };
+
+  const urlLabel =
+    access.access_type === "ssh" ? "SSH-Befehl" : access.access_type === "web_url" ? "URL" : "Connection URL";
+
+  const isVisible = passwordVisibility[accessKey] === true;
+
+  return (
+    <div className="rounded-lg border border-slate-200 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium text-slate-900">
+          {accessTypeLabels[access.access_type] || access.access_type}
+        </h4>
+        <Badge variant="outline">{access.access_type}</Badge>
+      </div>
+
+      <div className="grid gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">Username</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-slate-900">{access.username ?? "-"}</span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(access.username, "Username")}
+              disabled={!access.username}
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">Password</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-slate-900">
+              {isVisible ? access.password ?? "-" : getMaskedPassword(access.password)}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => togglePasswordVisibility(accessKey)}
+              disabled={!access.password}
+            >
+              {isVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(access.password, "Password")}
+              disabled={!access.password}
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">{urlLabel}</span>
+          <div className="flex items-center gap-2">
+            {access.connection_url ? (
+              access.access_type === "web_url" ? (
+                <a
+                  href={access.connection_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-blue-600 hover:underline break-all"
+                >
+                  {access.connection_url}
+                </a>
+              ) : (
+                <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono">
+                  {access.connection_url}
+                </code>
+              )
+            ) : (
+              <span className="text-sm text-slate-400">-</span>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(access.connection_url, urlLabel)}
+              disabled={!access.connection_url}
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">Port</span>
+          <span className="text-sm text-slate-900">{access.port ?? "-"}</span>
+        </div>
+      </div>
     </div>
   );
 }
@@ -999,6 +1227,32 @@ function LogRow({ log }: { log: DeploymentLogDto }) {
 
 function PhaseRow({ phase, isLive, defaultOpen }: { phase: LogPhase; isLive: boolean; defaultOpen: boolean }) {
   const [open, setOpen] = useState(defaultOpen);
+
+  // Auto-scroll: keep the log container pinned to the bottom as new entries
+  // stream in, but only while the user hasn't manually scrolled up. If they
+  // scroll away from the bottom we pause auto-scroll until they return — this
+  // is the standard terminal-tail behavior (tail -f, browser DevTools console).
+  const logContainerRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  const handleScroll = useCallback(() => {
+    const el = logContainerRef.current;
+    if (!el) return;
+    // Consider "at the bottom" within a 32px slack so the last partial line
+    // doesn't accidentally disengage auto-scroll.
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 32;
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const el = logContainerRef.current;
+    if (!el) return;
+    if (stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [phase.logs.length, phase.status, open]);
+
   const phaseIcon = PHASE_ICONS[phase.id] ?? <CheckCircle2 className="w-4 h-4" />;
   const dotClass =
     phase.status === "completed" ? "bg-green-500" :
@@ -1022,7 +1276,11 @@ function PhaseRow({ phase, isLive, defaultOpen }: { phase: LogPhase; isLive: boo
         {open ? <ChevronDown className="w-4 h-4 text-slate-400 flex-shrink-0" /> : <ChevronRight className="w-4 h-4 text-slate-400 flex-shrink-0" />}
       </button>
       {open && (
-        <div style={{ borderTop: "1px solid #1e293b", backgroundColor: "#0f172a", maxHeight: "400px", overflowY: "auto" }}>
+        <div
+          ref={logContainerRef}
+          onScroll={handleScroll}
+          style={{ borderTop: "1px solid #1e293b", backgroundColor: "#0f172a", maxHeight: "400px", overflowY: "auto" }}
+        >
           {phase.logs.length === 0 ? (
             <p className="px-4 py-3 text-xs italic font-mono" style={{ color: "#475569" }}>
               {phase.status === "pending" ? "// Noch nicht gestartet" : "// Keine Einträge"}

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -896,8 +896,14 @@ type AccessLike = {
   password: string | null;
   connection_url: string | null;
   port: number | null;
-  owner_kind: "teacher" | "group" | null;
-  owner_label: string | null;
+  /**
+   * course_groups.id this credential belongs to. NULL = lecturer/admin row
+   * (shown in Dozent tab). Non-NULL = student group row (Gruppen tab,
+   * accordion section per group_name).
+   */
+  group_id: string | null;
+  /** Human-readable group name from the JOIN on course_groups.name. */
+  group_name: string | null;
 };
 
 type CredentialInstanceLike = {
@@ -920,26 +926,27 @@ function CredentialInstanceCard({
   handleCopy: (value: string | null | undefined, label: string) => void;
   getMaskedPassword: (pw: string | null | undefined) => string;
 }) {
-  // Split accesses by owner. Legacy rows (owner_kind == null) fall into
-  // a third "Sonstige" bucket so they're still visible but don't pollute
-  // the teacher tab.
-  const teacherAccesses = instance.accesses.filter((a) => a.owner_kind === "teacher");
-  const groupAccesses = instance.accesses.filter((a) => a.owner_kind === "group");
-  const otherAccesses = instance.accesses.filter((a) => a.owner_kind == null);
+  // Split accesses by ownership: group_id IS NULL → lecturer/admin row →
+  // "Dozent" tab; group_id is a course_groups.id → student row → "Gruppen"
+  // tab, one accordion section per group_name.
+  const teacherAccesses = instance.accesses.filter((a) => a.group_id == null);
+  const groupAccesses = instance.accesses.filter((a) => a.group_id != null);
 
-  // Group the group-accesses by their owner_label so each group becomes
-  // one collapsible accordion row.
+  // Group the group-accesses by their group identity so each group becomes
+  // one collapsible accordion row. Prefer group_name for display; fall back
+  // to the bare group_id if the JOIN didn't yield a name (shouldn't happen
+  // in practice but keeps the UI safe).
   const groupsByLabel = new Map<string, AccessLike[]>();
   for (const a of groupAccesses) {
-    const key = a.owner_label || a.username || "Gruppe";
+    const key = a.group_name || a.group_id || "Gruppe";
     const list = groupsByLabel.get(key) ?? [];
     list.push(a);
     groupsByLabel.set(key, list);
   }
 
   // Default tab: prefer "dozent" if there are teacher entries, else "gruppen".
-  const defaultTab =
-    teacherAccesses.length > 0 ? "dozent" : groupsByLabel.size > 0 ? "gruppen" : "sonstige";
+  // If neither exists the card has no tabs (and no instance content to show).
+  const defaultTab = teacherAccesses.length > 0 ? "dozent" : "gruppen";
 
   return (
     <Card className="border-slate-200">
@@ -960,12 +967,6 @@ function CredentialInstanceCard({
               <TabsTrigger value="gruppen">
                 Gruppen
                 <Badge variant="secondary" className="ml-2">{groupsByLabel.size}</Badge>
-              </TabsTrigger>
-            )}
-            {otherAccesses.length > 0 && (
-              <TabsTrigger value="sonstige">
-                Sonstige
-                <Badge variant="secondary" className="ml-2">{otherAccesses.length}</Badge>
               </TabsTrigger>
             )}
           </TabsList>
@@ -1023,22 +1024,6 @@ function CredentialInstanceCard({
                   </AccordionItem>
                 ))}
               </Accordion>
-            </TabsContent>
-          )}
-
-          {otherAccesses.length > 0 && (
-            <TabsContent value="sonstige" className="space-y-3">
-              {otherAccesses.map((access, idx) => (
-                <AccessRow
-                  key={`other-${idx}`}
-                  accessKey={`${instance.instance_id}-other-${access.access_type}-${idx}`}
-                  access={access}
-                  passwordVisibility={passwordVisibility}
-                  togglePasswordVisibility={togglePasswordVisibility}
-                  handleCopy={handleCopy}
-                  getMaskedPassword={getMaskedPassword}
-                />
-              ))}
             </TabsContent>
           )}
         </Tabs>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,9 +65,19 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "https://141.72.13.2",
+        target: "http://localhost:8000",
         changeOrigin: true,
         secure: false,
+        // Required for Server-Sent Events: disable response buffering and
+        // strip Accept-Encoding so the upstream returns an unchunked,
+        // unzipped stream. Without this, the SSE endpoint /api/v1/deployments/
+        // .../logs/stream only flushes to the browser when the connection
+        // closes (terminal status), not in real time.
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq) => {
+            proxyReq.removeHeader("Accept-Encoding");
+          });
+        },
       },
     },
     port: 3000,


### PR DESCRIPTION
## Was sich aendert

### Credentials nach Owner gruppieren (`DeploymentDetails.tsx`)

Vorher lagen alle Credential-Eintraege flach unter einer Instance. Mit vielen Gruppen wurde das unuebersichtlich. Jetzt:

* Pro Instance ein Card, darin **Tabs**: `Dozent`, `Gruppen`, `Sonstige`.
* Im `Gruppen`-Tab: Akkordeon. Eine Sektion pro Gruppe (`owner_label`), erste Gruppe ist default offen.
* `Sonstige` zeigt Eintraege ohne `owner_kind` (Legacy-Rows aus der Zeit vor der Backend-Migration). Erscheint nur wenn vorhanden.
* Counter-Badges (`Dozent 2`, `Gruppen 4`) auf den Tab-Triggern.

Erfordert die Backend-Migration `add owner_kind and owner_label to deployment_instance_access` (separates PR im Backend).

### SSE-Log-Stream funktioniert wirklich live (`vite.config.ts`)

Vite-Proxy strippt `Accept-Encoding` aus dem Forward-Request — sonst antwortet das Backend gzip und der Stream wird erst beim Connection-Close in einem Schwung an den Browser durchgereicht. Symptom war: man musste die Seite reloaden, um neue Log-Eintraege zu sehen.

### Auto-Scroll im Phase-Log (`PhaseRow`)

Klassisches "tail -f"-Verhalten im offenen Phase-Container:
* `useRef` + `useEffect` scrollt zum Boden wenn neue Log-Eintraege reinkommen.
* User-Scroll wird ueber `onScroll` getrackt — sobald Distance vom Boden > 32px, wird Auto-Scroll pausiert.
* Sobald der User wieder zum Boden scrollt, geht Auto-Scroll an.

## Wie testen

1. Backend + Frontend lokal hochfahren, Deployment starten.
2. Im Network-Tab sehen dass `/logs/stream` auf `pending` haengt und Events alle paar Sekunden reinstroemen.
3. Im UI Log-Phase aufklappen — neue Eintraege rollen rein, kein Reload noetig.
4. Hochscrollen waehrend Logs reinkommen — Container bleibt stehen. Runter scrollen — Auto-Scroll geht wieder an.
5. Credentials-Section: Tabs zwischen `Dozent` und `Gruppen` switchen, Akkordeon pro Gruppe.