### PR TITLE
fix(buttons): GitHub-verbinden-Button bekommt Inline-Hintergrundfarbe…

### DIFF
--- a/src/components/AddTemplateDialog.tsx
+++ b/src/components/AddTemplateDialog.tsx
@@ -247,7 +247,12 @@ export function AddTemplateDialog({ open, onOpenChange, onImported }: AddTemplat
                     <Button
                       size="sm"
                       onClick={handleConnectGithub}
-                      className="bg-slate-900 hover:bg-slate-800 text-white shrink-0"
+                      className="shrink-0"
+                      // bg-slate-900 wird in der vor-gebackenen index.css
+                      // nicht generiert, sodass text-white auf transparentem
+                      // Hintergrund stehen würde — der Button wäre unsichtbar
+                      // (#149).
+                      style={{ backgroundColor: '#0f172a', color: '#ffffff' }}
                     >
                       <Github className="w-4 h-4 mr-2" />
                       GitHub verbinden

--- a/src/components/GithubIntegrationCard.tsx
+++ b/src/components/GithubIntegrationCard.tsx
@@ -160,7 +160,11 @@ export function GithubIntegrationCard() {
             <Button
               onClick={handleConnect}
               disabled={busy}
-              className="bg-slate-900 hover:bg-slate-800 text-white"
+              // bg-slate-900 wird in der vor-gebackenen index.css nicht
+              // generiert — text-white würde dadurch auf weißem Card-
+              // Hintergrund unsichtbar (#149). Inline-Style ist im Repo
+              // der etablierte Workaround (siehe Trennen-Button unten).
+              style={{ backgroundColor: '#0f172a', color: '#ffffff' }}
             >
               <Github className="w-4 h-4 mr-2" />
               GitHub verbinden


### PR DESCRIPTION
… (#149)

Die Buttons benutzten bg-slate-900 + text-white. bg-slate-900 wird in der vor-gebackenen src/index.css aber gar nicht generiert (nur bg-slate-{50, 100,200} sind da) — text-white griff also auf transparentem/weißem Card- Hintergrund und der Button war praktisch unsichtbar.

Workaround: Inline-Style mit #0f172a (slate-900 Hex) auf den beiden betroffenen Buttons in GithubIntegrationCard (/config) und AddTemplateDialog (Template hinzufügen). Das Pattern ist im Repo bereits etabliert — der 'Trennen'/'Entfernen'-Button nutzt denselben Workaround mit #dc2626.