### PR TITLE
docs(wizard): course_group_id-null-Pfad explizit auf Backend #169 ver…

### DIFF
--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -877,7 +877,16 @@ export function DeploymentWizard({
           groups: stack.assignedGroups.map((group) => ({
             group_name: group.groupName,
             group_index: group.groupId ? parseInt(group.groupId.replace(/\D/g, '')) || stackIndex + 1 : stackIndex + 1,
-            // course_group_id is resolved by the backend (get-or-create by name).
+            // Backend (DoziLab/appstore-backend#169) materialisiert die
+            // Mitgliedschaftskette synchron beim Deploy-POST:
+            // CourseMember/CourseGroup/GroupMember werden idempotent per
+            // (course_id, name) und (user_id, course_id) upgesertet, und die
+            // aufgelöste `course_group_id` wird in deployment_parameters
+            // zurückgeschrieben, bevor der Celery-Task Credentials persistiert.
+            // Daher sendet der Wizard hier explizit null — das Frontend hat
+            // keine zuverlässige Quelle für die persistierte CourseGroup-ID
+            // (Chicken-and-Egg auf dem ersten Deploy eines Courses), und der
+            // Read-Pfad /api/v1/student/deployments funktioniert trotzdem.
             course_group_id: null,
             students: group.students.map((student) => ({
               id: student.id,


### PR DESCRIPTION
…ankern

Staging hatte die alte Chicken-and-Egg-Logik um getMyCourses/getCourseGroups bereits entfernt und sendet course_group_id unbedingt als null — verlaesst sich also auf einen Backend-Backfill, den es zum Zeitpunkt des Refactors noch nicht gab. Das war exakt der Bug aus #171: Studenten sahen ihre Deployments nicht.

DoziLab/appstore-backend#169 schliesst die Luecke jetzt serverseitig: bei POST /deployments werden CourseMember/CourseGroup/GroupMember synchron per (course_id, name) und (user_id, course_id) upgesertet und course_group_id wird in deployment_parameters zurueckgeschrieben, bevor der Celery-Task die Credentials persistiert.

Damit ist 'course_group_id: null' an dieser Stelle kein Workaround mehr, sondern Vertrag. Diese Aenderung praezisiert den Kommentar so, dass jeder spaetere Leser sofort sieht (a) warum der Wizard hier nicht versucht die ID aufzuloesen und (b) welcher Backend-Mechanismus dafuer einspringt.

Closes #171