### PR TITLE
SSH-Key-Support für Deployment-Credentials (#104)

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -306,6 +306,71 @@ export async function deleteDeployment(deploymentId: string, openstackProjectId:
   }
 }
 
+/**
+ * Lädt den SSH Private Key eines Access-Eintrags als `.pem`-Datei. Lecturer-
+ * Variante des Endpoints — Pendant zu `downloadStudentSshKey` in
+ * `api/student.ts`. Beide haben identische Response-Form
+ * (`application/x-pem-file` + `Content-Disposition: attachment; filename=...`),
+ * unterscheiden sich nur im Pfad und darin, dass dieser hier
+ * `openstack_project_id` als Query-Param mitschickt.
+ *
+ * Wirft `Error` mit numerischem `.status`, damit der Caller 400/401/403/404
+ * unterscheiden kann — der Backend-Detail-Text in `.body` ist im 404er für
+ * UX-Toasts brauchbar (Deployment vs. Access vs. „kein Key hinterlegt").
+ */
+export async function downloadSshKey(
+  deploymentId: string,
+  accessId: string,
+  openstackProjectId: string | null,
+  fallbackUsername?: string | null,
+): Promise<void> {
+  // Token vor dem Stream erneuern — das Backend liefert sonst ggf. eine
+  // 0-Byte-Datei nach erstem Read, weil Auth erst beim Streamstart greift.
+  await keycloak.updateToken(30).catch(() => {});
+  const res = await fetch(
+    `/api/v1/deployments/${deploymentId}/credentials/access/${accessId}/ssh-key${projectQuery(openstackProjectId)}`,
+    {
+      method: "GET",
+      headers: keycloak.token ? { Authorization: `Bearer ${keycloak.token}` } : {},
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    const err = new Error(text || res.statusText) as Error & {
+      status: number;
+      body: string;
+    };
+    err.status = res.status;
+    err.body = text;
+    throw err;
+  }
+
+  // Dateiname bevorzugt aus Content-Disposition ziehen
+  // (`attachment; filename="id_ed25519_<user>"`). Fallback baut den Namen aus
+  // dem Username/Access-ID — verhindert das generische "download" im Browser.
+  const disposition = res.headers.get("content-disposition") || "";
+  let filename = "";
+  const match = disposition.match(/filename\*?=(?:UTF-8'')?["']?([^"';]+)["']?/i);
+  if (match?.[1]) {
+    filename = decodeURIComponent(match[1]);
+  }
+  if (!filename) {
+    const safeUser = (fallbackUsername || "").replace(/[^a-zA-Z0-9_.-]/g, "_");
+    filename = safeUser ? `id_ed25519_${safeUser}` : `id_ed25519_${accessId}`;
+  }
+
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
 // List deployments (stacks) from OpenStack view
 type DeploymentsListEnvelope = {
   success: boolean;

--- a/src/components/credentials/CredentialInstanceCard.tsx
+++ b/src/components/credentials/CredentialInstanceCard.tsx
@@ -14,7 +14,8 @@
 //    sowieso raus; wir bleiben defensiv und erwarten group_id != null in
 //    allen rows). SSH-Key-Download geht über onDownloadSshKey-Prop, die
 //    den dedizierten /access/{id}/ssh-key-Endpoint anstößt.
-import { Copy, Download, Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+import { Copy, Download, Eye, EyeOff, Key, Loader2, ShieldCheck } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -59,8 +60,26 @@ export interface CredentialInstanceCardProps {
    * der die Funktion mit (accessId, username) aufruft. Im Student-Mode
    * unbedingt setzen — dort gibt's keinen eingebetteten ssh_private_key
    * im Bundle-Download, der dedizierte Endpoint ist der einzige Pfad.
+   *
+   * Im Lecturer-Mode ebenfalls setzen, sobald wir den `/access/{id}/ssh-key`-
+   * Endpoint nutzen wollen — er liefert den PEM-Body via Browser-Download
+   * statt über das eingebettete Feld. Inline-Anzeige + Copy funktionieren
+   * unabhängig vom Handler (greifen direkt auf `access.ssh_private_key`).
+   *
+   * Darf eine `Promise` zurückgeben — die Row zeigt während des Requests
+   * einen Spinner, damit der Nutzer keinen Doppelklick auslöst.
    */
-  onDownloadSshKey?: (accessId: string, username: string | null) => void;
+  onDownloadSshKey?: (
+    accessId: string,
+    username: string | null,
+  ) => void | Promise<void>;
+  /**
+   * Username des eingeloggten Lecturers (Keycloak `preferred_username`).
+   * Wird als Heuristik für „dies ist der Admin-Zugang" verwendet — das
+   * Backend liefert (noch) kein explizites `is_admin`-Flag, also matchen
+   * wir case-insensitive gegen `access.username`. Im Student-Mode irrelevant.
+   */
+  currentUsername?: string | null;
 }
 
 export function CredentialInstanceCard({
@@ -71,6 +90,7 @@ export function CredentialInstanceCard({
   handleCopy,
   getMaskedPassword,
   onDownloadSshKey,
+  currentUsername,
 }: CredentialInstanceCardProps) {
   // Lecturer-View: Dozent-Zeilen (group_id IS NULL) vs. Gruppen-Zeilen.
   // Student-View: alle Zeilen sind Gruppen-Zeilen (Backend filtert NULL aus),
@@ -142,6 +162,7 @@ export function CredentialInstanceCard({
                     handleCopy={handleCopy}
                     getMaskedPassword={getMaskedPassword}
                     onDownloadSshKey={onDownloadSshKey}
+                    currentUsername={currentUsername}
                   />
                 ))}
               </TabsContent>
@@ -157,6 +178,7 @@ export function CredentialInstanceCard({
                   handleCopy={handleCopy}
                   getMaskedPassword={getMaskedPassword}
                   onDownloadSshKey={onDownloadSshKey}
+                  currentUsername={currentUsername}
                 />
               </TabsContent>
             )}
@@ -170,6 +192,7 @@ export function CredentialInstanceCard({
             handleCopy={handleCopy}
             getMaskedPassword={getMaskedPassword}
             onDownloadSshKey={onDownloadSshKey}
+            currentUsername={currentUsername}
           />
         ) : (
           <p className="text-sm text-slate-500">Keine Zugänge verfügbar.</p>
@@ -187,6 +210,7 @@ function GroupAccordion({
   handleCopy,
   getMaskedPassword,
   onDownloadSshKey,
+  currentUsername,
 }: {
   groupsByLabel: Map<string, CredentialAccess[]>;
   instanceId: string;
@@ -194,7 +218,11 @@ function GroupAccordion({
   togglePasswordVisibility: (key: string) => void;
   handleCopy: (value: string | null | undefined, label: string) => void;
   getMaskedPassword: (pw: string | null | undefined) => string;
-  onDownloadSshKey?: (accessId: string, username: string | null) => void;
+  onDownloadSshKey?: (
+    accessId: string,
+    username: string | null,
+  ) => void | Promise<void>;
+  currentUsername?: string | null;
 }) {
   return (
     <Accordion
@@ -227,6 +255,7 @@ function GroupAccordion({
                 handleCopy={handleCopy}
                 getMaskedPassword={getMaskedPassword}
                 onDownloadSshKey={onDownloadSshKey}
+                currentUsername={currentUsername}
               />
             ))}
           </AccordionContent>
@@ -244,6 +273,7 @@ function AccessRow({
   handleCopy,
   getMaskedPassword,
   onDownloadSshKey,
+  currentUsername,
 }: {
   accessKey: string;
   access: CredentialAccess;
@@ -251,7 +281,11 @@ function AccessRow({
   togglePasswordVisibility: (key: string) => void;
   handleCopy: (value: string | null | undefined, label: string) => void;
   getMaskedPassword: (pw: string | null | undefined) => string;
-  onDownloadSshKey?: (accessId: string, username: string | null) => void;
+  onDownloadSshKey?: (
+    accessId: string,
+    username: string | null,
+  ) => void | Promise<void>;
+  currentUsername?: string | null;
 }) {
   const urlLabel =
     access.access_type === "ssh"
@@ -261,19 +295,66 @@ function AccessRow({
         : "Connection URL";
 
   const isVisible = passwordVisibility[accessKey] === true;
-  // SSH-Key-Download nur zeigen, wenn (a) der Caller einen Handler liefert,
-  // (b) es ein SSH-Access ist und (c) der Backend-Eintrag tatsächlich eine
-  // access.id liefert. Lecturer-Mode kann optional ohne Handler laufen und
-  // den Key im Bundle-Download mitschicken.
+
+  // Inline-PEM-Anzeige hat einen eigenen Toggle — Standard zugeklappt,
+  // weil die meisten Nutzer den Download- oder Copy-Pfad wollen, nicht den
+  // rohen Text. State lebt lokal in der Row: kein Parent muss das wissen
+  // und es überlebt einen Re-Mount der Card sowieso nicht.
+  const [sshKeyVisible, setSshKeyVisible] = useState(false);
+  // In-flight-Flag für den Download. Verhindert Doppelklicks und treibt den
+  // Loader im Button.
+  const [sshDownloading, setSshDownloading] = useState(false);
+
+  // SSH-Key-Block nur zeigen, wenn der Eintrag (a) ein SSH-Access ist und
+  // (b) tatsächlich einen PEM trägt. Alte Deployments (vor Feature-Rollout)
+  // haben `ssh_private_key === null` und sollen die Sektion gar nicht erst
+  // sehen. Eye/Copy hängen am eingebetteten Feld — funktionieren also auch
+  // ohne Download-Handler. Der Download-Button braucht zusätzlich eine
+  // `access.id` (Backend liefert die seit der Schema-Erweiterung immer mit,
+  // aber wir bleiben defensiv).
+  const hasPrivateKey =
+    access.access_type === "ssh" && !!access.ssh_private_key;
   const canDownloadKey =
-    !!onDownloadSshKey && access.access_type === "ssh" && !!access.id;
+    hasPrivateKey && !!onDownloadSshKey && !!access.id;
+
+  // Admin-Heuristik: Der Access-Eintrag, dessen `username` zum eingeloggten
+  // Lecturer (Keycloak `preferred_username`) passt, ist der Admin-Zugang.
+  // Backend liefert (noch) kein explizites Flag. Case-insensitive, weil
+  // Keycloak und OpenStack-User unterschiedliches Casing tragen können.
+  const isAdminAccess =
+    access.access_type === "ssh" &&
+    !!currentUsername &&
+    !!access.username &&
+    access.username.toLowerCase() === currentUsername.toLowerCase();
+
+  const triggerDownload = async () => {
+    if (!onDownloadSshKey || !access.id || sshDownloading) return;
+    setSshDownloading(true);
+    try {
+      await onDownloadSshKey(access.id, access.username);
+    } finally {
+      setSshDownloading(false);
+    }
+  };
 
   return (
     <div className="rounded-lg border border-slate-200 p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h4 className="text-sm font-medium text-slate-900">
-          {accessTypeLabels[access.access_type] || access.access_type}
-        </h4>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <h4 className="text-sm font-medium text-slate-900">
+            {accessTypeLabels[access.access_type] || access.access_type}
+          </h4>
+          {isAdminAccess && (
+            <Badge
+              variant="default"
+              className="bg-teal-100 text-teal-700 hover:bg-teal-100 gap-1"
+              title="Dieser Eintrag ist dein Dozenten-Zugang. SSH-Key gibt dir sudo-Rechte auf der VM."
+            >
+              <ShieldCheck className="w-3 h-3" />
+              Admin
+            </Badge>
+          )}
+        </div>
         <Badge variant="outline">{access.access_type}</Badge>
       </div>
 
@@ -361,17 +442,60 @@ function AccessRow({
           <span className="text-sm text-slate-900">{access.port ?? "-"}</span>
         </div>
 
-        {canDownloadKey && (
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-xs text-slate-500">SSH Private Key</span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onDownloadSshKey?.(access.id, access.username)}
-            >
-              <Download className="w-4 h-4 mr-2" />
-              PEM herunterladen
-            </Button>
+        {hasPrivateKey && (
+          <div className="space-y-2 pt-2 border-t border-slate-100">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+                <Key className="w-3.5 h-3.5" />
+                SSH Private Key
+                {isAdminAccess && (
+                  <span className="text-slate-400">· Admin-Zugang</span>
+                )}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setSshKeyVisible((v) => !v)}
+                  title={sshKeyVisible ? "Key ausblenden" : "Key anzeigen"}
+                >
+                  {sshKeyVisible ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleCopy(access.ssh_private_key, "SSH Private Key")}
+                  disabled={!access.ssh_private_key}
+                  title="In Zwischenablage kopieren"
+                >
+                  <Copy className="w-4 h-4" />
+                </Button>
+                {canDownloadKey && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={triggerDownload}
+                    disabled={sshDownloading}
+                    title="Als .pem-Datei herunterladen"
+                  >
+                    {sshDownloading ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Download className="w-4 h-4" />
+                    )}
+                  </Button>
+                )}
+              </div>
+            </div>
+            {sshKeyVisible && (
+              <pre className="text-xs bg-slate-50 border border-slate-200 rounded-md p-3 font-mono whitespace-pre-wrap break-all overflow-x-auto max-h-64">
+{access.ssh_private_key}
+              </pre>
+            )}
           </div>
         )}
       </div>

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import React from "react";
 import {
   CheckCircle2,
@@ -45,12 +45,14 @@ import {
   DeploymentLogDto,
   getDeploymentCredentials,
   extendDeployment,
+  downloadSshKey,
   type RuntimeMonths,
 } from "../api/deployments";
 import { type LogPhase, type PhaseStatus } from "./DeploymentDetailsPage";
 import { getExpiryState } from "../utils/deployment";
 import { useActiveOpenstackProject } from "../contexts/OpenstackProjectContext";
 import { CredentialInstanceCard } from "../components/credentials/CredentialInstanceCard";
+import keycloak from "../auth/keycloak";
 
 interface DeploymentStep {
   id: string;
@@ -261,6 +263,45 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
     return "*".repeat(Math.max(8, value.length));
   };
 
+  // Username des eingeloggten Lecturers — Heuristik für „dies ist der
+  // Admin-Eintrag" laut Backend-Briefing. Wenn der `username` eines Access-
+  // Eintrags dem entspricht, badged die CredentialInstanceCard die Zeile als
+  // Admin-Zugang. Backend liefert (noch) kein explizites `is_admin`-Flag.
+  const currentUsername = useMemo<string | null>(() => {
+    const t = (keycloak?.tokenParsed ?? {}) as Record<string, any>;
+    const u = (t.preferred_username || "").toString().trim();
+    return u || null;
+  }, []);
+
+  const handleDownloadSshKey = useCallback(
+    async (accessId: string, username: string | null) => {
+      try {
+        await downloadSshKey(deployment.id, accessId, activeProjectId, username);
+        toast.success("SSH-Key heruntergeladen.");
+      } catch (err) {
+        const status = (err as { status?: number }).status;
+        if (status === 400) {
+          toast.error("openstack_project_id fehlt — bitte Projekt wählen.");
+        } else if (status === 401) {
+          toast.error("Session abgelaufen — bitte erneut anmelden.");
+        } else if (status === 403) {
+          toast.error("Keine Berechtigung für diesen SSH-Key.");
+        } else if (status === 404) {
+          // Backend unterscheidet im 404er-Body zwischen „Deployment nicht
+          // gefunden", „Access-Eintrag nicht gefunden" und „kein SSH-Key
+          // hinterlegt". Wir können das hier nicht sauber auseinanderhalten,
+          // also bleibt es bei einer allgemeinen Meldung. Der mit Abstand
+          // häufigste Fall (alte Deployments) ist „kein Key" — die Card
+          // sollte den Button gar nicht erst anzeigen, aber falls doch:
+          toast.error("Für diesen Zugang ist kein SSH-Key hinterlegt.");
+        } else {
+          toast.error("SSH-Key-Download fehlgeschlagen.");
+        }
+      }
+    },
+    [deployment.id, activeProjectId],
+  );
+
   const loadCredentials = useCallback(async () => {
     if (credentialsLoading) return;
     setCredentialsLoading(true);
@@ -300,14 +341,22 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
         const accessBlocks = instance.accesses
           .map((access) => {
             const title = accessTypeLabels[access.access_type] || access.access_type;
-            return [
+            const lines: string[] = [
               title,
               `Username: ${access.username ?? "-"}`,
               `Password: ${access.password ?? "-"}`,
               `Connection URL: ${access.connection_url ?? "-"}`,
               `Port: ${access.port ?? "-"}`,
-              "",
-            ].join("\n");
+            ];
+            // PEM nur einfügen, wenn vorhanden — sonst landen massenhaft
+            // „SSH Private Key: -"-Zeilen im Bundle und vermitteln, dass
+            // jeder Eintrag einen Key hätte, was vor dem Feature-Rollout
+            // nicht stimmt.
+            if (access.ssh_private_key) {
+              lines.push("SSH Private Key:", access.ssh_private_key);
+            }
+            lines.push("");
+            return lines.join("\n");
           })
           .join("\n");
         return `${header}${accessBlocks}`.trimEnd();
@@ -962,6 +1011,8 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
                       togglePasswordVisibility={togglePasswordVisibility}
                       handleCopy={handleCopy}
                       getMaskedPassword={getMaskedPassword}
+                      onDownloadSshKey={handleDownloadSshKey}
+                      currentUsername={currentUsername}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
Backend liefert pro Access-Eintrag jetzt zusätzlich `ssh_private_key` (PEM-String oder null) und einen dedizierten Download-Endpoint `GET /credentials/access/{access_id}/ssh-key`. Frontend ziehe ich nach.

Änderungen:

- API (`src/api/deployments.ts`): neue Funktion `downloadSshKey()` — Lecturer-Pendant zu `downloadStudentSshKey` aus `student.ts`. Schickt `?openstack_project_id=...` mit (Lecturer-Pflicht), parst `Content-Disposition` für den Filename, fällt auf `id_ed25519_<user>` zurück, Blob-Download. Wirft `Error` mit numerischem `.status` + `.body` für sauberes 400/401/403/404- Handling.

- CredentialInstanceCard: Geteilte Komponente erweitert (Lecturer + Student profitieren gleichermaßen):
  - Neuer Prop `currentUsername` für die Admin-Heuristik
  - Handler-Signatur akzeptiert `Promise<void>` → Loader-Spinner im Button während Download
  - SSH-Key-Sektion (nur sichtbar wenn `ssh_private_key` gesetzt): Eye/EyeOff (Inline-PEM, monospace, scrollbar), Copy (Zwischenablage), Download (.pem mit Spinner)
  - Admin-Badge (teal ShieldCheck) wenn `access.username` case-insensitive zum eingeloggten Lecturer passt — Backend liefert (noch) kein explizites `is_admin`-Flag

- DeploymentDetails: useMemo über `keycloak.tokenParsed.preferred_username` für die Heuristik, `handleDownloadSshKey` mit Status-spezifischen Toasts, beide an die Card durchgereicht. Credentials-Markdown-Export inkludiert den PEM-Block nur, wenn vorhanden.

Closes #104