### PR TITLE
SSH-Key-Support für Deployment-Credentials (#104)

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -61,9 +61,18 @@ export type AccessType =
   | "database";
 
 export type CredentialAccess = {
+  // Backend-Primärschlüssel des Access-Eintrags. Wird für die SSH-Key-
+  // Download-URL gebraucht. Bei sehr alten Responses (vor Schema-Erweiterung)
+  // kann das Feld fehlen — wir behandeln das defensiv und blenden den
+  // Download-Button dann aus.
+  id?: string | null;
   access_type: AccessType;
   username: string | null;
   password: string | null;
+  // PEM-encoded OpenSSH private key (mehrzeilig). `null` bei Deployments, die
+  // vor dem SSH-Key-Feature angelegt wurden oder bei Group-Accesses ohne
+  // `ssh_key: generate` in der app.yaml.
+  ssh_private_key?: string | null;
   connection_url: string | null;
   port: number | null;
 };
@@ -256,6 +265,67 @@ export async function deleteDeployment(deploymentId: string, openstackProjectId:
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(text || res.statusText);
+  }
+}
+
+/**
+ * Lädt den SSH Private Key eines Access-Eintrags als `.pem`-Datei in den
+ * Browser. Backend gibt das PEM als `application/x-pem-file` mit
+ * `Content-Disposition: attachment; filename="id_ed25519_<user>"` zurück. Wir
+ * parsen den Dateinamen, fallen sonst auf `id_ed25519_<username|access>.pem`
+ * zurück und triggern den Browser-Download über ein temporäres Anchor-Element
+ * (gleiches Pattern wie der existierende Logs/Credentials-Markdown-Export).
+ *
+ * Wirft ein `Error` mit numerischem `.status`, damit der Caller 400/403/404
+ * unterscheiden kann (z. B. „kein Key gesetzt" vs. „keine Berechtigung").
+ */
+export async function downloadSshKey(
+  deploymentId: string,
+  accessId: string,
+  openstackProjectId: string | null,
+  fallbackUsername: string | null,
+): Promise<void> {
+  await keycloak.updateToken(30).catch(() => {});
+  const res = await fetch(
+    `/api/v1/deployments/${deploymentId}/credentials/access/${accessId}/ssh-key${projectQuery(openstackProjectId)}`,
+    {
+      method: "GET",
+      headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    const err = new Error(text || res.statusText) as Error & { status?: number };
+    err.status = res.status;
+    throw err;
+  }
+
+  const disposition = res.headers.get("content-disposition") || "";
+  // Content-Disposition: attachment; filename="id_ed25519_lecturer"
+  // Quoted und unquoted Varianten abdecken; `.pem`-Suffix nachziehen, damit
+  // Editoren das File als PEM erkennen.
+  let filename = "";
+  const match = disposition.match(/filename\*?=(?:UTF-8'')?\"?([^\";]+)\"?/i);
+  if (match?.[1]) filename = decodeURIComponent(match[1]).trim();
+  if (!filename) {
+    const safeUser = (fallbackUsername || "user").replace(/[^a-zA-Z0-9._-]+/g, "_");
+    filename = `id_ed25519_${safeUser}`;
+  }
+  if (!/\.pem$/i.test(filename)) filename += ".pem";
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    // setTimeout, damit Safari/Firefox die Blob-URL nicht revoken, bevor der
+    // Download gestartet wurde.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   }
 }
 

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import React from "react";
 import {
   CheckCircle2,
@@ -19,6 +19,8 @@ import {
   AlertTriangle,
   AlertOctagon,
   Calendar,
+  Key,
+  ShieldCheck,
 } from "lucide-react";
 import { toast } from "sonner@2.0.3";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
@@ -48,11 +50,13 @@ import {
   DeploymentLogDto,
   getDeploymentCredentials,
   extendDeployment,
+  downloadSshKey,
   type RuntimeMonths,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
 import { getExpiryState } from "../utils/deployment";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
+import keycloak from "../auth/keycloak";
 
 interface DeploymentStep {
   id: string;
@@ -103,6 +107,13 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
   const [credentialsError, setCredentialsError] = useState<string | null>(null);
   const [credentialsData, setCredentialsData] = useState<DeploymentCredentialsResponse | null>(null);
   const [passwordVisibility, setPasswordVisibility] = useState<Record<string, boolean>>({});
+  // Pro Access-Eintrag merken wir uns, ob die mehrzeilige PEM bereits inline
+  // aufgeklappt wurde. Standard: zugeklappt — die meisten Nutzer wollen den
+  // Download-Button, nicht den rohen PEM-Text.
+  const [sshKeyVisibility, setSshKeyVisibility] = useState<Record<string, boolean>>({});
+  // Welche Downloads gerade fliegen (Access-ID → in-flight). Verhindert
+  // Doppelklicks und lässt uns einen Spinner pro Zeile anzeigen.
+  const [sshKeyDownloading, setSshKeyDownloading] = useState<Record<string, boolean>>({});
   // Inline extend-action state (B6). Pessimistic: button disabled while
   // request flies, error shown via toast, success refreshes the page so the
   // new expires_at lands in `deployment` via the parent's data loader.
@@ -183,6 +194,55 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
     }));
   };
 
+  const toggleSshKeyVisibility = (key: string) => {
+    setSshKeyVisibility((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  // Username des eingeloggten Lecturers — Heuristik für „dies ist der
+  // Admin-Eintrag" laut Briefing. Wenn der `username` eines Access-Eintrags
+  // dem Lecturer entspricht (z. B. `lecturer`), zeigen wir das als
+  // Admin-Zugang an. Backend liefert (noch) kein explizites `is_admin`-Flag.
+  const currentUsername = useMemo<string | null>(() => {
+    const t = (keycloak?.tokenParsed ?? {}) as Record<string, any>;
+    const u = (t.preferred_username || "").toString().trim();
+    return u || null;
+  }, []);
+
+  const handleDownloadSshKey = useCallback(
+    async (accessId: string, username: string | null) => {
+      setSshKeyDownloading((prev) => ({ ...prev, [accessId]: true }));
+      try {
+        await downloadSshKey(deployment.id, accessId, activeProjectId, username);
+        toast.success("SSH-Key heruntergeladen.");
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        if (status === 400) {
+          toast.error("openstack_project_id fehlt — bitte Projekt wählen.");
+        } else if (status === 401) {
+          toast.error("Session abgelaufen — bitte erneut anmelden.");
+        } else if (status === 403) {
+          toast.error("Keine Berechtigung für diesen SSH-Key.");
+        } else if (status === 404) {
+          // Im 404-Fall kann der Backend-Detail-Text zwischen „Deployment
+          // nicht gefunden", „Access-Eintrag nicht gefunden" und „kein SSH-
+          // Key hinterlegt" unterscheiden — wir können das hier nicht
+          // sauber auseinanderhalten, also bleibt es bei einer allgemeinen
+          // Meldung. Der häufigste Fall (alte Deployments) ist „kein Key".
+          toast.error("Für diesen Zugang ist kein SSH-Key hinterlegt.");
+        } else {
+          toast.error("SSH-Key-Download fehlgeschlagen.");
+        }
+      } finally {
+        setSshKeyDownloading((prev) => {
+          const next = { ...prev };
+          delete next[accessId];
+          return next;
+        });
+      }
+    },
+    [deployment.id, activeProjectId],
+  );
+
   const getMaskedPassword = (value: string | null) => {
     if (!value) return "-";
     return "*".repeat(Math.max(8, value.length));
@@ -231,14 +291,20 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
         const accessBlocks = instance.accesses
           .map((access) => {
             const title = accessTypeLabels[access.access_type] || access.access_type;
-            return [
+            const lines: string[] = [
               title,
               `Username: ${access.username ?? "-"}`,
               `Password: ${access.password ?? "-"}`,
               `Connection URL: ${access.connection_url ?? "-"}`,
               `Port: ${access.port ?? "-"}`,
-              "",
-            ].join("\n");
+            ];
+            // PEM nur exportieren, wenn vorhanden — sonst landen massenhaft
+            // „SSH Private Key: -"-Zeilen im Markdown.
+            if (access.ssh_private_key) {
+              lines.push("SSH Private Key:", access.ssh_private_key);
+            }
+            lines.push("");
+            return lines.join("\n");
           })
           .join("\n");
 
@@ -829,13 +895,46 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                         {instance.accesses.map((access, index) => {
                           const accessKey = `${instance.instance_id}-${access.access_type}-${index}`;
                           const isVisible = passwordVisibility[accessKey] === true;
+                          // SSH-Key-State pro Zeile. Wir bevorzugen die echte
+                          // Access-ID als Schlüssel (vom Backend stabil), fallen
+                          // aber auf accessKey zurück, wenn die ID (noch) fehlt
+                          // — z. B. wenn ein älterer Backend-Build geladen ist.
+                          const sshKeyKey = access.id || accessKey;
+                          const sshKeyVisible = sshKeyVisibility[sshKeyKey] === true;
+                          const sshKeyAvailable =
+                            access.access_type === "ssh" &&
+                            !!access.ssh_private_key &&
+                            access.ssh_private_key.length > 0;
+                          // Admin-Heuristik: der Eintrag, dessen username dem
+                          // eingeloggten Lecturer entspricht. Bewusst case-
+                          // insensitive, da Keycloak preferred_username
+                          // gelegentlich klein-, OpenStack-User aber Original-
+                          // Casing trägt.
+                          const isAdminAccess =
+                            access.access_type === "ssh" &&
+                            !!currentUsername &&
+                            !!access.username &&
+                            access.username.toLowerCase() === currentUsername.toLowerCase();
+                          const sshDownloadInFlight = !!sshKeyDownloading[sshKeyKey];
 
                           return (
                             <div key={accessKey} className="rounded-lg border border-slate-200 p-4 space-y-3">
-                              <div className="flex items-center justify-between">
-                                <h4 className="text-sm font-medium text-slate-900">
-                                  {accessTypeLabels[access.access_type] || access.access_type}
-                                </h4>
+                              <div className="flex items-center justify-between gap-2">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <h4 className="text-sm font-medium text-slate-900">
+                                    {accessTypeLabels[access.access_type] || access.access_type}
+                                  </h4>
+                                  {isAdminAccess && (
+                                    <Badge
+                                      variant="default"
+                                      className="bg-teal-100 text-teal-700 hover:bg-teal-100 gap-1"
+                                      title="Dieser Eintrag ist dein Dozenten-Zugang. SSH-Key gibt dir sudo-Rechte auf der VM."
+                                    >
+                                      <ShieldCheck className="w-3 h-3" />
+                                      Admin
+                                    </Badge>
+                                  )}
+                                </div>
                                 <Badge variant="outline">{access.access_type}</Badge>
                               </div>
 
@@ -926,6 +1025,74 @@ export function DeploymentDetails({ deployment, onBack, onDelete }: DeploymentDe
                                     {access.port ?? "-"}
                                   </span>
                                 </div>
+
+                                {access.access_type === "ssh" && sshKeyAvailable && (
+                                  <div className="space-y-2 pt-2 border-t border-slate-100">
+                                    <div className="flex flex-wrap items-center justify-between gap-2">
+                                      <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+                                        <Key className="w-3.5 h-3.5" />
+                                        SSH Private Key
+                                        {isAdminAccess && (
+                                          <span className="text-slate-400">· Admin-Zugang</span>
+                                        )}
+                                      </span>
+                                      <div className="flex items-center gap-2">
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          onClick={() => toggleSshKeyVisibility(sshKeyKey)}
+                                          title={sshKeyVisible ? "Key ausblenden" : "Key anzeigen"}
+                                        >
+                                          {sshKeyVisible ? (
+                                            <EyeOff className="w-4 h-4" />
+                                          ) : (
+                                            <Eye className="w-4 h-4" />
+                                          )}
+                                        </Button>
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          onClick={() => handleCopy(access.ssh_private_key ?? null, "SSH Private Key")}
+                                          disabled={!access.ssh_private_key}
+                                          title="In Zwischenablage kopieren"
+                                        >
+                                          <Copy className="w-4 h-4" />
+                                        </Button>
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          onClick={() => {
+                                            // Ohne id können wir den dedizierten
+                                            // Download-Endpoint nicht aufrufen
+                                            // (URL braucht die access_id). In dem
+                                            // unwahrscheinlichen Fall (alter
+                                            // Response-Build) blocken wir und
+                                            // weisen den Nutzer auf den Inline-
+                                            // Copy-Pfad hin.
+                                            if (!access.id) {
+                                              toast.error("Download nicht möglich (fehlende Access-ID). Bitte Copy benutzen.");
+                                              return;
+                                            }
+                                            void handleDownloadSshKey(access.id, access.username);
+                                          }}
+                                          disabled={!access.id || sshDownloadInFlight}
+                                          title="Als .pem-Datei herunterladen"
+                                        >
+                                          {sshDownloadInFlight ? (
+                                            <Loader2 className="w-4 h-4 animate-spin" />
+                                          ) : (
+                                            <Download className="w-4 h-4" />
+                                          )}
+                                        </Button>
+                                      </div>
+                                    </div>
+                                    {sshKeyVisible && (
+                                      <pre className="text-xs bg-slate-50 border border-slate-200 rounded-md p-3 font-mono whitespace-pre-wrap break-all overflow-x-auto max-h-64">
+{access.ssh_private_key}
+                                      </pre>
+                                    )}
+                                  </div>
+                                )}
                               </div>
                             </div>
                           );


### PR DESCRIPTION
Closes #104

## Was kommt rein

Backend hat im Credentials-Response zwei neue Felder pro Access-Eintrag (\`id\`, \`ssh_private_key\`) und einen dedizierten Download-Endpoint \`GET /deployments/{id}/credentials/access/{access_id}/ssh-key\`. Frontend ziehe ich nach.

## Änderungen

### \`src/api/deployments.ts\`
- \`CredentialAccess\` um \`id?: string | null\` und \`ssh_private_key?: string | null\` erweitert (beide optional, damit alte Backend-Builds das Frontend nicht brechen).
- Neue Funktion \`downloadSshKey(deploymentId, accessId, openstackProjectId, fallbackUsername)\`:
  - Triggert den Backend-Download-Endpoint mit Bearer-Token + \`?openstack_project_id\`.
  - Parst den Dateinamen aus \`Content-Disposition\`, fällt sonst auf \`id_ed25519_<user>.pem\` zurück.
  - Wirft \`Error\` mit numerischem \`.status\`, damit der Caller 400/401/403/404 unterscheiden kann.

### \`src/pages/DeploymentDetails.tsx\`
- Pro SSH-Access (nur sichtbar, wenn \`ssh_private_key\` gesetzt — alte Deployments bleiben unverändert):
  - **Eye/EyeOff**: PEM inline anzeigen (monospace, max. 256px Höhe, scrollbar).
  - **Copy**: PEM in Zwischenablage.
  - **Download**: \`.pem\`-Datei, mit Loader-Spinner während Request und Status-spezifischen Fehler-Toasts.
- **Admin-Heuristik**: Access-Eintrag, dessen \`username\` zum eingeloggten Lecturer (Keycloak \`preferred_username\`) passt, bekommt einen teal \`ShieldCheck\`-Badge mit Tooltip „sudo auf der VM". Backend liefert (noch) kein explizites \`is_admin\`-Flag — falls die Heuristik in der Praxis unstabil ist, ergänzen wir das im Schema nach.
- Markdown-Export (\"Credentials kopieren\"-Action) inkludiert den PEM-Block nur, wenn vorhanden.

## Backward-Compat

- Alte Deployments → \`ssh_private_key === null\` → SSH-Key-Sektion wird gar nicht gerendert.
- Sehr alter Backend-Build ohne \`id\` im Access-Response → Download-Button disabled + Toast „bitte Copy benutzen". Inline-Anzeige + Copy funktionieren weiterhin.

## Fehler-Handling

| HTTP | Toast |
|---|---|
| 400 | \"openstack_project_id fehlt — bitte Projekt wählen.\" |
| 401 | \"Session abgelaufen — bitte erneut anmelden.\" |
| 403 | \"Keine Berechtigung für diesen SSH-Key.\" |
| 404 | \"Für diesen Zugang ist kein SSH-Key hinterlegt.\" |

## Verification

- \`npm run lint\` → 0 errors (31 pre-existing warnings, keine neuen).
- \`npm run build\` → sauber (1.63s).
- Manuell pending — bitte testen:
  - [ ] Neues Deployment mit \`ssh_key: generate\` → Lecturer-Eintrag bekommt Admin-Badge, Download liefert PEM mit Filename aus Backend.
  - [ ] Altes Deployment ohne Keys → keine SSH-Sektion, keine Console-Fehler.
  - [ ] \`/api/v1/deployments/{id}/credentials/access/{access_id}/ssh-key?openstack_project_id=...\` im Network-Tab sichtbar, Token im Authorization-Header.