### PR TITLE
feat: publish-request UX + version validation error handling

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -97,7 +97,30 @@ export type ImportNewVersionBody = {
   github_url: string;
   app_yaml_path?: string | null;
   is_active?: boolean;
+  /**
+   * Wenn der `app.version`-String der neu importierten Version bereits im
+   * Template existiert: `true` → Backend löscht die bestehende Row inkl.
+   * Files und ersetzt sie durch die neue. Blockiert, wenn aktive
+   * Deployments an der zu ersetzenden Row hängen (`VERSION_REPLACE_BLOCKED_BY_DEPLOYMENTS`).
+   * Default `false` → Backend antwortet bei Kollision mit
+   * `VERSION_ALREADY_EXISTS`; Frontend bietet dem Owner dann zwei Wege:
+   * im Repo bumpen oder Replace bewusst auslösen.
+   */
+  replace_existing?: boolean;
 };
+// Backend-Fehler-Codes für Versions-Validierung (siehe
+// `appstore-backend/src/utils/version_validator.py`). Wir spiegeln sie hier
+// als String-Union, damit die UI-Komponenten ohne Magic-Strings darauf
+// branchen können.
+export const VERSION_ERROR_CODES = {
+  NOT_SEMVER: "VERSION_NOT_SEMVER",
+  MISSING_IN_MANIFEST: "VERSION_MISSING_IN_MANIFEST",
+  NOT_STRICTLY_GREATER: "VERSION_NOT_STRICTLY_GREATER",
+  ALREADY_EXISTS: "VERSION_ALREADY_EXISTS",
+  REPLACE_BLOCKED_BY_DEPLOYMENTS: "VERSION_REPLACE_BLOCKED_BY_DEPLOYMENTS",
+} as const;
+export type VersionErrorCode =
+  (typeof VERSION_ERROR_CODES)[keyof typeof VERSION_ERROR_CODES];
 
 export async function importTemplateFromGithub(
   body: ImportNewTemplateBody,
@@ -153,6 +176,9 @@ export type TemplateVersionQueueItem = {
     name: string;
     owner_id: string;
     visibility: "private" | "public";
+    /** True wenn das Template auf seine Erst-Genehmigung wartet. Admin-UI
+     *  zeigt einen Hinweis „erstmalige Veröffentlichung" am Karten-Header. */
+    publish_requested?: boolean;
   };
 };
 

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -2,6 +2,46 @@ import keycloak from "../auth/keycloak"; // ggf. Pfad anpassen
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL?.trim() || "";
 
+/**
+ * Strukturierter Fehler aus dem Backend.
+ *
+ * Backend-Konvention (siehe `appstore-backend/src/core/exceptions.py`):
+ * `BadRequestException` kann optional einen `code` (SCREAMING_SNAKE) und
+ * `details` (frei-strukturiertes Dict) tragen. Der Exception-Handler hängt
+ * beides ins JSON-Feld `errors` an, z.B.:
+ *   { "success": false, "message": "Version '2.0.0' bereits vorhanden",
+ *     "errors": { "code": "VERSION_ALREADY_EXISTS", "details": {…} } }
+ *
+ * Wir kopieren die zwei Felder hier aufs Error-Objekt, damit Callers
+ * darauf branchen können ohne `.body` selbst zu re-parsen.
+ */
+export class ApiError extends Error {
+  status: number;
+  body: string;
+  /** Stabiler Backend-Code, z.B. `VERSION_ALREADY_EXISTS`. `null` falls
+   *  der Backend-Pfad keinen Code mitsendet (Standardfehler). */
+  code: string | null;
+  /** Free-form-Payload, z.B. `{ existing_version_id: "…" }`. */
+  details: Record<string, unknown> | null;
+
+  constructor(
+    message: string,
+    init: {
+      status: number;
+      body: string;
+      code?: string | null;
+      details?: Record<string, unknown> | null;
+    },
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = init.status;
+    this.body = init.body;
+    this.code = init.code ?? null;
+    this.details = init.details ?? null;
+  }
+}
+
 
 async function getAccessToken(): Promise<string | undefined> {
   // Falls du bereits ein Token-Refresh-Pattern hast, nutze das.
@@ -34,17 +74,31 @@ export async function apiFetch<T>(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     let message = text || res.statusText;
+    let code: string | null = null;
+    let details: Record<string, unknown> | null = null;
     try {
       const json = JSON.parse(text);
       if (json?.message) message = json.message;
       else if (json?.detail) message = json.detail;
+      // Strukturierter Fehler-Payload aus `BadRequestException`:
+      // {"errors": {"code": "...", "details": {...}}}. Defensive
+      // Extraktion — alte Endpoints liefern `errors: null` oder eine
+      // Validation-Array-Form, die wir hier ignorieren.
+      if (json?.errors && typeof json.errors === "object" && !Array.isArray(json.errors)) {
+        if (typeof json.errors.code === "string") code = json.errors.code;
+        if (json.errors.details && typeof json.errors.details === "object") {
+          details = json.errors.details as Record<string, unknown>;
+        }
+      }
     } catch {
       // not JSON, use raw text
     }
-    const err = new Error(message) as Error & { status: number; body: string };
-    err.status = res.status;
-    err.body = text;
-    throw err;
+    throw new ApiError(message, {
+      status: res.status,
+      body: text,
+      code,
+      details,
+    });
   }
 
   return res.json() as Promise<T>;

--- a/src/api/templates.ts
+++ b/src/api/templates.ts
@@ -71,6 +71,17 @@ export type TemplateDto = {
   repo_url: string;
   icon_url: string | null;
   visibility: string;
+  /**
+   * True wenn der Owner das Template als „öffentlich" angelegt hat, aber
+   * noch keine Version genehmigt wurde. Das Template ist in dem Zustand
+   * weiterhin `visibility === "private"` — sobald ein Admin die erste
+   * Version approved, flippt Backend `visibility → "public"` und
+   * `publish_requested → false` atomar.
+   *
+   * UI-Konsequenz: für den Owner Badge „wartet auf Erst-Freigabe", auch
+   * wenn `visibility` noch privat ist. Siehe `lib/template-status.ts`.
+   */
+  publish_requested?: boolean;
   // Hinweis: Approval lebt nur noch pro Version. Der Backend-Endpoint
   // `GET /templates` liefert seit der Per-Version-Migration KEINEN
   // `approval_status` mehr auf Template-Ebene. Wenn Code früher

--- a/src/components/AddTemplateDialog.tsx
+++ b/src/components/AddTemplateDialog.tsx
@@ -13,8 +13,10 @@ import {
   getGithubInstallationStatus,
   importTemplateFromGithub,
   startGithubInstall,
+  VERSION_ERROR_CODES,
   type GithubInstallationStatus,
 } from '../api/github';
+import { ApiError } from '../api/http';
 
 interface AddTemplateDialogProps {
   open: boolean;
@@ -136,7 +138,7 @@ export function AddTemplateDialog({ open, onOpenChange, onImported }: AddTemplat
         description:
           visibility === 'private'
             ? 'Privates Template — sofort für dich verwendbar.'
-            : 'Öffentliches Template — Version wartet auf Admin-Freigabe.',
+            : 'Template wartet auf Erst-Freigabe (privat bis Admin approved).',
       });
       onImported?.();
       resetForm();
@@ -147,15 +149,49 @@ export function AddTemplateDialog({ open, onOpenChange, onImported }: AddTemplat
         navigate('/appstore');
       }
     } catch (err) {
-      // Die Backend-Fehlertexte sind aussagekräftig (z.B. „Folder contains 62
-      // files which exceeds the limit of 50.") — wir zeigen sie unverändert.
-      const msg = err instanceof Error ? err.message : 'Import fehlgeschlagen.';
+      // Strukturierte Versions-Validierungs-Fehler bekommen einen klar
+      // handlungsorientierten Text (mit Hinweis auf die app.yaml im Repo);
+      // alles andere fällt auf den generischen Backend-Text zurück.
+      const msg = humanizeImportError(err);
       setErrorMessage(msg);
       toast.error('Import fehlgeschlagen', { description: msg });
     } finally {
       setSubmitting(false);
     }
   };
+
+  /**
+   * Konvertiert Backend-Fehler in einen User-tauglichen Hinweis.
+   * Reagiert speziell auf die strukturierten ``VERSION_*``-Codes aus dem
+   * Versions-Validator; bei anderen Fehlern wird die Backend-Message
+   * unverändert übernommen (sie sind ohnehin meist gut formuliert,
+   * z.B. „Folder contains 62 files which exceeds the limit of 50").
+   */
+  function humanizeImportError(err: unknown): string {
+    if (err instanceof ApiError) {
+      switch (err.code) {
+        case VERSION_ERROR_CODES.MISSING_IN_MANIFEST:
+          return (
+            "Deine `app.yaml` enthält kein `app.version`-Feld (oder es ist leer). "
+            + "Bitte ergänze z. B. `app:\n  version: 1.0.0` im Repo und importiere erneut."
+          );
+        case VERSION_ERROR_CODES.NOT_SEMVER:
+          return (
+            "`app.version` in deiner app.yaml ist kein gültiges Semver. "
+            + "Format: `MAJOR.MINOR.PATCH`, z. B. `1.0.0` oder `2.0.1-beta`."
+          );
+        case VERSION_ERROR_CODES.NOT_STRICTLY_GREATER:
+        case VERSION_ERROR_CODES.ALREADY_EXISTS:
+          // Hier eher unwahrscheinlich (Erst-Import auf neues Template hat
+          // keine Vorgänger), aber wenn doch: klare Anweisung statt
+          // Standard-Text.
+          return err.message;
+        default:
+          return err.message;
+      }
+    }
+    return err instanceof Error ? err.message : 'Import fehlgeschlagen.';
+  }
 
   const connected = ghStatus?.connected === true;
 
@@ -413,7 +449,9 @@ export function AddTemplateDialog({ open, onOpenChange, onImported }: AddTemplat
                   <div className="space-y-0.5">
                     <p className="text-sm text-slate-900">Öffentlich (Marktplatz)</p>
                     <p className="text-xs text-slate-500">
-                      Im App Store sichtbar, sobald ein Admin die erste Version freigibt.
+                      Bleibt zunächst privat. Sobald ein Admin die erste
+                      Version freigibt, wird das Template im App Store
+                      sichtbar.
                     </p>
                   </div>
                 </button>

--- a/src/components/ApprovalBadge.tsx
+++ b/src/components/ApprovalBadge.tsx
@@ -37,6 +37,10 @@ function pickIcon(status: Props["status"]) {
     case "active":
       return ShieldCheck;
     case "pending":
+    case "awaiting_publish":
+      // Erst-Veröffentlichung-Wartezustand bekommt dasselbe „offen mit
+      // Fragezeichen"-Icon wie reguläres pending — sie sind aus User-Sicht
+      // beide „wartet auf Admin".
       return ShieldQuestion;
     case "rejected":
       return X;

--- a/src/components/CheckRemoteVersionsDialog.tsx
+++ b/src/components/CheckRemoteVersionsDialog.tsx
@@ -25,10 +25,12 @@ import {
   AlertCircle,
   CheckCircle2,
   Download,
+  ExternalLink,
   GitBranch,
   Github,
   Loader2,
   RefreshCcw,
+  Replace,
   Tag,
 } from "lucide-react";
 import { toast } from "sonner@2.0.3";
@@ -51,10 +53,13 @@ import {
   type RemoteCandidate,
   type RemoteCheckResult,
 } from "../lib/github-remote";
-import { buildGithubUrl } from "../lib/github-url";
+import { buildGithubEditUrl, buildGithubUrl } from "../lib/github-url";
 import {
   importTemplateVersionFromGithub,
+  VERSION_ERROR_CODES,
+  type VersionErrorCode,
 } from "../api/github";
+import { ApiError } from "../api/http";
 import type { TemplateDto } from "../api/templates";
 
 interface Props {
@@ -76,9 +81,22 @@ export function CheckRemoteVersionsDialog({
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<RemoteCheckResult | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  // Eine Zeile pro Kandidat. ``code`` ist gesetzt, wenn ein strukturierter
+  // Backend-Fehler kam — daraus rendern wir kandidaten-spezifische Action-
+  // Buttons (z.B. „Im Repo bumpen", „Bestehende Version ersetzen").
   const [importLog, setImportLog] = useState<
-    Array<{ label: string; ok: boolean; message?: string }>
+    Array<{
+      label: string;
+      ok: boolean;
+      message?: string;
+      code?: VersionErrorCode | null;
+      details?: Record<string, unknown> | null;
+    }>
   >([]);
+  // Pro Kandidat-SHA gemerkt: „der Owner hat hier schon einen Replace
+  // ausgelöst", damit wir doppelte Auslöser unterbinden und State zwischen
+  // Render-Pässen halten.
+  const [replacing, setReplacing] = useState<Set<string>>(new Set());
 
   // Wenn der Dialog frisch öffnet: alles zurücksetzen und sofort einen
   // Check anstoßen. Das spart dem User einen Klick — der Button heißt
@@ -90,6 +108,7 @@ export function CheckRemoteVersionsDialog({
     setResult(null);
     setSelected(new Set());
     setImportLog([]);
+    setReplacing(new Set());
     void runCheck();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -152,35 +171,60 @@ export function CheckRemoteVersionsDialog({
 
     const log: typeof importLog = [];
     for (const cand of selectedCandidates) {
-      try {
-        // Wir bauen die Import-URL bewusst aus den geparsten Bestandteilen
-        // der ursprünglichen Repo-URL zusammen, NICHT aus repo_url roh —
-        // sonst würde z.B. ein im Original mit `/tree/main` enthaltener
-        // alter Branch den neuen Tag überschreiben. `path` (Subordner zu
-        // app.yaml) übernehmen wir aber, weil das pro Template stabil ist.
-        const url = buildGithubUrl({
-          owner: result.parsed.owner,
-          repo: result.parsed.repo,
-          ref: cand.ref_for_import,
-          path: result.parsed.path,
-        });
-        await importTemplateVersionFromGithub(template.id, {
-          github_url: url,
-          app_yaml_path: null,
-          is_active: false,
-        });
-        log.push({ label: cand.label, ok: true });
-      } catch (err) {
-        log.push({
-          label: cand.label,
-          ok: false,
-          message: err instanceof Error ? err.message : "Import fehlgeschlagen.",
-        });
-      }
-      // Nach jedem Schritt das UI updaten, damit der User Fortschritt sieht.
+      const entry = await importOne(cand, { replace_existing: false });
+      log.push(entry);
       setImportLog([...log]);
     }
 
+    summariseToast(log);
+    setStep("done");
+    onImported();
+  };
+
+  /**
+   * Importiert einen einzelnen Kandidaten und gibt das Log-Entry zurück.
+   * Wird sowohl vom batch-runImport als auch vom Replace-Retry verwendet.
+   */
+  const importOne = async (
+    cand: RemoteCandidate,
+    opts: { replace_existing: boolean },
+  ): Promise<(typeof importLog)[number]> => {
+    if (!result) {
+      return { label: cand.label, ok: false, message: "Kein Repo-Kontext." };
+    }
+    try {
+      const url = buildGithubUrl({
+        owner: result.parsed.owner,
+        repo: result.parsed.repo,
+        ref: cand.ref_for_import,
+        path: result.parsed.path,
+      });
+      await importTemplateVersionFromGithub(template.id, {
+        github_url: url,
+        app_yaml_path: null,
+        is_active: false,
+        replace_existing: opts.replace_existing,
+      });
+      return { label: cand.label, ok: true };
+    } catch (err) {
+      if (err instanceof ApiError) {
+        return {
+          label: cand.label,
+          ok: false,
+          message: err.message,
+          code: err.code as VersionErrorCode | null,
+          details: err.details,
+        };
+      }
+      return {
+        label: cand.label,
+        ok: false,
+        message: err instanceof Error ? err.message : "Import fehlgeschlagen.",
+      };
+    }
+  };
+
+  const summariseToast = (log: typeof importLog) => {
     const successes = log.filter((l) => l.ok).length;
     const failures = log.length - successes;
     if (failures === 0) {
@@ -192,13 +236,45 @@ export function CheckRemoteVersionsDialog({
     } else if (successes === 0) {
       toast.error("Kein Import erfolgreich. Details unten im Dialog.");
     } else {
-      // Sonner v2 hat keine garantierte `warning`-Variante in unserer Alias-
-      // Version — wir bleiben bei `error` und beschreiben das gemischte
-      // Ergebnis im Text. Im Dialog sind die Details ohnehin sichtbar.
       toast.error(`${successes} von ${log.length} Versionen importiert.`);
     }
-    setStep("done");
-    onImported();
+  };
+
+  /**
+   * „Bestehende Version ersetzen" für einen einzelnen Kandidaten.
+   * Frage den Owner explizit, weil dabei die alte Version-Row inkl. Files
+   * gelöscht wird. Backend lehnt zusätzlich ab, wenn aktive Deployments
+   * an der alten Row hängen — wir surface die Meldung dann hier.
+   */
+  const handleReplace = async (cand: RemoteCandidate) => {
+    if (replacing.has(cand.commit_sha)) return;
+    const ok = window.confirm(
+      `Die bestehende Version ${cand.label} im Template wird inkl. ihrer `
+        + `Dateien überschrieben. Diese Aktion lässt sich nicht rückgängig `
+        + `machen. Fortfahren?`,
+    );
+    if (!ok) return;
+    setReplacing((prev) => new Set(prev).add(cand.commit_sha));
+    const next = await importOne(cand, { replace_existing: true });
+    setImportLog((prev) => {
+      const updated = prev.map((e) => (e.label === cand.label ? next : e));
+      // Erstes Replace pro Kandidat: wenn der Owner direkt nach dem Initial-
+      // Import auf Replace klickt, gibt es noch kein Log-Entry → einfügen.
+      return updated.some((e) => e.label === cand.label)
+        ? updated
+        : [...updated, next];
+    });
+    setReplacing((prev) => {
+      const updated = new Set(prev);
+      updated.delete(cand.commit_sha);
+      return updated;
+    });
+    if (next.ok) {
+      toast.success(`Version ${cand.label} ersetzt.`);
+      onImported();
+    } else {
+      toast.error(`Replace fehlgeschlagen: ${next.message ?? ""}`);
+    }
   };
 
   // ---------- Rendering pro Step -----------------------------------------
@@ -306,7 +382,7 @@ export function CheckRemoteVersionsDialog({
       <p className="text-xs text-slate-500">
         Die importierten Versionen landen zunächst inaktiv und warten je nach
         Admin-Regel auf Approval. Aktivieren kannst du sie anschließend über
-        „Aktualisieren".
+        „Aktive Version ändern".
       </p>
     </div>
   );
@@ -316,36 +392,71 @@ export function CheckRemoteVersionsDialog({
       {selectedCandidates.map((cand) => {
         const entry = importLog.find((l) => l.label === cand.label);
         const isPending = !entry;
+        const isReplacing = replacing.has(cand.commit_sha);
         return (
           <li
             key={cand.commit_sha}
-            className="flex items-start gap-3 p-2.5 rounded-lg border border-slate-200"
+            className="flex flex-col gap-2 p-2.5 rounded-lg border border-slate-200"
           >
-            <div className="mt-0.5 shrink-0">
-              {isPending && step === "importing" ? (
-                <Loader2 className="w-4 h-4 animate-spin text-slate-400" />
-              ) : entry?.ok ? (
-                <CheckCircle2 className="w-4 h-4 text-green-600" />
-              ) : (
-                <AlertCircle className="w-4 h-4 text-red-600" />
-              )}
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm text-slate-900 flex items-center gap-2">
-                {cand.kind === "tag" ? (
-                  <Tag className="w-3 h-3 text-blue-600" />
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 shrink-0">
+                {(isPending && step === "importing") || isReplacing ? (
+                  <Loader2 className="w-4 h-4 animate-spin text-slate-400" />
+                ) : entry?.ok ? (
+                  <CheckCircle2 className="w-4 h-4 text-green-600" />
                 ) : (
-                  <GitBranch className="w-3 h-3 text-slate-500" />
+                  <AlertCircle className="w-4 h-4 text-red-600" />
                 )}
-                {cand.label}
-                <span className="text-xs font-mono text-slate-500">
-                  {cand.commit_sha.slice(0, 7)}
-                </span>
-              </p>
-              {entry?.message && (
-                <p className="text-xs text-red-700 mt-1">{entry.message}</p>
-              )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-900 flex items-center gap-2">
+                  {cand.kind === "tag" ? (
+                    <Tag className="w-3 h-3 text-blue-600" />
+                  ) : (
+                    <GitBranch className="w-3 h-3 text-slate-500" />
+                  )}
+                  {cand.label}
+                  <span className="text-xs font-mono text-slate-500">
+                    {cand.commit_sha.slice(0, 7)}
+                  </span>
+                </p>
+                {entry?.message && (
+                  <p className="text-xs text-red-700 mt-1">{entry.message}</p>
+                )}
+              </div>
             </div>
+            {/* Aktion-Buttons bei strukturierten Versions-Fehlern.
+                MISSING / NOT_SEMVER / NOT_STRICTLY_GREATER → „Im Repo
+                bumpen" öffnet die app.yaml im GitHub-Editor.
+                ALREADY_EXISTS → zusätzlich „Bestehende Version ersetzen"
+                (Confirm + Backend-Replace-Pfad). */}
+            {entry && !entry.ok && entry.code && (
+              <CandidateActions
+                cand={cand}
+                code={entry.code}
+                disabled={isReplacing}
+                onReplace={() => void handleReplace(cand)}
+                appYamlPath={
+                  result?.parsed.path
+                    ? endsInYaml(result.parsed.path)
+                      ? result.parsed.path
+                      : `${result.parsed.path.replace(/\/$/, "")}/app.yaml`
+                    : "app.yaml"
+                }
+                editUrl={
+                  result
+                    ? buildGithubEditUrl({
+                        owner: result.parsed.owner,
+                        repo: result.parsed.repo,
+                        ref: cand.ref_for_import,
+                        path: endsInYaml(result.parsed.path ?? "")
+                          ? (result.parsed.path as string)
+                          : `${(result.parsed.path ?? "").replace(/\/$/, "")}/app.yaml`,
+                      })
+                    : null
+                }
+              />
+            )}
           </li>
         );
       })}
@@ -462,5 +573,73 @@ export function CheckRemoteVersionsDialog({
         {renderFooter()}
       </DialogContent>
     </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function endsInYaml(path: string): boolean {
+  return path.endsWith(".yaml") || path.endsWith(".yml");
+}
+
+/**
+ * Aktion-Buttons unterhalb eines fehlgeschlagenen Kandidaten:
+ * - „Im Repo bumpen" öffnet die app.yaml im GitHub-Web-Editor in einem
+ *   neuen Tab — der Owner kann dort `app.version` setzen und neu importieren.
+ * - „Bestehende Version ersetzen" erscheint nur bei
+ *   ``VERSION_ALREADY_EXISTS`` und triggert den Replace-Pfad mit Confirm.
+ */
+function CandidateActions({
+  cand,
+  code,
+  appYamlPath,
+  editUrl,
+  disabled,
+  onReplace,
+}: {
+  cand: RemoteCandidate;
+  code: VersionErrorCode;
+  appYamlPath: string;
+  editUrl: string | null;
+  disabled: boolean;
+  onReplace: () => void;
+}) {
+  const showReplace = code === VERSION_ERROR_CODES.ALREADY_EXISTS;
+  const showBump =
+    code === VERSION_ERROR_CODES.ALREADY_EXISTS
+    || code === VERSION_ERROR_CODES.NOT_STRICTLY_GREATER
+    || code === VERSION_ERROR_CODES.MISSING_IN_MANIFEST
+    || code === VERSION_ERROR_CODES.NOT_SEMVER;
+  if (!showBump && !showReplace) return null;
+  return (
+    <div className="flex flex-wrap gap-2 pl-7">
+      {showBump && editUrl && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => window.open(editUrl, "_blank", "noopener,noreferrer")}
+          className="h-7 text-xs"
+          title={`${appYamlPath} im GitHub-Editor öffnen`}
+        >
+          <ExternalLink className="w-3 h-3 mr-1.5" />
+          Im Repo bumpen
+        </Button>
+      )}
+      {showReplace && (
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onReplace}
+          disabled={disabled}
+          className="h-7 text-xs"
+          title={`Bestehende Version ${cand.label} im Template ersetzen`}
+        >
+          <Replace className="w-3 h-3 mr-1.5" />
+          Bestehende Version ersetzen
+        </Button>
+      )}
+    </div>
   );
 }

--- a/src/components/TemplateOwnerDetailDialog.tsx
+++ b/src/components/TemplateOwnerDetailDialog.tsx
@@ -2,23 +2,25 @@
 // generischen Details-Modal aus AppStore.tsx. Zeigt alle Felder, listet
 // Versionen mit ihrem Approval-Status, und bietet zwei Aktionen:
 //
-//   • „Aktualisieren" — eine neuere bereits importierte Version aktivieren
-//     (POST /api/v1/template-versions/{id}/activate). Kein Downgrade möglich:
-//     die Auswahl ist auf strikt-neuere Versionen als die aktuell aktive
-//     beschränkt (siehe `lib/version.ts → isStrictlyNewer`).
+//   • „Aktive Version ändern" — eine bereits importierte Version zur aktiven
+//     (= Standard-Vorauswahl im Deployment-Wizard) machen
+//     (POST /api/v1/template-versions/{id}/activate). Downgrades auf ältere
+//     Versionen sind erlaubt — die Auswahl umfasst ALLE nicht-aktiven
+//     Versionen, ohne Strict-Newer-Beschränkung.
 //
 //   • „Approven/Ablehnen" — nur sichtbar für Admins (Backend setzt
 //     `require_roles(ADMIN)` auf den Approve-Endpunkten). Wenn der Owner
 //     selbst Admin ist, kann er das also auf seinem eigenen Template tun;
 //     ansonsten muss ein Admin die Approval-Queue abarbeiten.
 //
-// Der eigentliche Versions-Upgrade-Dialog liegt in einem eigenen Component
-// (UpgradeVersionDialog), damit das hier nicht zu groß wird.
+// Der eigentliche „Aktive Version ändern"-Dialog liegt in einem eigenen
+// Component (ChangeActiveVersionDialog, datei UpgradeVersionDialog.tsx aus
+// Migration-Gründen), damit das hier nicht zu groß wird.
 
 import { useEffect, useMemo, useState } from "react";
 import {
   AlertCircle,
-  ArrowUpCircle,
+  ArrowLeftRight,
   Calendar,
   Check,
   CheckCircle2,
@@ -67,9 +69,8 @@ import {
   type TemplateUpdatePayload,
   type TemplateVersionDto,
 } from "../api/templates";
-import { isStrictlyNewer } from "../lib/version";
 import { deriveTemplateOverallStatus } from "../lib/template-status";
-import { UpgradeVersionDialog } from "./UpgradeVersionDialog";
+import { ChangeActiveVersionDialog } from "./UpgradeVersionDialog";
 import { CheckRemoteVersionsDialog } from "./CheckRemoteVersionsDialog";
 
 interface Props {
@@ -157,13 +158,12 @@ export function TemplateOwnerDetailDialog({
   // leiten wir hier eine UI-taugliche Aggregations-Bewertung ab.
   const overallStatus = deriveTemplateOverallStatus(template);
 
-  // Versionen, auf die der Owner hochziehen kann: strikt neuer als die
-  // aktuelle aktive Version. Wenn (noch) keine aktive existiert, jede.
-  const upgradeCandidates = versions.filter((v) => {
-    if (v.is_active) return false;
-    if (!activeVersion) return true;
-    return isStrictlyNewer(v, activeVersion);
-  });
+  // Kandidaten für „Aktive Version ändern": alle nicht-aktiven Versionen.
+  // Bewusst KEIN strict-newer-Filter mehr — der Owner darf jederzeit auch
+  // zu einer älteren Version zurück (z.B. wenn die jüngste einen Bug
+  // hat). Backend (`activate_version` + `deactivate_other_versions`)
+  // unterstützt den Switch in beide Richtungen atomar.
+  const activeChangeCandidates = versions.filter((v) => !v.is_active);
 
   const handleApprove = async (versionId: string) => {
     setBusyVersionId(versionId);
@@ -537,16 +537,16 @@ export function TemplateOwnerDetailDialog({
                   <Button
                     size="sm"
                     variant="outline"
-                    disabled={upgradeCandidates.length === 0}
+                    disabled={activeChangeCandidates.length === 0}
                     onClick={() => setUpgradeOpen(true)}
                     title={
-                      upgradeCandidates.length === 0
-                        ? "Keine neuere Version verfügbar"
-                        : undefined
+                      activeChangeCandidates.length === 0
+                        ? "Es gibt keine weitere Version, die du aktivieren könntest"
+                        : "Aktive Version (Standard-Vorauswahl im Deployment-Wizard) ändern"
                     }
                   >
-                    <ArrowUpCircle className="w-4 h-4 mr-2" />
-                    Aktualisieren
+                    <ArrowLeftRight className="w-4 h-4 mr-2" />
+                    Aktive Version ändern
                   </Button>
                 </div>
               </div>
@@ -782,10 +782,10 @@ export function TemplateOwnerDetailDialog({
         </DialogContent>
       </Dialog>
 
-      <UpgradeVersionDialog
+      <ChangeActiveVersionDialog
         open={upgradeOpen}
         onOpenChange={setUpgradeOpen}
-        candidates={upgradeCandidates}
+        candidates={activeChangeCandidates}
         activeVersion={activeVersion ?? null}
         onActivated={() => {
           setUpgradeOpen(false);
@@ -799,7 +799,7 @@ export function TemplateOwnerDetailDialog({
         onOpenChange={setCheckRemoteOpen}
         onImported={() => {
           // Liste neu laden, damit die frisch importierten Versionen
-          // in der Versionsliste und im Aktualisieren-Dialog auftauchen.
+          // in der Versionsliste und im „Aktive Version ändern"-Dialog auftauchen.
           onChanged();
         }}
       />

--- a/src/components/UpgradeVersionDialog.tsx
+++ b/src/components/UpgradeVersionDialog.tsx
@@ -1,15 +1,22 @@
-// Auswahl- und Bestätigungsdialog für „Aktualisieren": der Owner wählt eine
-// strikt neuere, bereits importierte Version, das Backend setzt sie via
-// POST /api/v1/template-versions/{id}/activate als aktiv (und deaktiviert
-// dabei automatisch die bisherige Aktive). Approval ist hier kein Faktor —
-// inaktive Versionen können den Status `pending`/`approved`/`rejected` haben;
-// das wird zur Information angezeigt, blockiert die Aktivierung aber nicht.
+// „Aktive Version ändern" — Auswahl- und Bestätigungsdialog: der Owner
+// wählt eine bereits importierte Version (auch ältere!), das Backend setzt
+// sie via POST /api/v1/template-versions/{id}/activate als aktiv und
+// deaktiviert dabei automatisch die bisherige Aktive. Approval ist hier
+// kein Faktor — inaktive Versionen können den Status `pending`/`approved`/
+// `rejected` haben; das wird zur Information angezeigt, blockiert die
+// Aktivierung aber nicht.
 //
-// Die Vorauswahl der Kandidaten (Downgrade-Filter) macht der Aufrufer in
-// TemplateOwnerDetailDialog; hier kommt nur die fertige Liste an.
+// Downgrade-Hinweis: bewusst keine Strictly-Newer-Sperre. Wenn die jüngste
+// Version z.B. einen Bug hat, soll der Owner zurück auf eine ältere
+// Version wechseln können. Backend (`activate_version` +
+// `deactivate_other_versions`) erlaubt das atomar.
+//
+// Die Vorauswahl der Kandidaten macht der Aufrufer in
+// TemplateOwnerDetailDialog; hier kommt nur die fertige Liste an. Aktive
+// Version wird vom Aufrufer aus der Liste ausgeschlossen.
 
 import { useEffect, useState } from "react";
-import { ArrowUpCircle, GitBranch } from "lucide-react";
+import { ArrowLeftRight, GitBranch } from "lucide-react";
 import { toast } from "sonner@2.0.3";
 import {
   Dialog,
@@ -34,7 +41,7 @@ interface Props {
   onActivated: () => void;
 }
 
-export function UpgradeVersionDialog({
+export function ChangeActiveVersionDialog({
   open,
   onOpenChange,
   candidates,
@@ -55,7 +62,7 @@ export function UpgradeVersionDialog({
     setBusy(true);
     try {
       await activateTemplateVersion(selected);
-      toast.success("Version aktiviert.");
+      toast.success("Aktive Version geändert.");
       onActivated();
     } catch (err) {
       toast.error(
@@ -71,12 +78,13 @@ export function UpgradeVersionDialog({
       <DialogContent className="max-w-xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <ArrowUpCircle className="w-5 h-5 text-teal-600" />
-            Auf neuere Version aktualisieren
+            <ArrowLeftRight className="w-5 h-5 text-teal-600" />
+            Aktive Version ändern
           </DialogTitle>
           <DialogDescription>
-            Wähle eine bereits importierte, neuere Version. Downgrades sind
-            nicht möglich.
+            Wähle die Version, die im Deployment-Wizard vorausgewählt werden
+            soll. Du kannst auch zu einer älteren Version wechseln —
+            Downgrades sind erlaubt.
           </DialogDescription>
         </DialogHeader>
 
@@ -88,8 +96,9 @@ export function UpgradeVersionDialog({
 
         {candidates.length === 0 ? (
           <p className="text-sm text-slate-500 italic">
-            Keine neuere Version verfügbar. Importiere zunächst eine neue
-            Version aus dem verknüpften Repository.
+            Es gibt keine weitere Version, die du aktivieren könntest.
+            Importiere zunächst eine neue Version aus dem verknüpften
+            Repository.
           </p>
         ) : (
           <RadioGroup
@@ -133,10 +142,14 @@ export function UpgradeVersionDialog({
             onClick={handleActivate}
             disabled={!selected || busy || candidates.length === 0}
           >
-            {busy ? "Wird aktiviert…" : "Aktivieren"}
+            {busy ? "Wird aktiviert…" : "Als aktiv setzen"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
   );
 }
+
+// Backwards-compat alias: andere Imports referenzieren ggf. noch den alten
+// Namen. Wenn alle Aufrufer umgezogen sind, kann dieser Re-Export raus.
+export { ChangeActiveVersionDialog as UpgradeVersionDialog };

--- a/src/lib/github-url.ts
+++ b/src/lib/github-url.ts
@@ -85,3 +85,29 @@ export function buildGithubUrl(parts: {
     .join("/");
   return `${base}/${refSeg}/${pathSeg}`;
 }
+
+/** Baut eine GitHub-Edit-URL für eine konkrete Datei. Genutzt vom UI, wenn
+ *  ein Backend-Fehler dem Owner empfiehlt „bumpe `app.version` im Repo": der
+ *  Edit-Button springt direkt in GitHubs Web-Editor für die `app.yaml`.
+ *
+ *  Format laut GitHub-Convention:
+ *    https://github.com/{owner}/{repo}/edit/{ref}/{path}
+ *  Falls kein ref bekannt ist, fallen wir auf `main` zurück — der Owner kann
+ *  im GitHub-UI nachträglich den Branch wechseln, das ist weniger störend
+ *  als ein 404 wegen fehlendem Branch.
+ */
+export function buildGithubEditUrl(parts: {
+  owner: string;
+  repo: string;
+  ref?: string | null;
+  path: string;
+}): string {
+  const ref = parts.ref ?? "main";
+  const refSeg = encodeURIComponent(ref);
+  const pathSeg = parts.path
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+  return `https://github.com/${parts.owner}/${parts.repo}/edit/${refSeg}/${pathSeg}`;
+}

--- a/src/lib/template-status.ts
+++ b/src/lib/template-status.ts
@@ -4,6 +4,9 @@
 //
 //   1. `deriveTemplateOverallStatus(template)` leitet eine UI-taugliche
 //      Aggregations-Bewertung aus den Versionen ab. Reihenfolge:
+//        - publish_requested ist gesetzt UND es gibt PENDING-Versionen
+//          (Owner hat „öffentlich" gewählt; Template ist PRIVATE bis
+//          zur Erst-Genehmigung) → "awaiting_publish"
 //        - Hat eine `approval_status === null` & is_active Version
 //          (Private-Template — kein Approval-Flow, direkt nutzbar) → "active"
 //        - Hat eine APPROVED & is_active Version  → "active"
@@ -24,17 +27,31 @@
 import type { TemplateDto, TemplateVersionApprovalStatus } from "../api/templates";
 
 export type TemplateOverallStatus =
+  | "awaiting_publish"  // Owner hat „öffentlich" gewählt; wartet auf Erst-Genehmigung
   | "active"     // mind. eine deploybare Version (approved+aktiv oder Private)
   | "approved"   // approved Versionen vorhanden, aber keine aktive
-  | "pending"    // wartet auf Admin-Approval
+  | "pending"    // wartet auf Admin-Approval (bestehend-öffentliches Template)
   | "rejected"   // alles abgelehnt oder veraltet
   | "empty";     // gar keine Versionen importiert
 
 export function deriveTemplateOverallStatus(
-  template: Pick<TemplateDto, "versions">,
+  template: Pick<TemplateDto, "versions" | "publish_requested" | "visibility">,
 ): TemplateOverallStatus {
   const versions = template.versions ?? [];
   if (versions.length === 0) return "empty";
+
+  // Erst-Veröffentlichungs-Pfad: Owner hat das Template als „öffentlich"
+  // markiert, Backend hält es bis zur Erst-Genehmigung als PRIVATE +
+  // publish_requested. Wir zeigen das DEM OWNER als eigenständigen Status,
+  // damit es nicht fälschlich als „nur privat" oder „normal pending"
+  // wahrgenommen wird. Andere (Non-Owner) sehen dieses Template ohnehin
+  // gar nicht erst — Backend filtert sie aus.
+  if (
+    template.publish_requested === true
+    && versions.some((v) => v.approval_status === "pending")
+  ) {
+    return "awaiting_publish";
+  }
 
   // Private-Templates: Versionen tragen approval_status === null und sind
   // für den Owner ohne weiteren Workflow nutzbar.
@@ -79,6 +96,11 @@ export function overallBadgeStyle(
   status: TemplateOverallStatus,
 ): { text: string; cls: string } {
   switch (status) {
+    case "awaiting_publish":
+      return {
+        text: "wartet auf Erst-Freigabe",
+        cls: "bg-amber-100 text-amber-700",
+      };
     case "active":
       return { text: "einsatzbereit", cls: "bg-green-100 text-green-700" };
     case "approved":

--- a/src/pages/AppStore.tsx
+++ b/src/pages/AppStore.tsx
@@ -150,8 +150,21 @@ export function AppStore({ onDeploy }: AppStoreProps) {
     if (!template.name.toLowerCase().includes(searchQuery.toLowerCase())) {
       return false;
     }
-    if (visibilityFilter !== 'all' && template.visibility !== visibilityFilter) {
-      return false;
+    if (visibilityFilter !== 'all') {
+      // „Öffentlich" filtert auch eigene Templates ein, deren Marktplatz-
+      // Veröffentlichung noch auf Erst-Genehmigung wartet (publish_requested):
+      // sie tragen aktuell visibility=private, gehören aber konzeptuell in den
+      // „Öffentlich"-Tab — sonst verschwinden sie für den Owner aus dem Blick.
+      // „Privat" zeigt nur „echt-private" (kein laufender Marktplatz-Wunsch).
+      if (visibilityFilter === 'public') {
+        const isPublicLike =
+          template.visibility === 'public' || template.publish_requested === true;
+        if (!isPublicLike) return false;
+      } else if (visibilityFilter === 'private') {
+        if (template.visibility !== 'private' || template.publish_requested === true) {
+          return false;
+        }
+      }
     }
     if (ownershipFilter === 'mine' && template.owner_id !== myInternalUserId) {
       return false;
@@ -308,6 +321,18 @@ export function AppStore({ onDeploy }: AppStoreProps) {
                             Öffentlich
                           </Badge>
                         )}
+                        {/* Erst-Veröffentlichung-Hinweis: das Template ist
+                            noch PRIVATE in der DB, aber der Owner hat es
+                            für die Marketplace beantragt. Wir zeigen es
+                            visuell wie ein angefragtes „öffentlich" —
+                            blau-amber-Mix wäre verwirrend, deshalb
+                            durchgängig amber wie der overall-badge. */}
+                        {template.visibility === 'private'
+                          && template.publish_requested === true && (
+                            <Badge className="bg-amber-100 text-amber-700 hover:bg-amber-100">
+                              Öffentlich (offen)
+                            </Badge>
+                        )}
                       </div>
                     </div>
                     <CardTitle className="text-slate-900 line-clamp-2 min-h-[3.5rem]">{template.name}</CardTitle>
@@ -436,6 +461,12 @@ export function AppStore({ onDeploy }: AppStoreProps) {
                 />
                 {selectedTemplate.visibility === 'public' && (
                   <Badge className="bg-blue-100 text-blue-700">Öffentlich</Badge>
+                )}
+                {selectedTemplate.visibility === 'private'
+                  && selectedTemplate.publish_requested === true && (
+                    <Badge className="bg-amber-100 text-amber-700">
+                      Öffentlich (offen)
+                    </Badge>
                 )}
               </div>
 


### PR DESCRIPTION
Frontend-Companion zu DoziLab/appstore-backend#171. Drei UI-Flows, die nicht zum tatsächlichen Datenmodell passen:

## 1) „Öffentlich" beim Anlegen + `awaiting_publish`-State

Backend hält ein publish-requestedes Template bis zur Erst-Freigabe als `PRIVATE`. Das UI spiegelt das jetzt sauber:

- Neuer `TemplateOverallStatus = "awaiting_publish"` in [`lib/template-status.ts`](src/lib/template-status.ts) — amber Badge **„wartet auf Erst-Freigabe"**
- AppStore-Filter „Öffentlich" inkludiert eigene `publish_requested`-Templates, damit der Owner sie im selben Tab sieht, in dem sie nach der Freigabe landen
- AppStore-Karte + Detail zeigen Badge **„Öffentlich (offen)"** wenn `visibility=private && publish_requested=true`
- `AddTemplateDialog`-Success-Toast spiegelt den neuen Flow

## 2) Strukturierte Backend-Fehler → handlungsorientierte UI

`apiFetch` wirft jetzt eine typisierte [`ApiError`](src/api/http.ts), die `code` + `details` aus dem `errors`-Envelope des Backends trägt. Zwei Import-Flow-Komponenten branchen darauf:

- **`AddTemplateDialog`**: Inline-Message pro `VERSION_*`-Code mit konkretem Next-Step („ergänze `app.version` in app.yaml")
- **`CheckRemoteVersionsDialog`**: Pro fehlgeschlagenem Kandidat zwei Aktionen — **„Im Repo bumpen"** öffnet die `app.yaml` im GitHub-Web-Editor (neuer [`buildGithubEditUrl`](src/lib/github-url.ts)-Helper), **„Bestehende Version ersetzen"** retried mit `replace_existing=true` nach Confirm-Dialog. Replace bleibt blockiert, wenn aktive Deployments noch auf die alte Row zeigen.

## 3) „Aktualisieren" → „Aktive Version ändern"

Alter Name suggerierte „nur Upgrade", und der Filter (`isStrictlyNewer(v, active)`) hat das auch erzwungen — sobald die neueste Version aktiv war, hat der Button sich für immer ausgegraut. Backend unterstützt schon immer freies Switching (`deactivate_other_versions` arbeitet in beide Richtungen).

- Filter relaxiert zu `versions.filter(v => !v.is_active)` → jede nicht-aktive Version ist Kandidat (auch ältere)
- Komponente umbenannt: `UpgradeVersionDialog` → `ChangeActiveVersionDialog` (Datei bleibt, Backward-Compat-Alias re-exportiert). Title/Description angepasst, Downgrade-Hinweis raus
- Button-Label + Icon: „Aktualisieren" + `ArrowUpCircle` → **„Aktive Version ändern"** + `ArrowLeftRight`

## File summary

| Datei | Was |
|---|---|
| `src/api/http.ts` | typisierte `ApiError` mit `code`/`details` |
| `src/api/github.ts` | `replace_existing` in `ImportNewVersionBody`, `VERSION_ERROR_CODES` const-union, `publish_requested` auf Queue-Type |
| `src/api/templates.ts` | `publish_requested?: boolean` auf `TemplateDto` |
| `src/lib/github-url.ts` | neuer `buildGithubEditUrl(parts)` |
| `src/lib/template-status.ts` | `awaiting_publish`-State + Badge |
| `src/components/ApprovalBadge.tsx` | Icon-Mapping für den neuen State |
| `src/pages/AppStore.tsx` | Filter + Badge-Wiring |
| `src/components/AddTemplateDialog.tsx` | `humanizeImportError` |
| `src/components/CheckRemoteVersionsDialog.tsx` | Pro-Kandidat-Aktionen |
| `src/components/UpgradeVersionDialog.tsx` | Umbenannt + Downgrade-friendly |
| `src/components/TemplateOwnerDetailDialog.tsx` | Filter + Button + Icon |

## Verifikation

Diff syntaktisch über `tsc --noEmit` gegen die berührten Dateien — keine Type-Errors (Infra-Errors wegen Vite-spezifischer `import.meta.env` und der `lib@version`-Import-Aliase sind preexisting im Repo).

## Reihenfolge

Backend-PR DoziLab/appstore-backend#171 muss zuerst gemergt + Migrationen müssen gelaufen sein. Ohne `publish_requested` auf der TemplateDto kennt das Frontend den `awaiting_publish`-State nicht und Backend-Replace-Requests landen auf einem 400 mit der alten String-Message.