### PR TITLE
fix(deployment-wizard): Speicher-Dropdown zeigt ausgewählten Wert an

### DIFF
--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -1036,7 +1036,7 @@ export function DeploymentWizard({
             </SelectTrigger>
             <SelectContent>
               {param.enum.map((option) => (
-                <SelectItem key={option} value={option}>
+                <SelectItem key={String(option)} value={String(option)}>
                   {option}
                 </SelectItem>
               ))}


### PR DESCRIPTION
Enum-Parameter mit numerischen Werten (z. B. Speicher (GB): 8/16/32/64/128) wurden im Select nach der Auswahl nicht angezeigt, obwohl der Wert intern korrekt im State landete.

Ursache: Radix Select vergleicht den Select.value (per String(...) bereits zu String konvertiert) strikt mit den SelectItem.value-Props. Für Enums aus der app.yaml mit YAML-Integers kommen die Werte als JS-Numbers an, sodass "8" !== 8 und Radix kein passendes Item findet → Placeholder bleibt sichtbar.

Fix: SelectItem-Wert ebenfalls per String(option) konvertieren. Verhalten für String-Enums bleibt identisch.

Fixes #158