### PR TITLE
Deployment cancel/delete via einheitlichen DELETE-Endpoint

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -243,8 +243,22 @@ export function streamDeploymentLogs(
   return () => controller.abort();
 }
 
+/**
+ * Single delete/cancel endpoint.
+ *
+ * The backend uses ONE endpoint for both operations: it inspects the
+ * current deployment status and decides itself whether to cancel an
+ * in-flight build (`queued`, `creating`) or tear down a finished
+ * deployment (`running`, `failed`). The frontend does not branch.
+ *
+ * Returns 204 No Content on success and flips the row's status to
+ * `deleting` synchronously, so the caller can poll for the actual
+ * teardown to finish.
+ *
+ * Throws an `Error & { status: number }` on non-2xx so callers can map
+ * 401/403/404/500 to the right toast.
+ */
 export async function deleteDeployment(deploymentId: string, openstackProjectId: string | null) {
-  // Backend returns 204 No Content — don't call res.json()
   await keycloak.updateToken(30).catch(() => {});
   const res = await fetch(
     `/api/v1/deployments/${deploymentId}${projectQuery(openstackProjectId)}`,
@@ -255,7 +269,10 @@ export async function deleteDeployment(deploymentId: string, openstackProjectId:
   );
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(text || res.statusText);
+    const err = new Error(text || res.statusText) as Error & { status: number; body: string };
+    err.status = res.status;
+    err.body = text;
+    throw err;
   }
 }
 

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -69,6 +69,13 @@ interface Deployment {
   id: string;
   name: string;
   status: 'deploying' | 'running' | 'failed' | 'cancelled' | 'stopped' | 'deleting' | 'delete_failed';
+  /**
+   * Raw backend status (lower-case). Populated by DeploymentDetailsPage from
+   * `DeploymentDto.status`. Drives the action button label / confirmation
+   * text — `status` alone collapses `queued` and `creating` into `deploying`,
+   * which we need to distinguish for the "Abbrechen" copy.
+   */
+  rawStatus?: string;
   course: string;
   startedAt: string;
   completedAt?: string;
@@ -112,6 +119,72 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
   const [extendDialogOpen, setExtendDialogOpen] = useState(false);
   const [selectedExtendMonths, setSelectedExtendMonths] = useState<RuntimeMonths | null>(null);
   const [retryInFlight, setRetryInFlight] = useState(false);
+  const [deleteInFlight, setDeleteInFlight] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+  // ── Status-driven delete/cancel action ────────────────────────────────────
+  //
+  // Backend uses ONE endpoint for cancel-build and delete-deployment; it
+  // inspects the row's current status and picks the right operation itself.
+  // The UI just needs to label the button and the confirmation correctly so
+  // the user knows what they're about to trigger.
+  //
+  // Statuses outside this table render no action button at all (the spec
+  // covers `stopped`, `deleting`, `delete_failed`, `cancelled` elsewhere
+  // via banners/spinners — they don't need a manual delete trigger here).
+  const deleteAction = (() => {
+    switch (deployment.rawStatus) {
+      case "queued":
+      case "creating":
+        return {
+          label: "Abbrechen",
+          confirmTitle: "Build wirklich abbrechen?",
+          confirmText:
+            "Aktueller Build wird gestoppt, alle bereits erstellten Ressourcen werden gelöscht.",
+          confirmCta: "Ja, abbrechen",
+        };
+      case "running":
+        return {
+          label: "Löschen",
+          confirmTitle: "Deployment wirklich löschen?",
+          confirmText: "VMs werden heruntergefahren und alle Daten entfernt.",
+          confirmCta: "Ja, löschen",
+        };
+      case "failed":
+        return {
+          label: "Aufräumen",
+          confirmTitle: "Deployment aufräumen?",
+          confirmText:
+            "Fehlgeschlagenes Deployment und verbliebene Ressourcen werden entfernt.",
+          confirmCta: "Ja, aufräumen",
+        };
+      default:
+        return null;
+    }
+  })();
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!onDelete || deleteInFlight) return;
+    setDeleteInFlight(true);
+    try {
+      await onDelete(deployment.id);
+      // Page-level handler flips status to "deleting" or navigates away on
+      // success, AND surfaces errors via toast. Either way the dialog should
+      // close — keep the spinner running until the parent unmounts us or
+      // the status changes to something without a delete action.
+      setDeleteDialogOpen(false);
+    } catch {
+      // Page swallows errors and toasts them; re-enable the button so the
+      // user can retry. (Reached only if onDelete itself rejects, which the
+      // current implementation doesn't, but stay defensive.)
+      setDeleteInFlight(false);
+    }
+  }, [onDelete, deployment.id, deleteInFlight]);
+
+  // Once the parent flips status to `deleting`, the action button disappears
+  // anyway — but keep the local flag in sync so a stale `deleteInFlight`
+  // from a previous click doesn't leak across status transitions.
+  const isDeleting = deployment.status === "deleting";
 
   const handleRetry = useCallback(async () => {
     if (retryInFlight || !onRetry) return;
@@ -319,29 +392,51 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
     }
   };
 
-  // Shared delete confirmation dialog content — reused across status variants
-  const DeleteConfirmDialog = () => (
-    <AlertDialogContent className="bg-white w-auto max-w-sm sm:max-w-md max-h-[70vh] overflow-y-auto">
-      <AlertDialogHeader>
-        <AlertDialogTitle className="flex items-center gap-2">
-          <XCircle className="w-5 h-5 text-red-600" />
-          Deployment wirklich löschen?
-        </AlertDialogTitle>
-        <AlertDialogDescription>
-          Diese Aktion kann nicht rückgängig gemacht werden. Das Deployment und alle zugehörigen Ressourcen werden unwiderruflich entfernt.
-        </AlertDialogDescription>
-      </AlertDialogHeader>
-      <AlertDialogFooter className="justify-center sm:justify-center">
-        <AlertDialogCancel className="sm:w-auto">Nein, abbrechen</AlertDialogCancel>
-        <AlertDialogAction
-          className="sm:w-auto border bg-white border-slate-200 text-red-600 hover:text-red-700 hover:bg-red-50"
-          onClick={() => onDelete?.(deployment.id)}
-        >
-          Ja, löschen
-        </AlertDialogAction>
-      </AlertDialogFooter>
-    </AlertDialogContent>
-  );
+  // Status-aware delete confirmation dialog. Single instance — opened by
+  // whichever button (Actions card or "delete_failed" retry banner) sets
+  // deleteDialogOpen=true.
+  const renderDeleteDialog = () => {
+    if (!deleteAction) return null;
+    return (
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent className="bg-white w-auto max-w-sm sm:max-w-md max-h-[70vh] overflow-y-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <XCircle className="w-5 h-5 text-red-600" />
+              {deleteAction.confirmTitle}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteAction.confirmText}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="justify-center sm:justify-center">
+            <AlertDialogCancel className="sm:w-auto" disabled={deleteInFlight}>
+              Nein, abbrechen
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="sm:w-auto border bg-white border-slate-200 text-red-600 hover:text-red-700 hover:bg-red-50"
+              disabled={deleteInFlight}
+              onClick={(e) => {
+                // Keep the dialog open while the request is in flight; we
+                // close it ourselves in handleConfirmDelete on success.
+                e.preventDefault();
+                void handleConfirmDelete();
+              }}
+            >
+              {deleteInFlight ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Wird gelöscht...
+                </>
+              ) : (
+                deleteAction.confirmCta
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  };
 
   return (
     <div className="p-8 space-y-8">
@@ -611,9 +706,17 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
                 <Button
                   variant="outline"
                   className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                  onClick={() => onDelete?.(deployment.id)}
+                  disabled={deleteInFlight || !onDelete}
+                  onClick={() => void handleConfirmDelete()}
                 >
-                  Erneut versuchen
+                  {deleteInFlight ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Wird gelöscht...
+                    </>
+                  ) : (
+                    "Erneut versuchen"
+                  )}
                 </Button>
               </div>
             </div>
@@ -699,100 +802,85 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
               <CardTitle>Aktionen</CardTitle>
             </CardHeader>
             <CardContent className="space-y-2">
-              {/* ── running ── */}
               {deployment.status === 'running' && (
-                <>
-                  <Button variant="outline" className="w-full opacity-50 cursor-not-allowed" disabled>
-                    VM starten
-                  </Button>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="outline" className="w-full text-red-600 hover:text-red-700 hover:bg-red-50">
-                        Deployment löschen
-                      </Button>
-                    </AlertDialogTrigger>
-                    <DeleteConfirmDialog />
-                  </AlertDialog>
-                </>
-              )}
-
-              {/* ── deploying ── */}
-              {deployment.status === 'deploying' && (
-                <Button variant="outline" className="w-full text-orange-600 hover:text-orange-700 hover:bg-orange-50">
-                  Deployment abbrechen
+                <Button variant="outline" className="w-full opacity-50 cursor-not-allowed" disabled>
+                  VM starten
                 </Button>
               )}
 
-              {/* ── failed ── */}
+              {/* Retry-from-failed (separate flow from the delete/cleanup action) */}
               {deployment.status === 'failed' && (
-                <>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className="w-full"
-                        disabled={retryInFlight || !onRetry}
-                      >
-                        {retryInFlight ? (
-                          <>
-                            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                            Wird vorbereitet…
-                          </>
-                        ) : (
-                          "Erneut versuchen"
-                        )}
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent className="bg-white w-auto max-w-sm sm:max-w-md max-h-[70vh] overflow-y-auto">
-                      <AlertDialogHeader>
-                        <AlertDialogTitle className="flex items-center gap-2">
-                          <AlertCircle className="w-5 h-5 text-slate-600" />
-                            Deployment erneut versuchen?
-                          </AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Dieses Deployment wird gelöscht und ihre aktuellen Einstellungen und Daten für ein erneutes Deployment übernommen.
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className="w-full"
+                      disabled={retryInFlight || !onRetry || isDeleting || deleteInFlight}
+                    >
+                      {retryInFlight ? (
+                        <>
+                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                          Wird vorbereitet…
+                        </>
+                      ) : (
+                        "Erneut versuchen"
+                      )}
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent className="bg-white w-auto max-w-sm sm:max-w-md max-h-[70vh] overflow-y-auto">
+                    <AlertDialogHeader>
+                      <AlertDialogTitle className="flex items-center gap-2">
+                        <AlertCircle className="w-5 h-5 text-slate-600" />
+                        Deployment erneut versuchen?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Dieses Deployment wird gelöscht und ihre aktuellen Einstellungen und Daten für ein erneutes Deployment übernommen.
                       </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter className="justify-center sm:justify-center">
-                        <AlertDialogCancel className="sm:w-auto">Abbrechen</AlertDialogCancel>
-                        <AlertDialogAction
-                          className="sm:w-auto border bg-white border-slate-200 text-slate-900 hover:bg-slate-50"
-                          onClick={handleRetry}
-                        >
-                          Ja, erneut versuchen
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="outline" className="w-full text-red-600 hover:text-red-700 hover:bg-red-50">
-                        Deployment löschen
-                      </Button>
-                    </AlertDialogTrigger>
-                    <DeleteConfirmDialog />
-                  </AlertDialog>
-                </>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter className="justify-center sm:justify-center">
+                      <AlertDialogCancel className="sm:w-auto">Abbrechen</AlertDialogCancel>
+                      <AlertDialogAction
+                        className="sm:w-auto border bg-white border-slate-200 text-slate-900 hover:bg-slate-50"
+                        onClick={handleRetry}
+                      >
+                        Ja, erneut versuchen
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
 
-              {/* ── cancelled ── */}
+              {/* Cancelled deployments may still be re-tried via the wizard */}
               {deployment.status === 'cancelled' && (
-                <>
-                  <Button variant="outline" className="w-full">
-                    Erneut versuchen
-                  </Button>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="outline" className="w-full text-red-600 hover:text-red-700 hover:bg-red-50">
-                        Deployment löschen
-                      </Button>
-                    </AlertDialogTrigger>
-                    <DeleteConfirmDialog />
-                  </AlertDialog>
-                </>
+                <Button variant="outline" className="w-full">
+                  Erneut versuchen
+                </Button>
+              )}
+
+              {/* Unified delete/cancel/cleanup button — label and confirmation
+                  text come from `deleteAction`, which switches on the raw
+                  backend status (queued/creating/running/failed). For all
+                  other statuses, deleteAction is null and no button renders. */}
+              {deleteAction && (
+                <Button
+                  variant="outline"
+                  className="w-full text-red-600 hover:text-red-700 hover:bg-red-50"
+                  disabled={isDeleting || deleteInFlight || !onDelete}
+                  onClick={() => setDeleteDialogOpen(true)}
+                >
+                  {isDeleting || deleteInFlight ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Wird gelöscht...
+                    </>
+                  ) : (
+                    deleteAction.label
+                  )}
+                </Button>
               )}
             </CardContent>
           </Card>
+          {renderDeleteDialog()}
         </div>
       </div>
 

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -342,6 +342,12 @@ export function DeploymentDetailsPage() {
   );
 
   const handleDeleteDeployment = async (id: string) => {
+    // Snapshot the backend's raw status BEFORE we flip to "deleting" — we
+    // need it to decide whether to show the "Abbruch eingeleitet" toast for
+    // builds that were cancelled mid-flight.
+    const rawStatus: string | undefined = backendDeploymentRef.current?.status?.toString().toLowerCase();
+    const wasInFlight = rawStatus === "queued" || rawStatus === "creating";
+
     isDeletingRef.current = true;
     stopStreamRef.current?.();
     setDeploymentData((prev: any) => prev ? { ...prev, status: "deleting" } : prev);
@@ -349,7 +355,41 @@ export function DeploymentDetailsPage() {
     try {
       await deleteDeployment(id, activeProjectId);
     } catch (err) {
-      console.error("Failed to initiate delete", err);
+      // Restore previous status so the action buttons reappear and the user
+      // can retry. The page stays mounted; the SSE stream is gone but the
+      // existing UI still works off the cached deployment.
+      isDeletingRef.current = false;
+      setDeploymentData((prev: any) =>
+        prev ? { ...prev, status: STATUS_MAP[rawStatus?.toUpperCase() ?? ""] ?? prev.status } : prev,
+      );
+
+      const error = err as Error & { status?: number };
+      if (error.status === 401) {
+        // Auth refresh happens inside deleteDeployment; a 401 reaching us
+        // means the refresh itself failed. Let the global auth flow handle
+        // it — surface a generic message.
+        toast.error("Sitzung abgelaufen. Bitte erneut anmelden.");
+      } else if (error.status === 403) {
+        toast.error("Du hast keinen Zugriff auf dieses Deployment.");
+      } else if (error.status === 404) {
+        // Already gone — refresh from server. The next getDeployment call
+        // will likely 404 too, which the catch-arm below maps to dashboard.
+        try {
+          const resp = await getDeployment(id, activeProjectId);
+          backendDeploymentRef.current = resp.data;
+          setDeploymentData(buildDeploymentData(resp.data, logsRef.current));
+        } catch {
+          navigate("/dashboard");
+        }
+      } else {
+        toast.error("Löschen fehlgeschlagen. Bitte erneut versuchen.");
+      }
+      return;
+    }
+
+    // Success path — backend returned 204 and flipped status to "deleting".
+    if (wasInFlight) {
+      toast.info("Abbruch eingeleitet. Kann je nach aktueller Phase einige Sekunden bis wenige Minuten dauern.");
     }
 
     // Poll for max 60s, then give up and show retry
@@ -445,6 +485,11 @@ export function DeploymentDetailsPage() {
         id: backendDeployment.id,
         name: backendDeployment.name || "Unnamed Deployment",
         status: mappedStatus,
+        // Raw backend status (lower-case) — DeploymentDetails uses this to
+        // pick the action-button label ("Abbrechen" vs "Löschen" vs
+        // "Aufräumen"), which can't be derived from the mapped status
+        // alone (queued and creating both map to "deploying").
+        rawStatus: (backendDeployment.status ?? "").toString().toLowerCase(),
         course: resolvedCourseName,
         startedAt: backendDeployment.created_at,
         completedAt:


### PR DESCRIPTION
Vorher gab es drei doppelte Löschen-Dialoge (running/failed/cancelled) und einen toten 'Deployment abbrechen'-Button (deploying), der nichts tat. Backend hat inzwischen einen einzigen Endpoint, der anhand des aktuellen Status selbst entscheidet, ob ein laufender Build abgebrochen oder ein fertiges Deployment gelöscht wird — das spiegelt das Frontend jetzt.

DeploymentDetails.tsx
- Eine statusgetriebene deleteAction-Tabelle (queued/creating → Abbrechen, running → Löschen, failed → Aufräumen) ersetzt die drei hardcoded Dialoge. Für alle anderen Status rendert kein Button.
- Ein einziger AlertDialog (statt drei) mit dynamischem Titel/Text/CTA. Dialog bleibt offen während die Mutation läuft (preventDefault auf AlertDialogAction); Cancel-Button und Action sind disabled, Action zeigt Spinner + 'Wird gelöscht...'.
- Neues rawStatus-Feld auf der Deployment-Prop, weil das bestehende gemappte status queued und creating beide auf 'deploying' kollabiert — für die 'Abbrechen'-Beschriftung muss aber unterschieden werden.
- delete_failed-Banner-Retry geht jetzt durch handleConfirmDelete statt onDelete direkt aufzurufen, damit der Loading-State konsistent ist.

DeploymentDetailsPage.tsx
- handleDeleteDeployment snapshottet den Backend-Status VOR dem Flip auf 'deleting', um nach erfolgreichem 204 bei queued/creating den Toast 'Abbruch eingeleitet. Kann je nach aktueller Phase einige Sekunden bis wenige Minuten dauern.' anzuzeigen.
- Vollständige Fehlerbehandlung statt nur console.error:
  - 401 → 'Sitzung abgelaufen. Bitte erneut anmelden.'
  - 403 → 'Du hast keinen Zugriff auf dieses Deployment.'
  - 404 → getDeployment neu laden, bei dortigem 404 zum Dashboard
  - 500 / sonstige → 'Löschen fehlgeschlagen. Bitte erneut versuchen.' In allen Error-Pfaden wird der vorige Status wiederhergestellt, damit der Button erneut klickbar ist.
- rawStatus wird in buildDeploymentData mit durchgereicht.

api/deployments.ts
- deleteDeployment wirft jetzt Error & { status, body } statt nur Error(message), damit der Aufrufer die HTTP-Statuscodes für die Toast-Auswahl unterscheiden kann.
- Doc-Comment, der den 'ein Endpoint für beides'-Vertrag dokumentiert.