### PR TITLE
feat(credentials): render Overleaf activation_link as clickable URL

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -58,7 +58,8 @@ export type AccessType =
   | "guacamole"
   | "rdp"
   | "vnc"
-  | "database";
+  | "database"
+  | "activation_link";
 
 export type CredentialAccess = {
   /**

--- a/src/components/credentials/CredentialInstanceCard.tsx
+++ b/src/components/credentials/CredentialInstanceCard.tsx
@@ -44,6 +44,10 @@ const accessTypeLabels: Record<string, string> = {
   rdp: "RDP",
   vnc: "VNC",
   database: "Database",
+  // Einmaliger Setup-Link, den das Playbook auf der VM erzeugt (z.B.
+  // Overleaf-CLI). Keine Passwort-Zeile, klickbarer Link im Verbindungs-
+  // Feld — siehe AccessRow weiter unten.
+  activation_link: "Aktivierungslink",
 };
 
 export type CredentialsMode = "lecturer" | "student";
@@ -292,7 +296,9 @@ function AccessRow({
       ? "SSH-Befehl"
       : access.access_type === "web_url"
         ? "URL"
-        : "Connection URL";
+        : access.access_type === "activation_link"
+          ? "Aktivierungslink"
+          : "Connection URL";
 
   const isVisible = passwordVisibility[accessKey] === true;
 
@@ -374,42 +380,44 @@ function AccessRow({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">Password</span>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-slate-900">
-              {isVisible
-                ? (access.password ?? "-")
-                : getMaskedPassword(access.password)}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => togglePasswordVisibility(accessKey)}
-              disabled={!access.password}
-            >
-              {isVisible ? (
-                <EyeOff className="w-4 h-4" />
-              ) : (
-                <Eye className="w-4 h-4" />
-              )}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => handleCopy(access.password, "Password")}
-              disabled={!access.password}
-            >
-              <Copy className="w-4 h-4" />
-            </Button>
+        {access.access_type !== "activation_link" && (
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="text-xs text-slate-500">Password</span>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-slate-900">
+                {isVisible
+                  ? (access.password ?? "-")
+                  : getMaskedPassword(access.password)}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => togglePasswordVisibility(accessKey)}
+                disabled={!access.password}
+              >
+                {isVisible ? (
+                  <EyeOff className="w-4 h-4" />
+                ) : (
+                  <Eye className="w-4 h-4" />
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleCopy(access.password, "Password")}
+                disabled={!access.password}
+              >
+                <Copy className="w-4 h-4" />
+              </Button>
+            </div>
           </div>
-        </div>
+        )}
 
         <div className="flex flex-wrap items-center justify-between gap-2">
           <span className="text-xs text-slate-500">{urlLabel}</span>
           <div className="flex items-center gap-2">
             {access.connection_url ? (
-              access.access_type === "web_url" ? (
+              access.access_type === "web_url" || access.access_type === "activation_link" ? (
                 <a
                   href={access.connection_url}
                   target="_blank"

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -239,6 +239,7 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
     rdp: "RDP",
     vnc: "VNC",
     database: "Database",
+    activation_link: "Aktivierungslink",
   };
 
   const handleCopy = useCallback(async (value: string | null, label: string) => {


### PR DESCRIPTION
## Was und warum

Begleitender Frontend-PR zum Backend-Change [DoziLab/appstore-backend#165](https://github.com/DoziLab/appstore-backend/pull/165).

Overleaf liefert pro Account keine Credentials im klassischen Sinn (kein Passwort, kein SSH-Key) sondern einen **einmaligen Aktivierungslink** (`http://<vm>/user/activate?token=...`). Backend schreibt diese jetzt als `DeploymentInstanceAccess`-Zeilen mit `access_type=activation_link` und der URL im `connection_url`. Dieser PR rendert sie korrekt in der bestehenden Credentials-UI — ohne neuen Tab, ohne neue Komponente.

## Änderungen

| Datei | Änderung |
|---|---|
| `src/api/deployments.ts` | `AccessType`-Union um `"activation_link"` erweitert. |
| `src/components/credentials/CredentialInstanceCard.tsx` | Shared Komponente (Dozent + Student). `accessTypeLabels` um `activation_link: "Aktivierungslink"` erweitert. Password-Block für `activation_link` per `&&`-Guard ausgeblendet (Wert ist immer `null`). URL-Block: `activation_link` rendert wie `web_url` als `<a target="_blank">` statt als `<code>`. URL-Header-Label und Copy-Toast entsprechend. |
| `src/pages/DeploymentDetails.tsx` | `accessTypeLabels` (zweite, duplizierte Map für den Bundle-Download) ebenfalls erweitert — sonst würde der TS-Compiler die Map nicht mehr als `Record<AccessType, string>` akzeptieren. |

## Was profitiert automatisch

- **Student-View** (`StudentDeploymentDetails.tsx`): rendert über dieselbe `CredentialInstanceCard`-Komponente → alle Änderungen greifen dort, ohne dass Code dupliziert wird.
- **Berechtigung**: Backend filtert über `group_id` → Studenten sehen nur den eigenen Gruppen-Link, **niemals** den Admin-Link (`group_id=NULL`). Frontend muss nichts zusätzlich filtern.

## Bewusst NICHT geändert

- Kein separater "Aktivierungslinks"-Tab. Aktivierungslinks erscheinen einfach als weiterer Zugang neben SSH-Zugang in derselben Liste — minimaler visueller Aufwand, gleicher Kopier-/Klick-Flow wie URLs.
- Bundle-Download generiert für `activation_link` weiterhin eine `Password: -`-Zeile — kosmetisch suboptimal, aber konsistent mit dem bisherigen Pattern (SSH-Keys werden auch nur bei Vorhandensein eingefügt, restliche Felder immer). Lass ich für später.

## Verifikation

Manuell nach Merge des Backend-PRs:
1. Overleaf-Deployment via Wizard starten, abwarten.
2. „Zugangsdaten anzeigen" → im Dozent-Tab eine zusätzliche „Aktivierungslink"-Zeile mit Admin-E-Mail als Username, kein Passwort-Block, klickbarer Link mit `<Copy>`-Button. Gleiches pro Gruppe im Gruppen-Tab.
3. Als Student in „Gruppe 1" einloggen, Student-Deployment-Details → nur den eigenen Gruppen-Link, keinen Admin-Link.