### PR TITLE
refactor(settings): Sidebar-Nav durch shadcn-Tabs ersetzen

### DIFF
--- a/src/pages/OpenStackConfig.tsx
+++ b/src/pages/OpenStackConfig.tsx
@@ -1,4 +1,4 @@
-import { Settings, RefreshCw, CheckCircle2, AlertCircle, Server, Eye, EyeOff, Trash2 } from 'lucide-react';
+import { Settings, RefreshCw, CheckCircle2, AlertCircle, Server, Eye, EyeOff, Trash2, Github, Plug } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
@@ -7,8 +7,9 @@ import { Badge } from '../components/ui/badge';
 import { Switch } from '../components/ui/switch';
 import { Textarea } from '../components/ui/textarea';
 import { Progress } from '../components/ui/progress';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import { AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '../components/ui/alert-dialog';
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { toast } from 'sonner@2.0.3';
 import {
   listOpenstackProjects,
@@ -36,6 +37,17 @@ const formatMBasGB = (v?: number) => {
   if (v == null) return '—';
   return `${Math.round(v / 1024)} GB`;
 };
+
+// Settings-Navigation: ein Eintrag pro Tab, gerendert sowohl als
+// <TabsTrigger> als auch (über value) als <TabsContent>. Reihenfolge hier
+// = Reihenfolge im UI.
+type TabKey = 'connection' | 'github' | 'authentication' | 'quotas';
+const TAB_ITEMS: ReadonlyArray<{ key: TabKey; label: string; icon: typeof Plug }> = [
+  { key: 'connection', label: 'Verbindung', icon: Plug },
+  { key: 'github', label: 'GitHub', icon: Github },
+  { key: 'authentication', label: 'Authentifizierung', icon: Settings },
+  { key: 'quotas', label: 'Quotas', icon: Server },
+];
 
 export function OpenStackConfig() {
   const [showPassword, setShowPassword] = useState(false);
@@ -259,20 +271,10 @@ export function OpenStackConfig() {
     }
   };
 
-  // Refs for internal sections
-  const connectionRef = useRef<HTMLElement | null>(null);
-  const githubRef = useRef<HTMLElement | null>(null);
-  const authRef = useRef<HTMLElement | null>(null);
-  const quotasRef = useRef<HTMLElement | null>(null);
-  type SectionKey = 'connection' | 'github' | 'authentication' | 'quotas';
-  const [hoveredSection, setHoveredSection] = useState<SectionKey | null>(null);
-  const activeSection = hoveredSection; // only hover determines active section
-
-  const scrollToRef = useCallback((ref: typeof connectionRef) => {
-    ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  }, []);
-
-  // Hover-only behaviour: no scroll-based observer
+  // Tab-State für die neue, schlanke Settings-Navigation. Datengetrieben
+  // (TAB_ITEMS unten) statt 4x Copy-Paste-Buttons, mit shadcn-<Tabs/>-Primitive
+  // wie an anderen Stellen im Projekt (siehe AddTemplateDialog).
+  const [activeTab, setActiveTab] = useState<TabKey>('connection');
 
   return (
     <div className="p-8">
@@ -281,64 +283,20 @@ export function OpenStackConfig() {
         <p className="text-slate-600">Verwalten Sie Ihre OpenStack-Konfiguration und Systemeinstellungen</p>
       </div>
 
-      <div className="flex gap-8">
-        {/* Left: internal nav — shrinks to the widest tab label */}
-        <aside className="md:block flex-shrink-0 w-auto">
-          <nav className="space-y-2">
-            <button
-              onClick={() => scrollToRef(connectionRef)}
-              onMouseEnter={() => setHoveredSection('connection')}
-              onMouseLeave={() => setHoveredSection(null)}
-              className={`w-full text-left whitespace-nowrap px-3 py-2 rounded-md transition ${activeSection === 'connection' ? 'bg-teal-50 text-teal-600' : 'text-slate-600 hover:bg-slate-50'}`}
-              title="Verbindungsstatus"
-            >
-              Verbindungsstatus
-            </button>
+      <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabKey)} className="w-full">
+        <TabsList className="mb-6">
+          {TAB_ITEMS.map(({ key, label, icon: Icon }) => (
+            <TabsTrigger key={key} value={key} className="gap-2">
+              <Icon className="w-4 h-4" />
+              {label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
 
-            <button
-              onClick={() => scrollToRef(githubRef)}
-              onMouseEnter={() => setHoveredSection('github')}
-              onMouseLeave={() => setHoveredSection(null)}
-              className={`w-full text-left whitespace-nowrap px-3 py-2 rounded-md transition ${activeSection === 'github' ? 'bg-teal-50 text-teal-600' : 'text-slate-600 hover:bg-slate-50'}`}
-              title="GitHub-Integration"
-            >
-              GitHub-Integration
-            </button>
-
-            <button
-              onClick={() => scrollToRef(authRef)}
-              onMouseEnter={() => setHoveredSection('authentication')}
-              onMouseLeave={() => setHoveredSection(null)}
-              className={`w-full text-left whitespace-nowrap px-3 py-2 rounded-md transition ${activeSection === 'authentication' ? 'bg-teal-50 text-teal-600' : 'text-slate-600 hover:bg-slate-50'}`}
-              title="Authentifizierung"
-            >
-              Authentifizierung
-            </button>
-
-            <button
-              onClick={() => scrollToRef(quotasRef)}
-              onMouseEnter={() => setHoveredSection('quotas')}
-              onMouseLeave={() => setHoveredSection(null)}
-              className={`w-full text-left whitespace-nowrap px-3 py-2 rounded-md transition ${activeSection === 'quotas' ? 'bg-teal-50 text-teal-600' : 'text-slate-600 hover:bg-slate-50'}`}
-              title="Quotas"
-            >
-              Quotas
-            </button>
-          </nav>
-        </aside>
-
-        {/* Right: content */}
-        <main className="flex-1 pr-4 space-y-6">
-          {/* Connection Status Card */}
-          <section
-            ref={connectionRef}
-            data-section="connection"
-            aria-labelledby="connection-heading"
-            onMouseEnter={() => setHoveredSection('connection')}
-            onMouseLeave={() => setHoveredSection(null)}
-          >
-            <Card className="border-slate-200 shadow-sm">
-              <CardContent className="p-6">
+        {/* Tab: Verbindung */}
+        <TabsContent value="connection">
+          <Card className="border-slate-200 shadow-sm">
+            <CardContent className="p-6">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-4">
                   <div className={`w-12 h-12 rounded-full flex items-center justify-center ${
@@ -354,7 +312,7 @@ export function OpenStackConfig() {
                     )}
                   </div>
                   <div>
-                    <p className="text-slate-900" id="connection-heading">Verbindungsstatus</p>
+                    <p className="text-slate-900">Verbindungsstatus</p>
                     <p className="text-sm text-slate-500">
                       {credentialsLoading ? 'Wird geprüft...' :
                        connectionStatus === 'connected'
@@ -377,31 +335,18 @@ export function OpenStackConfig() {
               </div>
             </CardContent>
           </Card>
-          </section>
+        </TabsContent>
 
-          {/* GitHub-Integration — eigenständige Section zwischen Verbindung
-              und Authentifizierung, mit eigenem Sidebar-Tab und Hover-Hook
-              (siehe #127, #139). */}
-          <section
-            ref={githubRef}
-            data-section="github"
-            aria-labelledby="github-heading"
-            onMouseEnter={() => setHoveredSection('github')}
-            onMouseLeave={() => setHoveredSection(null)}
-          >
-            <GithubIntegrationCard />
-          </section>
+        {/* Tab: GitHub */}
+        <TabsContent value="github">
+          <GithubIntegrationCard />
+        </TabsContent>
 
-          <section
-            ref={authRef}
-            data-section="authentication"
-            onMouseEnter={() => setHoveredSection('authentication')}
-            onMouseLeave={() => setHoveredSection(null)}
-          >
-            {/* Authentication Settings */}
+        {/* Tab: Authentifizierung */}
+        <TabsContent value="authentication">
             <Card className="border-slate-200 shadow-sm">
               <CardHeader>
-                <CardTitle className="flex items-center gap-2" id="authentication-heading">
+                <CardTitle className="flex items-center gap-2">
                   <Settings className="w-5 h-5" />
                   Authentifizierung
                 </CardTitle>
@@ -585,17 +530,13 @@ export function OpenStackConfig() {
                 </form>
               </CardContent>
             </Card>
-          </section>
+        </TabsContent>
 
-          <section
-            ref={quotasRef}
-            data-section="quotas"
-            onMouseEnter={() => setHoveredSection('quotas')}
-            onMouseLeave={() => setHoveredSection(null)}
-          >
+        {/* Tab: Quotas */}
+        <TabsContent value="quotas">
             <Card className="border-slate-200 shadow-sm">
               <CardHeader>
-                <CardTitle className="flex items-center gap-2" id="quotas-heading">
+                <CardTitle className="flex items-center gap-2">
                   <Server className="w-5 h-5" />
                   Ressourcen-Quotas
                 </CardTitle>
@@ -662,10 +603,8 @@ export function OpenStackConfig() {
                   })()}
                 </CardContent>
               </Card>
-            </section>
-
-        </main>
-      </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
Die alte Settings-Sidebar (4 Copy-Paste-Buttons mit eigener Hover/Scroll- Spy-Logik, eigenen Refs pro Section, scrollIntoView etc.) komplett entfernt und durch shadcn-<Tabs/> ersetzt — das ist im Projekt das etablierte Tab- Pattern (AddTemplateDialog, CredentialInstanceCard).

Änderungen:
- TAB_ITEMS-Array als single source of truth für Reihenfolge/Label/Icon.
- <Tabs value={activeTab} onValueChange={…}> rendert TabsList aus den Items in einer Schleife — kein Copy-Paste mehr.
- Pro Section ein <TabsContent>. Nur die aktive Section ist sichtbar, Mounting passiert per Tab-Wechsel.
- useRef/useCallback/hoveredSection/scrollToRef/SectionKey-Type komplett entfernt — wird mit echten Tabs nicht mehr gebraucht.
- aria-labelledby auf Sections gestrichen (Tabs liefern eigene a11y).
- Icons (Plug/Github/Settings/Server) in den Tabs als visueller Anker.