### PR TITLE
Student Self-Service: eigenes Routing, /student/* API, course_group_i…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { DashboardPage } from "./pages/DashboardPage";
 import { AppStorePage } from "./pages/AppStorePage";
 import { DeploymentWizardPage } from "./pages/DeploymentWizardPage";
 import { DeploymentDetailsPage } from "./pages/DeploymentDetailsPage";
+import { StudentDashboardPage } from "./pages/StudentDashboardPage";
+import { StudentDeploymentDetailsPage } from "./pages/StudentDeploymentDetailsPage";
 import { OpenStackSetup } from "./pages/OpenStackSetup";
 import { GithubConnected } from "./pages/GithubConnected";
 import { Toaster } from "./components/ui/sonner";
@@ -28,6 +30,11 @@ export default function App() {
   // Admins don't need a project to use the app, so we don't push them into the
   // OpenStack-setup route. We resolve this once after auth and keep it sticky.
   const [isLecturer, setIsLecturer] = useState(false);
+  // Studenten haben einen eigenen /student/* Namespace; OpenStack-Setup wird
+  // für sie komplett übersprungen. Wir merken uns das pro Session, damit die
+  // Routing-Entscheidung stabil bleibt, auch wenn der Token zwischendurch
+  // refreshed wird.
+  const [isStudent, setIsStudent] = useState(false);
 
   // The GitHub-App install callback redirects the browser to
   // `/github/connected?status=…`. That route has to stay reachable even if
@@ -51,10 +58,19 @@ export default function App() {
     if (!keycloak.authenticated) return;
     const roles: string[] = (keycloak.tokenParsed as Record<string, any>)?.realm_access?.roles ?? [];
     const lecturer = roles.includes("lecturer") || roles.includes("teacher");
+    const admin = roles.includes("admin");
+    const student = roles.includes("student");
     setIsLecturer(lecturer);
+    // Reiner Student (kein Lecturer/Admin) → eigene Routen, kein
+    // OpenStack-Setup-Gate. Wenn ein User beides hat (z. B. testweise
+    // Lecturer+Student), gewinnt Lecturer/Admin, weil die Lecturer-Flow
+    // ausgereifter ist und der Student kann sich /student/* manuell aufrufen
+    // (kommt in der Realität nicht vor, aber wir halten den Cut sauber).
+    const pureStudent = student && !lecturer && !admin;
+    setIsStudent(pureStudent);
     if (!lecturer) {
-      // Admins don't need a project to use the app — keep activeProject null;
-      // the deployment endpoints accept admins without the query param.
+      // Admins und reine Studenten brauchen kein OpenStack-Projekt; in beiden
+      // Fällen lassen wir activeProject auf null und springen das Setup-Gate.
       setActiveProject(null);
       setProjectsChecked(true);
       return;
@@ -147,17 +163,37 @@ export default function App() {
       <div className="flex h-screen bg-slate-50">
         <Sidebar logo={logo} />
         <main className="flex-1 overflow-auto">
-          <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<DashboardPage />} />
-            <Route path="/courses" element={<Courses />} />
-            <Route path="/appstore" element={<AppStorePage />} />
-            <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
-            <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
-            <Route path="/config" element={<OpenStackConfig />} />
-            <Route path="/admin" element={<AdminMonitoring />} />
-          </Routes>
+          {isStudent ? (
+            // Studenten haben keinen Zugriff auf Lecturer-Endpoints (Backend
+            // gibt 403). Wir registrieren bewusst NUR /student/*, /config
+            // (Settings) und einen Catch-All-Redirect; alles andere
+            // (Dashboard, Courses, AppStore, Deploy, Admin) landet damit
+            // automatisch wieder auf /student/dashboard.
+            <Routes>
+              <Route path="/" element={<Navigate to="/student/dashboard" replace />} />
+              <Route path="/student/dashboard" element={<StudentDashboardPage />} />
+              <Route
+                path="/student/deployment/:deploymentId"
+                element={<StudentDeploymentDetailsPage />}
+              />
+              <Route path="/config" element={<OpenStackConfig />} />
+              <Route path="*" element={<Navigate to="/student/dashboard" replace />} />
+            </Routes>
+          ) : (
+            <Routes>
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/setup" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/courses" element={<Courses />} />
+              <Route path="/appstore" element={<AppStorePage />} />
+              <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
+              <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
+              <Route path="/config" element={<OpenStackConfig />} />
+              <Route path="/admin" element={<AdminMonitoring />} />
+              {/* Lecturer/Admin auf /student/* → zurück aufs Dashboard. */}
+              <Route path="/student/*" element={<Navigate to="/dashboard" replace />} />
+            </Routes>
+          )}
         </main>
       </div>
       <Toaster richColors />

--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -61,9 +61,21 @@ export type AccessType =
   | "database";
 
 export type CredentialAccess = {
+  /**
+   * DB id of the access entry. Used to address the dedicated SSH-key
+   * download endpoint (lecturer + student) — `/credentials/access/{id}/ssh-key`.
+   */
+  id: string;
   access_type: AccessType;
   username: string | null;
   password: string | null;
+  /**
+   * Decrypted SSH private key in OpenSSH PEM format. Present for SSH
+   * accesses where a keypair was generated. Lecturer view can embed it in
+   * the bundle download; student view always uses the dedicated PEM
+   * endpoint instead.
+   */
+  ssh_private_key: string | null;
   connection_url: string | null;
   port: number | null;
   /**
@@ -124,6 +136,13 @@ export type DeploymentCreateRequest = {
     groups: Array<{
       group_name: string;
       group_index: number;
+      // course_groups.id der zugehörigen Gruppe. Optional für Backwards-
+      // Compat (alte Wizards / Lecturer-Workflows ohne Course-Groups),
+      // aber funktional notwendig: ohne diese ID bleibt
+      // DeploymentInstanceAccess.group_id NULL und Studenten sehen das
+      // Deployment nie über /api/v1/student/*. Der Wizard löst die ID
+      // beim Submit via getCourseGroups/createCourseGroup auf.
+      course_group_id?: string | null;
       students: Array<{
         id: string;
         username: string;

--- a/src/api/student.ts
+++ b/src/api/student.ts
@@ -1,0 +1,123 @@
+// Student self-service API wrapper. Spiegelt /api/v1/student/* aus dem
+// Backend (siehe appstore-backend/src/api/student.py).
+//
+// Wichtig:
+// - Diese Endpoints sind exklusiv für Realm-Role "student". Lecturer/Admin-
+//   Tokens bekommen 403.
+// - Kein openstack_project_id-Param — Backend filtert komplett über die
+//   Course-Group-Mitgliedschaft des Users.
+// - Schema der Credentials-Response ist identisch mit dem Lecturer-Endpoint
+//   (`DeploymentCredentialsResponse`), nur das Set ist enger gefiltert.
+import { apiFetch } from "./http";
+import keycloak from "../auth/keycloak";
+import type { DeploymentCredentialsResponse } from "./deployments";
+
+// Getrimmte Sicht für Studenten — bewusst nicht DeploymentDto recyceln:
+// Backend liefert deployment_parameters/course_id/lecturer-Felder gar nicht
+// erst aus, und wir wollen nichts versehentlich rendern, was nicht da ist.
+export type StudentDeploymentDto = {
+  id: string;
+  name: string;
+  status: string;
+  template: {
+    name: string | null;
+    version: string | null;
+  };
+  instances: Array<{
+    id: string;
+    vm_name: string | null;
+    ip_address: string | null;
+  }>;
+  created_at: string | null;
+  expires_at: string | null;
+};
+
+type EnvelopeArray<T> = {
+  success: boolean;
+  message?: string;
+  data: T[];
+  errors?: unknown;
+  timestamp?: string;
+  request_id?: string;
+};
+
+type Envelope<T> = {
+  success: boolean;
+  message?: string;
+  data: T;
+  errors?: unknown;
+  timestamp?: string;
+  request_id?: string;
+};
+
+export async function getStudentDeployments(): Promise<StudentDeploymentDto[]> {
+  const resp = await apiFetch<EnvelopeArray<StudentDeploymentDto>>(
+    `/api/v1/student/deployments`,
+  );
+  return resp?.data ?? [];
+}
+
+export async function getStudentDeploymentCredentials(
+  deploymentId: string,
+): Promise<DeploymentCredentialsResponse> {
+  const resp = await apiFetch<Envelope<DeploymentCredentialsResponse>>(
+    `/api/v1/student/deployments/${deploymentId}/credentials`,
+  );
+  return resp.data;
+}
+
+// PEM-Stream-Download. Eigene fetch()-Schleife statt apiFetch, weil:
+// - Response ist kein JSON, sondern application/x-pem-file
+// - Wir brauchen den Content-Disposition-Header für den Dateinamen
+// - Bei 401/403/404 wollen wir den Fehler hochwerfen (analog deleteDeployment)
+export async function downloadStudentSshKey(
+  deploymentId: string,
+  accessId: string,
+  fallbackUsername?: string | null,
+): Promise<void> {
+  // Token vor dem Stream erneuern — das Backend liefert sonst ggf. eine
+  // 0-Byte-Datei nach erstem Read, weil Auth erst beim Streamstart greift.
+  await keycloak.updateToken(30).catch(() => {});
+  const res = await fetch(
+    `/api/v1/student/deployments/${deploymentId}/credentials/access/${accessId}/ssh-key`,
+    {
+      method: "GET",
+      headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    const err = new Error(text || res.statusText) as Error & {
+      status: number;
+      body: string;
+    };
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+
+  // Dateiname bevorzugt aus Content-Disposition ziehen (`attachment;
+  // filename="id_ed25519_<user>"`). Fallback baut den Namen aus dem
+  // Username/Access-ID — verhindert das generische "download" im Browser.
+  const disposition = res.headers.get("content-disposition") || "";
+  let filename = "";
+  const match = disposition.match(/filename\*?=(?:UTF-8'')?["']?([^"';]+)["']?/i);
+  if (match?.[1]) {
+    filename = decodeURIComponent(match[1]);
+  }
+  if (!filename) {
+    const safeUser = (fallbackUsername || "").replace(/[^a-zA-Z0-9_.-]/g, "_");
+    filename = safeUser ? `id_ed25519_${safeUser}` : `id_ed25519_${accessId}`;
+  }
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/auth/useCurrentUser.ts
+++ b/src/auth/useCurrentUser.ts
@@ -14,6 +14,10 @@ export type CurrentUser = {
   email: string | null;
   isAdmin: boolean;
   isLecturer: boolean;
+  // Realm-Role "student" aus Keycloak. Reine Studenten (kein Lecturer/Admin)
+  // werden im Router auf den /student/* Namespace gelenkt; ihre API ist
+  // /api/v1/student/* — Lecturer-Endpoints geben für sie 403.
+  isStudent: boolean;
   authenticated: boolean;
 };
 
@@ -28,6 +32,7 @@ export function useCurrentUser(): CurrentUser {
     email: token.email ?? null,
     isAdmin: roles.includes("admin"),
     isLecturer: roles.includes("lecturer") || roles.includes("teacher"),
+    isStudent: roles.includes("student"),
     authenticated: !!keycloak?.authenticated,
   };
 }

--- a/src/components/credentials/CredentialInstanceCard.tsx
+++ b/src/components/credentials/CredentialInstanceCard.tsx
@@ -1,0 +1,380 @@
+// Gemeinsamer Credentials-Renderer für Lecturer- und Student-Views.
+//
+// Hintergrund: Dasselbe Tab/Accordion/Copy/Mask-Layout wurde früher inline in
+// DeploymentDetails gehalten — wir teilen es jetzt, damit
+// StudentDeploymentDetails dieselbe UI bekommt, ohne ~350 Zeilen zu
+// duplizieren.
+//
+// Zwei Modes:
+//  - "lecturer": zeigt zwei Tabs (Dozent / Gruppen). Dozent-Tab listet alle
+//    Accesses mit group_id == null, Gruppen-Tab gruppiert nach group_name.
+//    SSH-Keys werden aus dem eingebetteten ssh_private_key-Feld geladen
+//    (kein dedizierter Endpoint nötig).
+//  - "student": nur ein Gruppen-Accordion (Backend filtert Dozent-Rows
+//    sowieso raus; wir bleiben defensiv und erwarten group_id != null in
+//    allen rows). SSH-Key-Download geht über onDownloadSshKey-Prop, die
+//    den dedizierten /access/{id}/ssh-key-Endpoint anstößt.
+import { Copy, Download, Eye, EyeOff } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../ui/card";
+import { Button } from "../ui/button";
+import { Badge } from "../ui/badge";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "../ui/tabs";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../ui/accordion";
+import type {
+  CredentialAccess,
+  CredentialInstance,
+} from "../../api/deployments";
+
+const accessTypeLabels: Record<string, string> = {
+  ssh: "SSH",
+  web_url: "Web URL",
+  guacamole: "Guacamole",
+  rdp: "RDP",
+  vnc: "VNC",
+  database: "Database",
+};
+
+export type CredentialsMode = "lecturer" | "student";
+
+export interface CredentialInstanceCardProps {
+  instance: CredentialInstance;
+  mode: CredentialsMode;
+  passwordVisibility: Record<string, boolean>;
+  togglePasswordVisibility: (key: string) => void;
+  handleCopy: (value: string | null | undefined, label: string) => void;
+  getMaskedPassword: (pw: string | null | undefined) => string;
+  /**
+   * Optional. Wenn gesetzt, erscheint pro SSH-Access ein Download-Button,
+   * der die Funktion mit (accessId, username) aufruft. Im Student-Mode
+   * unbedingt setzen — dort gibt's keinen eingebetteten ssh_private_key
+   * im Bundle-Download, der dedizierte Endpoint ist der einzige Pfad.
+   */
+  onDownloadSshKey?: (accessId: string, username: string | null) => void;
+}
+
+export function CredentialInstanceCard({
+  instance,
+  mode,
+  passwordVisibility,
+  togglePasswordVisibility,
+  handleCopy,
+  getMaskedPassword,
+  onDownloadSshKey,
+}: CredentialInstanceCardProps) {
+  // Lecturer-View: Dozent-Zeilen (group_id IS NULL) vs. Gruppen-Zeilen.
+  // Student-View: alle Zeilen sind Gruppen-Zeilen (Backend filtert NULL aus),
+  // wir gruppieren trotzdem nach group_name, um mehrere Gruppen sauber
+  // darzustellen — ein Student kann theoretisch in mehreren Gruppen sein.
+  const teacherAccesses =
+    mode === "lecturer"
+      ? instance.accesses.filter((a) => a.group_id == null)
+      : [];
+  const groupAccesses =
+    mode === "lecturer"
+      ? instance.accesses.filter((a) => a.group_id != null)
+      : instance.accesses;
+
+  const groupsByLabel = new Map<string, CredentialAccess[]>();
+  for (const a of groupAccesses) {
+    const key = a.group_name || a.group_id || "Gruppe";
+    const list = groupsByLabel.get(key) ?? [];
+    list.push(a);
+    groupsByLabel.set(key, list);
+  }
+
+  const defaultTab = teacherAccesses.length > 0 ? "dozent" : "gruppen";
+
+  return (
+    <Card className="border-slate-200">
+      <CardHeader>
+        <CardTitle className="text-base">{instance.vm_name || "VM"}</CardTitle>
+        <CardDescription>
+          Stack ID: {instance.openstack_stack_id || "-"}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {/*
+          Lecturer-Mode: Tabs (Dozent | Gruppen). Student-Mode: kein Tab
+          drumherum, direkt das Accordion — sonst sieht der Student ein
+          einsames "Gruppen"-Tab das nichts toggled.
+        */}
+        {mode === "lecturer" ? (
+          <Tabs defaultValue={defaultTab} className="w-full">
+            <TabsList className="mb-4">
+              {teacherAccesses.length > 0 && (
+                <TabsTrigger value="dozent">
+                  Dozent
+                  <Badge variant="secondary" className="ml-2">
+                    {teacherAccesses.length}
+                  </Badge>
+                </TabsTrigger>
+              )}
+              {groupsByLabel.size > 0 && (
+                <TabsTrigger value="gruppen">
+                  Gruppen
+                  <Badge variant="secondary" className="ml-2">
+                    {groupsByLabel.size}
+                  </Badge>
+                </TabsTrigger>
+              )}
+            </TabsList>
+
+            {teacherAccesses.length > 0 && (
+              <TabsContent value="dozent" className="space-y-3">
+                {teacherAccesses.map((access, idx) => (
+                  <AccessRow
+                    key={`teacher-${idx}`}
+                    accessKey={`${instance.instance_id}-teacher-${access.access_type}-${idx}`}
+                    access={access}
+                    passwordVisibility={passwordVisibility}
+                    togglePasswordVisibility={togglePasswordVisibility}
+                    handleCopy={handleCopy}
+                    getMaskedPassword={getMaskedPassword}
+                    onDownloadSshKey={onDownloadSshKey}
+                  />
+                ))}
+              </TabsContent>
+            )}
+
+            {groupsByLabel.size > 0 && (
+              <TabsContent value="gruppen">
+                <GroupAccordion
+                  groupsByLabel={groupsByLabel}
+                  instanceId={instance.instance_id}
+                  passwordVisibility={passwordVisibility}
+                  togglePasswordVisibility={togglePasswordVisibility}
+                  handleCopy={handleCopy}
+                  getMaskedPassword={getMaskedPassword}
+                  onDownloadSshKey={onDownloadSshKey}
+                />
+              </TabsContent>
+            )}
+          </Tabs>
+        ) : groupsByLabel.size > 0 ? (
+          <GroupAccordion
+            groupsByLabel={groupsByLabel}
+            instanceId={instance.instance_id}
+            passwordVisibility={passwordVisibility}
+            togglePasswordVisibility={togglePasswordVisibility}
+            handleCopy={handleCopy}
+            getMaskedPassword={getMaskedPassword}
+            onDownloadSshKey={onDownloadSshKey}
+          />
+        ) : (
+          <p className="text-sm text-slate-500">Keine Zugänge verfügbar.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function GroupAccordion({
+  groupsByLabel,
+  instanceId,
+  passwordVisibility,
+  togglePasswordVisibility,
+  handleCopy,
+  getMaskedPassword,
+  onDownloadSshKey,
+}: {
+  groupsByLabel: Map<string, CredentialAccess[]>;
+  instanceId: string;
+  passwordVisibility: Record<string, boolean>;
+  togglePasswordVisibility: (key: string) => void;
+  handleCopy: (value: string | null | undefined, label: string) => void;
+  getMaskedPassword: (pw: string | null | undefined) => string;
+  onDownloadSshKey?: (accessId: string, username: string | null) => void;
+}) {
+  return (
+    <Accordion
+      type="multiple"
+      defaultValue={Array.from(groupsByLabel.keys()).slice(0, 1)}
+      className="space-y-2"
+    >
+      {Array.from(groupsByLabel.entries()).map(([label, accesses]) => (
+        <AccordionItem
+          key={label}
+          value={label}
+          className="border border-slate-200 rounded-lg px-3"
+        >
+          <AccordionTrigger className="hover:no-underline">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-slate-900">{label}</span>
+              <Badge variant="outline" className="text-xs">
+                {accesses.length} {accesses.length === 1 ? "Zugang" : "Zugänge"}
+              </Badge>
+            </div>
+          </AccordionTrigger>
+          <AccordionContent className="space-y-3 pt-2">
+            {accesses.map((access, idx) => (
+              <AccessRow
+                key={`${label}-${idx}`}
+                accessKey={`${instanceId}-${label}-${access.access_type}-${idx}`}
+                access={access}
+                passwordVisibility={passwordVisibility}
+                togglePasswordVisibility={togglePasswordVisibility}
+                handleCopy={handleCopy}
+                getMaskedPassword={getMaskedPassword}
+                onDownloadSshKey={onDownloadSshKey}
+              />
+            ))}
+          </AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}
+
+function AccessRow({
+  accessKey,
+  access,
+  passwordVisibility,
+  togglePasswordVisibility,
+  handleCopy,
+  getMaskedPassword,
+  onDownloadSshKey,
+}: {
+  accessKey: string;
+  access: CredentialAccess;
+  passwordVisibility: Record<string, boolean>;
+  togglePasswordVisibility: (key: string) => void;
+  handleCopy: (value: string | null | undefined, label: string) => void;
+  getMaskedPassword: (pw: string | null | undefined) => string;
+  onDownloadSshKey?: (accessId: string, username: string | null) => void;
+}) {
+  const urlLabel =
+    access.access_type === "ssh"
+      ? "SSH-Befehl"
+      : access.access_type === "web_url"
+        ? "URL"
+        : "Connection URL";
+
+  const isVisible = passwordVisibility[accessKey] === true;
+  // SSH-Key-Download nur zeigen, wenn (a) der Caller einen Handler liefert,
+  // (b) es ein SSH-Access ist und (c) der Backend-Eintrag tatsächlich eine
+  // access.id liefert. Lecturer-Mode kann optional ohne Handler laufen und
+  // den Key im Bundle-Download mitschicken.
+  const canDownloadKey =
+    !!onDownloadSshKey && access.access_type === "ssh" && !!access.id;
+
+  return (
+    <div className="rounded-lg border border-slate-200 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium text-slate-900">
+          {accessTypeLabels[access.access_type] || access.access_type}
+        </h4>
+        <Badge variant="outline">{access.access_type}</Badge>
+      </div>
+
+      <div className="grid gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">Username</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-slate-900">{access.username ?? "-"}</span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(access.username, "Username")}
+              disabled={!access.username}
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">Password</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-slate-900">
+              {isVisible
+                ? (access.password ?? "-")
+                : getMaskedPassword(access.password)}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => togglePasswordVisibility(accessKey)}
+              disabled={!access.password}
+            >
+              {isVisible ? (
+                <EyeOff className="w-4 h-4" />
+              ) : (
+                <Eye className="w-4 h-4" />
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(access.password, "Password")}
+              disabled={!access.password}
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">{urlLabel}</span>
+          <div className="flex items-center gap-2">
+            {access.connection_url ? (
+              access.access_type === "web_url" ? (
+                <a
+                  href={access.connection_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-blue-600 hover:underline break-all"
+                >
+                  {access.connection_url}
+                </a>
+              ) : (
+                <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono">
+                  {access.connection_url}
+                </code>
+              )
+            ) : (
+              <span className="text-sm text-slate-400">-</span>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleCopy(access.connection_url, urlLabel)}
+              disabled={!access.connection_url}
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-xs text-slate-500">Port</span>
+          <span className="text-sm text-slate-900">{access.port ?? "-"}</span>
+        </div>
+
+        {canDownloadKey && (
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-xs text-slate-500">SSH Private Key</span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onDownloadSshKey?.(access.id, access.username)}
+            >
+              <Download className="w-4 h-4 mr-2" />
+              PEM herunterladen
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -5,7 +5,8 @@ import {
   Settings,
   ChevronRight,
   LogOut,
-  Shield
+  Shield,
+  Server,
 } from "lucide-react";
 import { useMemo } from "react";
 import { useKeycloak } from "@react-keycloak/web";
@@ -27,15 +28,31 @@ export function Sidebar({ logo }: SidebarProps) {
   const { keycloak, initialized } = useKeycloak();
   const location = useLocation();
 
-  const navItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard, path: '/dashboard' },
-    { id: 'courses', label: 'Kurse', icon: BookOpen, path: '/courses' },
-    { id: 'appstore', label: 'App Store', icon: Store, path: '/appstore' },
-    { id: 'admin', label: 'Admin Monitoring', icon: Shield, path: '/admin' },
-  ];
-
   // tokenParsed ist typisiert als unknown | KeycloakTokenParsed, daher casten wir vorsichtig
   const token = (keycloak?.tokenParsed ?? {}) as Record<string, any>;
+  const roles: string[] = token?.realm_access?.roles ?? [];
+  const isAdmin = roles.includes("admin");
+  const isLecturer = roles.includes("lecturer") || roles.includes("teacher");
+  const isStudent = roles.includes("student") && !isLecturer && !isAdmin;
+
+  // Studenten haben einen reduzierten Navigations-Stack — alles Lecturer-
+  // spezifische würde im Backend 403 produzieren und sollte deshalb gar
+  // nicht erst klickbar sein.
+  const navItems = isStudent
+    ? [
+        {
+          id: "student-dashboard",
+          label: "Meine Deployments",
+          icon: Server,
+          path: "/student/dashboard",
+        },
+      ]
+    : [
+        { id: "dashboard", label: "Dashboard", icon: LayoutDashboard, path: "/dashboard" },
+        { id: "courses", label: "Kurse", icon: BookOpen, path: "/courses" },
+        { id: "appstore", label: "App Store", icon: Store, path: "/appstore" },
+        { id: "admin", label: "Admin Monitoring", icon: Shield, path: "/admin" },
+      ];
 
   const displayName = useMemo(() => {
     // Typische Claims: name, preferred_username, email
@@ -48,14 +65,11 @@ export function Sidebar({ logo }: SidebarProps) {
   }, [token.name, token.preferred_username, token.email]);
 
   const roleLabel = useMemo(() => {
-    const roles: string[] = token?.realm_access?.roles ?? [];
-    if (roles.includes("admin")) return "Admin";
-    if (roles.includes("lecturer") || roles.includes("teacher")) return "Dozent";
-    if (roles.includes("student")) return "Student";
+    if (isAdmin) return "Admin";
+    if (isLecturer) return "Dozent";
+    if (isStudent) return "Student";
     return "Benutzer";
-  }, [token]);
-
-  const isAdmin = ((token?.realm_access?.roles ?? []) as string[]).includes("admin");
+  }, [isAdmin, isLecturer, isStudent]);
 
   const initials = initialsFromName(displayName);
 
@@ -70,13 +84,17 @@ export function Sidebar({ logo }: SidebarProps) {
   // Check if we're in a deployment wizard to disable navigation
   const deploymentActive = location.pathname.startsWith('/deploy/');
 
+  // Studenten haben keinen Lecturer-Wizard und auch keine /dashboard-Route —
+  // das Logo soll sie zu ihrer eigenen Übersicht führen.
+  const homePath = isStudent ? "/student/dashboard" : "/dashboard";
+
   return (
     <aside className="relative w-64 bg-white border-r border-slate-200 flex flex-col">
       {/* Logo */}
       <NavLink
-        to="/dashboard"
+        to={homePath}
         className="p-6 border-b border-slate-200 block transition-opacity hover:opacity-80"
-        aria-label="Zum Dashboard"
+        aria-label="Zur Startseite"
       >
         <img src={logo} alt="DoziLab" className="h-40 w-auto" />
       </NavLink>

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -6,9 +6,6 @@ import {
   AlertCircle,
   XCircle,
   ArrowLeft,
-  Eye,
-  EyeOff,
-  Copy,
   Download,
   Loader2,
   ChevronDown,
@@ -25,8 +22,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../co
 import { Button } from "../components/ui/button";
 import { Badge } from "../components/ui/badge";
 import { Progress } from "../components/ui/progress";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "../components/ui/tabs";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "../components/ui/accordion";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -55,6 +50,7 @@ import {
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
 import { getExpiryState } from "../utils/deployment";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
+import { CredentialInstanceCard } from "../components/credentials/CredentialInstanceCard";
 
 interface DeploymentStep {
   id: string;
@@ -961,6 +957,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
                     <CredentialInstanceCard
                       key={instance.instance_id}
                       instance={instance}
+                      mode="lecturer"
                       passwordVisibility={passwordVisibility}
                       togglePasswordVisibility={togglePasswordVisibility}
                       handleCopy={handleCopy}
@@ -977,268 +974,10 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
 }
 
 // ── Credentials helpers ───────────────────────────────────────────────────────
+// CredentialInstanceCard + AccessRow leben jetzt in
+// components/credentials/CredentialInstanceCard.tsx — geteilt mit dem
+// Student-View (mode="student"). Hier nur noch der mode="lecturer"-Caller.
 
-type AccessLike = {
-  access_type: string;
-  username: string | null;
-  password: string | null;
-  connection_url: string | null;
-  port: number | null;
-  /**
-   * course_groups.id this credential belongs to. NULL = lecturer/admin row
-   * (shown in Dozent tab). Non-NULL = student group row (Gruppen tab,
-   * accordion section per group_name).
-   */
-  group_id: string | null;
-  /** Human-readable group name from the JOIN on course_groups.name. */
-  group_name: string | null;
-};
-
-type CredentialInstanceLike = {
-  instance_id: string;
-  vm_name: string | null;
-  openstack_stack_id: string | null;
-  accesses: AccessLike[];
-};
-
-function CredentialInstanceCard({
-  instance,
-  passwordVisibility,
-  togglePasswordVisibility,
-  handleCopy,
-  getMaskedPassword,
-}: {
-  instance: CredentialInstanceLike;
-  passwordVisibility: Record<string, boolean>;
-  togglePasswordVisibility: (key: string) => void;
-  handleCopy: (value: string | null | undefined, label: string) => void;
-  getMaskedPassword: (pw: string | null | undefined) => string;
-}) {
-  // Split accesses by ownership: group_id IS NULL → lecturer/admin row →
-  // "Dozent" tab; group_id is a course_groups.id → student row → "Gruppen"
-  // tab, one accordion section per group_name.
-  const teacherAccesses = instance.accesses.filter((a) => a.group_id == null);
-  const groupAccesses = instance.accesses.filter((a) => a.group_id != null);
-
-  // Group the group-accesses by their group identity so each group becomes
-  // one collapsible accordion row. Prefer group_name for display; fall back
-  // to the bare group_id if the JOIN didn't yield a name (shouldn't happen
-  // in practice but keeps the UI safe).
-  const groupsByLabel = new Map<string, AccessLike[]>();
-  for (const a of groupAccesses) {
-    const key = a.group_name || a.group_id || "Gruppe";
-    const list = groupsByLabel.get(key) ?? [];
-    list.push(a);
-    groupsByLabel.set(key, list);
-  }
-
-  // Default tab: prefer "dozent" if there are teacher entries, else "gruppen".
-  // If neither exists the card has no tabs (and no instance content to show).
-  const defaultTab = teacherAccesses.length > 0 ? "dozent" : "gruppen";
-
-  return (
-    <Card className="border-slate-200">
-      <CardHeader>
-        <CardTitle className="text-base">{instance.vm_name || "VM"}</CardTitle>
-        <CardDescription>Stack ID: {instance.openstack_stack_id || "-"}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Tabs defaultValue={defaultTab} className="w-full">
-          <TabsList className="mb-4">
-            {teacherAccesses.length > 0 && (
-              <TabsTrigger value="dozent">
-                Dozent
-                <Badge variant="secondary" className="ml-2">{teacherAccesses.length}</Badge>
-              </TabsTrigger>
-            )}
-            {groupsByLabel.size > 0 && (
-              <TabsTrigger value="gruppen">
-                Gruppen
-                <Badge variant="secondary" className="ml-2">{groupsByLabel.size}</Badge>
-              </TabsTrigger>
-            )}
-          </TabsList>
-
-          {teacherAccesses.length > 0 && (
-            <TabsContent value="dozent" className="space-y-3">
-              {teacherAccesses.map((access, idx) => (
-                <AccessRow
-                  key={`teacher-${idx}`}
-                  accessKey={`${instance.instance_id}-teacher-${access.access_type}-${idx}`}
-                  access={access}
-                  passwordVisibility={passwordVisibility}
-                  togglePasswordVisibility={togglePasswordVisibility}
-                  handleCopy={handleCopy}
-                  getMaskedPassword={getMaskedPassword}
-                />
-              ))}
-            </TabsContent>
-          )}
-
-          {groupsByLabel.size > 0 && (
-            <TabsContent value="gruppen">
-              <Accordion
-                type="multiple"
-                defaultValue={Array.from(groupsByLabel.keys()).slice(0, 1)}
-                className="space-y-2"
-              >
-                {Array.from(groupsByLabel.entries()).map(([label, accesses]) => (
-                  <AccordionItem
-                    key={label}
-                    value={label}
-                    className="border border-slate-200 rounded-lg px-3"
-                  >
-                    <AccordionTrigger className="hover:no-underline">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-slate-900">{label}</span>
-                        <Badge variant="outline" className="text-xs">
-                          {accesses.length} {accesses.length === 1 ? "Zugang" : "Zugänge"}
-                        </Badge>
-                      </div>
-                    </AccordionTrigger>
-                    <AccordionContent className="space-y-3 pt-2">
-                      {accesses.map((access, idx) => (
-                        <AccessRow
-                          key={`${label}-${idx}`}
-                          accessKey={`${instance.instance_id}-${label}-${access.access_type}-${idx}`}
-                          access={access}
-                          passwordVisibility={passwordVisibility}
-                          togglePasswordVisibility={togglePasswordVisibility}
-                          handleCopy={handleCopy}
-                          getMaskedPassword={getMaskedPassword}
-                        />
-                      ))}
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
-              </Accordion>
-            </TabsContent>
-          )}
-        </Tabs>
-      </CardContent>
-    </Card>
-  );
-}
-
-function AccessRow({
-  accessKey,
-  access,
-  passwordVisibility,
-  togglePasswordVisibility,
-  handleCopy,
-  getMaskedPassword,
-}: {
-  accessKey: string;
-  access: AccessLike;
-  passwordVisibility: Record<string, boolean>;
-  togglePasswordVisibility: (key: string) => void;
-  handleCopy: (value: string | null | undefined, label: string) => void;
-  getMaskedPassword: (pw: string | null | undefined) => string;
-}) {
-  const accessTypeLabels: Record<string, string> = {
-    ssh: "SSH",
-    web_url: "Web URL",
-    guacamole: "Guacamole",
-    rdp: "RDP",
-    vnc: "VNC",
-    database: "Database",
-  };
-
-  const urlLabel =
-    access.access_type === "ssh" ? "SSH-Befehl" : access.access_type === "web_url" ? "URL" : "Connection URL";
-
-  const isVisible = passwordVisibility[accessKey] === true;
-
-  return (
-    <div className="rounded-lg border border-slate-200 p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h4 className="text-sm font-medium text-slate-900">
-          {accessTypeLabels[access.access_type] || access.access_type}
-        </h4>
-        <Badge variant="outline">{access.access_type}</Badge>
-      </div>
-
-      <div className="grid gap-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">Username</span>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-slate-900">{access.username ?? "-"}</span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleCopy(access.username, "Username")}
-              disabled={!access.username}
-            >
-              <Copy className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">Password</span>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-slate-900">
-              {isVisible ? access.password ?? "-" : getMaskedPassword(access.password)}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => togglePasswordVisibility(accessKey)}
-              disabled={!access.password}
-            >
-              {isVisible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleCopy(access.password, "Password")}
-              disabled={!access.password}
-            >
-              <Copy className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">{urlLabel}</span>
-          <div className="flex items-center gap-2">
-            {access.connection_url ? (
-              access.access_type === "web_url" ? (
-                <a
-                  href={access.connection_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-blue-600 hover:underline break-all"
-                >
-                  {access.connection_url}
-                </a>
-              ) : (
-                <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono">
-                  {access.connection_url}
-                </code>
-              )
-            ) : (
-              <span className="text-sm text-slate-400">-</span>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleCopy(access.connection_url, urlLabel)}
-              disabled={!access.connection_url}
-            >
-              <Copy className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">Port</span>
-          <span className="text-sm text-slate-900">{access.port ?? "-"}</span>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 // ── Phase helpers ─────────────────────────────────────────────────────────────
 

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -49,6 +49,11 @@ import {
   createDeployment,
   type DeploymentCreateRequest,
 } from "../api/deployments";
+import {
+  getMyCourses,
+  getCourseGroups,
+  createCourseGroup,
+} from "../api/courses";
 import { GroupManager, type StudentGroup } from "../components/GroupManager";
 import keycloak from "../auth/keycloak";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
@@ -142,6 +147,13 @@ export function DeploymentWizard({
   );
   const [selectedKeycloakGroupId, setSelectedKeycloakGroupId] =
     useState<string>(() => initialState?.keycloakGroupId ?? "");
+  // Interne course_id (UUID aus `courses.id` im appstore-backend), die zur
+  // ausgewählten Keycloak-Group passt. Brauchen wir, um beim Submit pro
+  // Wizard-Gruppe eine `course_groups`-Row zu erzeugen/finden und deren
+  // `id` als `course_group_id` ins Deployment-Payload zu legen — ohne
+  // diese ID können Studenten ihre Credentials nicht über /api/v1/student/
+  // sehen. Null, solange noch nicht aufgelöst oder kein Match existiert.
+  const [internalCourseId, setInternalCourseId] = useState<string | null>(null);
   const [deploymentName, setDeploymentName] = useState<string>(
     () => initialState?.deploymentName ?? "",
   );
@@ -266,6 +278,37 @@ export function DeploymentWizard({
     }
     loadKeycloakGroupMembers();
   }, [selectedKeycloakGroupId, loadKeycloakGroupMembers]);
+
+  // Resolve the internal `courses.id` for the chosen Keycloak group. We need
+  // this to create/find `course_groups` rows on submit. Falls fehlschlägt,
+  // bleibt internalCourseId null — der Wizard deployt dann ohne
+  // course_group_id (Backwards-Compat: Backend macht ein Best-Effort-Backfill
+  // über Name, aber Studenten könnten ihre Credentials verlieren).
+  useEffect(() => {
+    if (!selectedKeycloakGroupId) {
+      setInternalCourseId(null);
+      return;
+    }
+    let cancelled = false;
+    getMyCourses({
+      page: 1,
+      page_size: 200,
+      openstack_project_id: activeProjectId,
+    })
+      .then((resp) => {
+        if (cancelled) return;
+        const match = (resp.data || []).find(
+          (c) => c.keycloak_course_id === selectedKeycloakGroupId,
+        );
+        setInternalCourseId(match?.id ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setInternalCourseId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedKeycloakGroupId, activeProjectId]);
 
   // Auto-create groups and stacks when deployment mode or members change.
   // Skipped on the very first run when `initialState` was supplied (retry
@@ -871,6 +914,58 @@ export function DeploymentWizard({
         userFilesPayload[name] = base64;
       }
 
+      // Pro Wizard-Group eine course_groups-Row sicherstellen. Backend stempelt
+      // die FK dann auf alle generierten Credential-Rows, was Studenten den
+      // Zugriff via /api/v1/student/* freigibt. Ohne diesen Schritt bleibt
+      // group_id NULL und Studenten sehen nichts.
+      //
+      // Strategie: existierende course_groups holen, per Name matchen,
+      // unbekannte Namen via POST anlegen. Ein Toast/Error blockt das Deploy
+      // bewusst — wenn der Course-Group-Mechanismus kaputt ist, will der
+      // Lecturer das sofort wissen, statt erst nach dem Deploy bei Student-
+      // Reports zu merken, dass Credentials unsichtbar sind.
+      const wizardGroupToCourseGroupId = new Map<string, string>();
+      if (internalCourseId) {
+        try {
+          const existingResp = await getCourseGroups(internalCourseId);
+          const byName = new Map<string, string>();
+          for (const g of existingResp.data || []) {
+            byName.set(g.name, g.id);
+          }
+          // Sammeln aller distinct Wizard-Group-Namen (nach Group-ID, da der
+          // gleiche Name nicht mehrfach in einem Stack vorkommen sollte, aber
+          // wir bleiben defensiv).
+          const distinctWizardGroups = new Map<string, { id: string; name: string }>();
+          for (const stack of groupStackAssignments) {
+            for (const g of stack.assignedGroups) {
+              distinctWizardGroups.set(g.groupId, {
+                id: g.groupId,
+                name: g.groupName,
+              });
+            }
+          }
+          for (const wg of distinctWizardGroups.values()) {
+            const existingId = byName.get(wg.name);
+            if (existingId) {
+              wizardGroupToCourseGroupId.set(wg.id, existingId);
+              continue;
+            }
+            const created = await createCourseGroup(internalCourseId, wg.name);
+            wizardGroupToCourseGroupId.set(wg.id, created.data.id);
+            // Cache für den Fall, dass mehrere Wizard-Groups denselben Namen
+            // tragen — sollte nicht passieren, aber wir reusen die ID.
+            byName.set(wg.name, created.data.id);
+          }
+        } catch (err) {
+          console.error("Course-group resolution failed:", err);
+          setError(
+            "Die Kursgruppen konnten nicht angelegt werden. Studenten würden ihre Credentials nicht sehen — Deployment wurde abgebrochen.",
+          );
+          setIsDeploying(false);
+          return;
+        }
+      }
+
       // Build deployment request with stack assignments
       const deploymentData: DeploymentCreateRequest = {
         name: deploymentName.trim(),
@@ -887,6 +982,11 @@ export function DeploymentWizard({
           groups: stack.assignedGroups.map((group) => ({
             group_name: group.groupName,
             group_index: group.groupId ? parseInt(group.groupId.replace(/\D/g, '')) || stackIndex + 1 : stackIndex + 1,
+            // Auflösung aus dem Map oben. Null, wenn kein internalCourseId
+            // ermittelt werden konnte (kein Course für die Keycloak-Group):
+            // Backend hat dafür einen Backfill-Versuch, aber Studenten sehen
+            // ggf. nichts. Lecturer-Flow funktioniert unverändert.
+            course_group_id: wizardGroupToCourseGroupId.get(group.groupId) ?? null,
             students: group.students.map((student) => ({
               id: student.id,
               username: student.username || "",

--- a/src/pages/StudentDashboard.tsx
+++ b/src/pages/StudentDashboard.tsx
@@ -1,0 +1,225 @@
+// Student-Dashboard: listet alle Deployments, denen der eingeloggte Student
+// über eine course_groups-Mitgliedschaft zugeordnet ist. Bewusst dünner als
+// das Lecturer-Dashboard — kein OpenStack-Project-Filter (Backend filtert
+// rein über CourseMember → CourseGroup → DeploymentInstanceAccess.group_id),
+// keine Stats-Grid, keine Create/Delete/Extend-Buttons.
+import { useEffect, useState } from "react";
+import {
+  Loader2,
+  Server,
+  Calendar,
+  CheckCircle2,
+  AlertCircle,
+  Clock,
+  XCircle,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import {
+  getStudentDeployments,
+  type StudentDeploymentDto,
+} from "../api/student";
+
+interface StudentDashboardProps {
+  onSelectDeployment: (deploymentId: string) => void;
+}
+
+// Lokale Status-Badge-Map. Wir kopieren absichtlich nicht die Lecturer-
+// Logik aus DeploymentDetails (die kennt Phasen / Failed-Mix-States), weil
+// der Student-Endpoint diese Felder nicht ausliefert.
+function StatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "running":
+      return (
+        <Badge className="bg-green-100 text-green-700 hover:bg-green-100">
+          <CheckCircle2 className="w-3.5 h-3.5 mr-1.5" />
+          Läuft
+        </Badge>
+      );
+    case "queued":
+    case "creating":
+    case "deploying":
+      return (
+        <Badge className="bg-blue-100 text-blue-700 hover:bg-blue-100">
+          <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+          Wird bereitgestellt
+        </Badge>
+      );
+    case "failed":
+      return (
+        <Badge className="bg-red-100 text-red-700 hover:bg-red-100">
+          <XCircle className="w-3.5 h-3.5 mr-1.5" />
+          Fehlgeschlagen
+        </Badge>
+      );
+    case "deleting":
+    case "deleted":
+      return (
+        <Badge className="bg-slate-100 text-slate-700 hover:bg-slate-100">
+          <Clock className="w-3.5 h-3.5 mr-1.5" />
+          Wird entfernt
+        </Badge>
+      );
+    default:
+      return (
+        <Badge className="bg-slate-100 text-slate-700 hover:bg-slate-100">
+          {status}
+        </Badge>
+      );
+  }
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+export function StudentDashboard({ onSelectDeployment }: StudentDashboardProps) {
+  const [deployments, setDeployments] = useState<StudentDeploymentDto[] | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getStudentDeployments()
+      .then((data) => {
+        if (!cancelled) setDeployments(data);
+      })
+      .catch((err) => {
+        // 403 wäre theoretisch möglich (Token verloren Rolle), aber Backend
+        // gibt für legitime Studenten ohne Group-Mitgliedschaft 200 + leere
+        // Liste. Wir mappen also einen 403/401 auf Auth-Fehler, alles andere
+        // auf generischen Fehlertext.
+        const status = (err as { status?: number })?.status;
+        if (status === 401 || status === 403) {
+          setError(
+            "Du bist nicht (mehr) als Student angemeldet — bitte erneut einloggen.",
+          );
+        } else {
+          setError("Deployments konnten nicht geladen werden.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="p-6 lg:p-10 max-w-5xl mx-auto space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold text-slate-900">
+          Meine Deployments
+        </h1>
+        <p className="text-sm text-slate-500">
+          Hier siehst du alle Umgebungen, die dir dein Dozent zugewiesen hat.
+        </p>
+      </header>
+
+      {loading && (
+        <Card className="border-slate-200">
+          <CardContent className="py-10 flex items-center justify-center gap-2 text-slate-500">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span className="text-sm">Lade Deployments...</span>
+          </CardContent>
+        </Card>
+      )}
+
+      {!loading && error && (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="py-6 flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
+            <div className="space-y-2 flex-1">
+              <p className="text-sm text-red-700">{error}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => window.location.reload()}
+              >
+                Erneut versuchen
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {!loading && !error && deployments && deployments.length === 0 && (
+        // Empty-State: laut Briefing ist eine leere Liste ein erwarteter
+        // 200-Response. Nicht als Fehler darstellen.
+        <Card className="border-slate-200">
+          <CardContent className="py-12 text-center space-y-2">
+            <Server className="w-10 h-10 text-slate-400 mx-auto" />
+            <p className="text-sm text-slate-700 font-medium">
+              Aktuell keine Deployments für dich verfügbar.
+            </p>
+            <p className="text-xs text-slate-500">
+              Du bist noch in keiner Gruppe eines Deployments — bitte wende dich
+              an deinen Dozenten.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {!loading && !error && deployments && deployments.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {deployments.map((d) => (
+            <Card
+              key={d.id}
+              className="border-slate-200 hover:border-teal-300 hover:shadow-md transition cursor-pointer"
+              onClick={() => onSelectDeployment(d.id)}
+            >
+              <CardHeader>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <CardTitle className="text-base truncate">
+                      {d.name}
+                    </CardTitle>
+                    <CardDescription className="truncate">
+                      {d.template.name || "Template"}
+                      {d.template.version ? ` · v${d.template.version}` : ""}
+                    </CardDescription>
+                  </div>
+                  <StatusBadge status={d.status} />
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <div className="flex items-center gap-2 text-xs text-slate-500">
+                  <Server className="w-3.5 h-3.5" />
+                  <span>
+                    {d.instances.length}{" "}
+                    {d.instances.length === 1 ? "VM" : "VMs"}
+                  </span>
+                </div>
+                {d.expires_at && (
+                  <div className="flex items-center gap-2 text-xs text-slate-500">
+                    <Calendar className="w-3.5 h-3.5" />
+                    <span>Läuft ab am {formatDate(d.expires_at)}</span>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/StudentDashboardPage.tsx
+++ b/src/pages/StudentDashboardPage.tsx
@@ -1,0 +1,11 @@
+import { useNavigate } from "react-router-dom";
+import { StudentDashboard } from "./StudentDashboard";
+
+export function StudentDashboardPage() {
+  const navigate = useNavigate();
+  return (
+    <StudentDashboard
+      onSelectDeployment={(id) => navigate(`/student/deployment/${id}`)}
+    />
+  );
+}

--- a/src/pages/StudentDeploymentDetails.tsx
+++ b/src/pages/StudentDeploymentDetails.tsx
@@ -1,0 +1,337 @@
+// Student-Detailansicht eines Deployments. Zeigt:
+// - VM-Liste mit Status und IP
+// - Eigene Group-Credentials (eingeschränkter mode der geteilten
+//   CredentialInstanceCard — kein Dozent-Tab)
+//
+// Bewusst weggelassen ggü. der Lecturer-Ansicht: Logs/SSE, Extend-Button,
+// Delete-Button, Retry-Wizard, Phasen-Tracker, Stats-Karten. Studenten
+// dürfen das alles nicht und das Backend würde es ihnen ohnehin als 403
+// liefern.
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  Loader2,
+  Server,
+  AlertCircle,
+  Calendar,
+} from "lucide-react";
+import { toast } from "sonner@2.0.3";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
+import {
+  getStudentDeployments,
+  getStudentDeploymentCredentials,
+  downloadStudentSshKey,
+  type StudentDeploymentDto,
+} from "../api/student";
+import type { DeploymentCredentialsResponse } from "../api/deployments";
+import { CredentialInstanceCard } from "../components/credentials/CredentialInstanceCard";
+
+interface StudentDeploymentDetailsProps {
+  deploymentId: string;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "-";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "-";
+  return d.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+export function StudentDeploymentDetails({
+  deploymentId,
+}: StudentDeploymentDetailsProps) {
+  const navigate = useNavigate();
+
+  // Backend liefert keinen Single-Endpoint /student/deployments/{id} —
+  // wir holen die ganze Liste und filtern lokal. Klein genug (Student sieht
+  // typischerweise <10 Deployments), kein Round-Trip-Optimum nötig.
+  const [deployment, setDeployment] = useState<StudentDeploymentDto | null>(
+    null,
+  );
+  const [deploymentLoading, setDeploymentLoading] = useState(true);
+  const [deploymentError, setDeploymentError] = useState<string | null>(null);
+
+  const [credentialsData, setCredentialsData] =
+    useState<DeploymentCredentialsResponse | null>(null);
+  const [credentialsLoading, setCredentialsLoading] = useState(false);
+  const [credentialsError, setCredentialsError] = useState<string | null>(null);
+  const [passwordVisibility, setPasswordVisibility] = useState<
+    Record<string, boolean>
+  >({});
+
+  useEffect(() => {
+    let cancelled = false;
+    setDeploymentLoading(true);
+    setDeploymentError(null);
+    getStudentDeployments()
+      .then((list) => {
+        if (cancelled) return;
+        const found = list.find((d) => d.id === deploymentId);
+        if (!found) {
+          setDeploymentError(
+            "Dieses Deployment ist nicht (mehr) für dich freigegeben.",
+          );
+          return;
+        }
+        setDeployment(found);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDeploymentError("Deployment konnte nicht geladen werden.");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setDeploymentLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [deploymentId]);
+
+  const loadCredentials = useCallback(async () => {
+    if (credentialsLoading) return;
+    setCredentialsLoading(true);
+    setCredentialsError(null);
+    try {
+      const data = await getStudentDeploymentCredentials(deploymentId);
+      setCredentialsData(data);
+    } catch (err) {
+      const status = (err as { status?: number })?.status;
+      if (status === 403) {
+        setCredentialsError(
+          "Du gehörst zu keiner Gruppe dieses Deployments mehr.",
+        );
+      } else if (status === 404) {
+        setCredentialsError("Deployment nicht gefunden.");
+      } else {
+        setCredentialsError("Credentials konnten nicht geladen werden.");
+      }
+    } finally {
+      setCredentialsLoading(false);
+    }
+  }, [credentialsLoading, deploymentId]);
+
+  // Credentials sofort laden, sobald wir das Deployment kennen — Studenten
+  // sind ausschließlich wegen der Credentials hier, kein extra Klick nötig.
+  useEffect(() => {
+    if (deployment && !credentialsData && !credentialsLoading && !credentialsError) {
+      void loadCredentials();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deployment]);
+
+  const handleCopy = useCallback(async (value: string | null | undefined, label: string) => {
+    if (!value) {
+      toast.error("Kein Wert zum Kopieren vorhanden.");
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success(`${label} kopiert.`);
+    } catch {
+      toast.error("Kopieren fehlgeschlagen.");
+    }
+  }, []);
+
+  const togglePasswordVisibility = (key: string) => {
+    setPasswordVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const getMaskedPassword = (value: string | null | undefined) => {
+    if (!value) return "-";
+    return "*".repeat(Math.max(8, value.length));
+  };
+
+  const handleDownloadSshKey = useCallback(
+    async (accessId: string, username: string | null) => {
+      try {
+        await downloadStudentSshKey(deploymentId, accessId, username);
+        toast.success("SSH-Key heruntergeladen.");
+      } catch (err) {
+        const status = (err as { status?: number })?.status;
+        if (status === 403) {
+          toast.error("Du hast keinen Zugriff auf diesen SSH-Key.");
+        } else if (status === 404) {
+          toast.error("Für diesen Zugang ist kein SSH-Key hinterlegt.");
+        } else {
+          toast.error("Download fehlgeschlagen.");
+        }
+      }
+    },
+    [deploymentId],
+  );
+
+  return (
+    <div className="p-6 lg:p-10 max-w-5xl mx-auto space-y-6">
+      <button
+        type="button"
+        onClick={() => navigate("/student/dashboard")}
+        className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Zurück zur Übersicht
+      </button>
+
+      {deploymentLoading && (
+        <Card className="border-slate-200">
+          <CardContent className="py-10 flex items-center justify-center gap-2 text-slate-500">
+            <Loader2 className="w-4 h-4 animate-spin" />
+            <span className="text-sm">Lade Deployment...</span>
+          </CardContent>
+        </Card>
+      )}
+
+      {!deploymentLoading && deploymentError && (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="py-6 flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
+            <div className="space-y-2 flex-1">
+              <p className="text-sm text-red-700">{deploymentError}</p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate("/student/dashboard")}
+              >
+                Zur Übersicht
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {!deploymentLoading && !deploymentError && deployment && (
+        <>
+          <header className="space-y-1">
+            <h1 className="text-2xl font-semibold text-slate-900">
+              {deployment.name}
+            </h1>
+            <p className="text-sm text-slate-500">
+              {deployment.template.name || "Template"}
+              {deployment.template.version
+                ? ` · v${deployment.template.version}`
+                : ""}
+            </p>
+            {deployment.expires_at && (
+              <p className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+                <Calendar className="w-3.5 h-3.5" />
+                Läuft ab am {formatDate(deployment.expires_at)}
+              </p>
+            )}
+          </header>
+
+          {/* VMs / Instances */}
+          <Card className="border-slate-200">
+            <CardHeader>
+              <CardTitle className="text-base">Virtuelle Maschinen</CardTitle>
+              <CardDescription>
+                {deployment.instances.length} VM
+                {deployment.instances.length === 1 ? "" : "s"} sind dir
+                zugewiesen.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {deployment.instances.length === 0 && (
+                <p className="text-sm text-slate-500">
+                  Aktuell keine VMs verfügbar.
+                </p>
+              )}
+              {deployment.instances.map((inst) => (
+                <div
+                  key={inst.id}
+                  className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Server className="w-4 h-4 text-slate-400 shrink-0" />
+                    <span className="text-sm text-slate-900 truncate">
+                      {inst.vm_name || inst.id}
+                    </span>
+                  </div>
+                  {inst.ip_address ? (
+                    <Badge variant="outline" className="font-mono text-xs">
+                      {inst.ip_address}
+                    </Badge>
+                  ) : (
+                    <span className="text-xs text-slate-400">keine IP</span>
+                  )}
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          {/* Credentials */}
+          <Card className="border-slate-200">
+            <CardHeader>
+              <CardTitle className="text-base">Deine Zugangsdaten</CardTitle>
+              <CardDescription>
+                Username/Passwort und SSH-Keys deiner Gruppe.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {credentialsLoading && (
+                <div className="flex items-center gap-2 text-slate-500">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span className="text-sm">Credentials werden geladen...</span>
+                </div>
+              )}
+
+              {!credentialsLoading && credentialsError && (
+                <div className="space-y-3">
+                  <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+                    <span className="text-sm text-red-700">
+                      {credentialsError}
+                    </span>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={loadCredentials}>
+                    Erneut versuchen
+                  </Button>
+                </div>
+              )}
+
+              {!credentialsLoading &&
+                !credentialsError &&
+                credentialsData &&
+                credentialsData.instances.length === 0 && (
+                  <p className="text-sm text-slate-500">
+                    Aktuell keine Credentials für dich verfügbar.
+                  </p>
+                )}
+
+              {!credentialsLoading &&
+                !credentialsError &&
+                credentialsData &&
+                credentialsData.instances.length > 0 && (
+                  <div className="space-y-4">
+                    {credentialsData.instances.map((instance) => (
+                      <CredentialInstanceCard
+                        key={instance.instance_id}
+                        instance={instance}
+                        mode="student"
+                        passwordVisibility={passwordVisibility}
+                        togglePasswordVisibility={togglePasswordVisibility}
+                        handleCopy={handleCopy}
+                        getMaskedPassword={getMaskedPassword}
+                        onDownloadSshKey={handleDownloadSshKey}
+                      />
+                    ))}
+                  </div>
+                )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/StudentDeploymentDetailsPage.tsx
+++ b/src/pages/StudentDeploymentDetailsPage.tsx
@@ -1,0 +1,10 @@
+import { useParams, Navigate } from "react-router-dom";
+import { StudentDeploymentDetails } from "./StudentDeploymentDetails";
+
+export function StudentDeploymentDetailsPage() {
+  const { deploymentId } = useParams<{ deploymentId: string }>();
+  if (!deploymentId) {
+    return <Navigate to="/student/dashboard" replace />;
+  }
+  return <StudentDeploymentDetails deploymentId={deploymentId} />;
+}


### PR DESCRIPTION
…d im Wizard

- useCurrentUser/Sidebar/App: isStudent-Rolle erkennen, reine Studenten überspringen das OpenStack-Setup-Gate und bekommen einen eigenen Routes- Block (/student/dashboard, /student/deployment/:id). Lecturer/Admin auf /student/* werden zurück aufs Dashboard geschickt.

- src/api/student.ts: drei Wrapper für GET /student/deployments, GET /student/deployments/{id}/credentials und den dedizierten /access/{id}/ssh-key-PEM-Endpoint (mit Token-Refresh vor dem Stream und Content-Disposition-Filename).

- StudentDashboard + StudentDeploymentDetails: getrimmte Views ohne Delete/Extend/Logs. Empty-State für Studenten ohne Group, 403/404 sauber abgefangen. Credentials werden direkt geladen (kein Anzeigen-Button).

- Credentials-Renderer (CredentialInstanceCard/AccessRow) aus DeploymentDetails in components/credentials extrahiert; mode='lecturer' zeigt Dozent+Gruppen-Tabs, mode='student' nur das Gruppen-Accordion. Im Student-Mode triggert der SSH-Download den dedizierten Backend- Endpoint statt das ssh_private_key-Feld inline zu lesen.

- DeploymentCreateRequest.stack_assignments[].groups[].course_group_id als optionales Feld ergänzt. CredentialAccess um id + ssh_private_key erweitert (matched Backend-Schema).

- DeploymentWizard: löst beim Group-Wechsel die interne course_id über getMyCourses (Match auf keycloak_course_id) auf. Im handleDeploy wird pro Wizard-Group eine course_groups-Row sichergestellt (Name-Match, sonst POST), und die ID als course_group_id ins Payload geschrieben. Fehlschlag der Auto-Create-Phase blockt das Deploy statt still ohne course_group_id durchzulaufen — sonst sehen Studenten ihre Credentials nicht und der Lecturer merkt es erst hinterher.