### PR TITLE
fix(github-integration): busy-Flag bei Rückkehr von GitHub zurücksetz…

### DIFF
--- a/src/components/GithubIntegrationCard.tsx
+++ b/src/components/GithubIntegrationCard.tsx
@@ -57,6 +57,25 @@ export function GithubIntegrationCard() {
     refresh();
   }, []);
 
+  // Wenn der Nutzer per Browser-Back oder Tab-Wechsel zurückkommt (z.B. von
+  // der GitHub-Install-Page, ohne dass /github/connected unsere Komponente
+  // neu gemountet hat — etwa weil die Navigation gecancelt wurde oder per
+  // Back-Button), kann `busy` aus dem vorigen handleConnect()-Aufruf noch
+  // auf true stehen. Das macht den Connect-Button via disabled:opacity-50
+  // auf bg-slate-900 optisch fast unsichtbar (#149). Reset, sobald die Page
+  // wieder im Vordergrund ist bzw. aus dem bfcache wieder angezeigt wird.
+  useEffect(() => {
+    const reset = () => {
+      if (document.visibilityState === 'visible') setBusy(false);
+    };
+    document.addEventListener('visibilitychange', reset);
+    window.addEventListener('pageshow', reset);
+    return () => {
+      document.removeEventListener('visibilitychange', reset);
+      window.removeEventListener('pageshow', reset);
+    };
+  }, []);
+
   const handleConnect = async () => {
     setBusy(true);
     try {


### PR DESCRIPTION
…en (#149)

handleConnect() setzt busy=true und navigiert dann per window.location.href zu GitHub. Wenn der Nutzer per Browser-Back oder Tab-Wechsel zurückkommt ohne dass /github/connected die Komponente neu gemountet hat, blieb busy auf true hängen. Effekt: der Connect-Button steht permanent auf disabled, mit der Tailwind-Default-Klasse disabled:opacity-50 — auf dem dunklen bg-slate-900 erzeugt das ein blasses Dunkelgrau, das auf hellem bg-slate-50-Container optisch fast unsichtbar wirkt (User-Report: "Button ist da, aber nicht sichtbar oder hinter etwas").

Fix: visibilitychange/pageshow-Listener setzen busy zurück, sobald die Seite wieder im Vordergrund ist bzw. aus dem bfcache angezeigt wird.