### PR TITLE
fix(ui): allow user-data strings and dashboard buttons to wrap instea…

### DIFF
--- a/src/components/GroupToStackAssigner.tsx
+++ b/src/components/GroupToStackAssigner.tsx
@@ -159,13 +159,13 @@ export function GroupToStackAssigner({
               <Card key={stack.stackId} className="border-slate-200">
                 <CardHeader className="pb-3">
                   <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3 flex-1">
+                    <div className="flex items-center gap-3 flex-1 min-w-0">
                       <Button
                         type="button"
                         variant="ghost"
                         size="sm"
                         onClick={() => toggleStackExpanded(stack.stackId)}
-                        className="p-1 h-auto"
+                        className="p-1 h-auto flex-shrink-0"
                       >
                         {isExpanded ? (
                           <ChevronUp className="w-4 h-4" />
@@ -173,8 +173,8 @@ export function GroupToStackAssigner({
                           <ChevronDown className="w-4 h-4" />
                         )}
                       </Button>
-                      <Server className="w-4 h-4 text-slate-600" />
-                      <span className="text-sm font-medium">{stack.stackName}</span>
+                      <Server className="w-4 h-4 text-slate-600 flex-shrink-0" />
+                      <span className="text-sm font-medium truncate min-w-0">{stack.stackName}</span>
                       <Badge variant="secondary" className="text-xs">
                         {stack.assignedGroups.length} Gruppe
                         {stack.assignedGroups.length !== 1 ? 'n' : ''}

--- a/src/components/TemplateOwnerDetailDialog.tsx
+++ b/src/components/TemplateOwnerDetailDialog.tsx
@@ -314,8 +314,8 @@ export function TemplateOwnerDetailDialog({
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <span>{template.name}</span>
+            <DialogTitle className="flex items-center gap-2 min-w-0">
+              <span className="break-words min-w-0">{template.name}</span>
               <Badge variant="outline" className="text-xs">
                 eigenes Template
               </Badge>

--- a/src/pages/AdminMonitoring.tsx
+++ b/src/pages/AdminMonitoring.tsx
@@ -507,7 +507,7 @@ export function AdminMonitoring() {
                           className="cursor-pointer hover:bg-slate-50"
                           onClick={() => setSelectedTeacher(project.teacher)}
                         >
-                          <TableCell className="text-slate-900">
+                          <TableCell className="text-slate-900 whitespace-normal break-words">
                             {project.teacher.name}
                           </TableCell>
                           <TableCell>
@@ -535,8 +535,8 @@ export function AdminMonitoring() {
                     ← Zurück
                   </Button>
                   <div className="mb-4">
-                    <h3 className="text-lg font-semibold text-slate-900">Deployments von {selectedTeacher.name}</h3>
-                    <p className="text-sm text-slate-500">{selectedTeacher.email}</p>
+                    <h3 className="text-lg font-semibold text-slate-900 break-words">Deployments von {selectedTeacher.name}</h3>
+                    <p className="text-sm text-slate-500 break-all">{selectedTeacher.email}</p>
                   </div>
                   <Table>
                     <TableHeader>
@@ -556,9 +556,9 @@ export function AdminMonitoring() {
                             className="cursor-pointer hover:bg-slate-50"
                             onClick={() => navigate(`/deployment/${d.id}`)}
                           >
-                            <TableCell className="text-slate-900 text-blue-600 hover:underline">{d.name}</TableCell>
-                            <TableCell>{extractCourse(d)}</TableCell>
-                            <TableCell>{d.template_version?.template_name || '—'}</TableCell>
+                            <TableCell className="text-slate-900 text-blue-600 hover:underline whitespace-normal break-words">{d.name}</TableCell>
+                            <TableCell className="whitespace-normal break-words">{extractCourse(d)}</TableCell>
+                            <TableCell className="whitespace-normal break-words">{d.template_version?.template_name || '—'}</TableCell>
                             <TableCell className="text-sm text-slate-600">
                               {new Date(d.created_at).toLocaleString()}
                             </TableCell>
@@ -617,7 +617,7 @@ export function AdminMonitoring() {
                     ← Zurück
                   </Button>
                   <div className="mb-4">
-                    <h3 className="text-lg font-semibold text-slate-900">Deployments im Kurs {selectedCourse}</h3>
+                    <h3 className="text-lg font-semibold text-slate-900 break-words">Deployments im Kurs {selectedCourse}</h3>
                   </div>
                   <Table>
                     <TableHeader>
@@ -637,9 +637,9 @@ export function AdminMonitoring() {
                             className="cursor-pointer hover:bg-slate-50"
                             onClick={() => navigate(`/deployment/${d.id}`)}
                           >
-                            <TableCell className="text-slate-900 text-blue-600 hover:underline">{d.name}</TableCell>
-                            <TableCell>{extractTeacher(d).name}</TableCell>
-                            <TableCell>{d.template_version?.template_name || '—'}</TableCell>
+                            <TableCell className="text-slate-900 text-blue-600 hover:underline whitespace-normal break-words">{d.name}</TableCell>
+                            <TableCell className="whitespace-normal break-words">{extractTeacher(d).name}</TableCell>
+                            <TableCell className="whitespace-normal break-words">{d.template_version?.template_name || '—'}</TableCell>
                             <TableCell className="text-sm text-slate-600">
                               {new Date(d.created_at).toLocaleString()}
                             </TableCell>
@@ -668,9 +668,9 @@ export function AdminMonitoring() {
                         className="cursor-pointer hover:bg-slate-50"
                         onClick={() => navigate(`/deployment/${d.id}`)}
                       >
-                        <TableCell className="text-blue-600 hover:underline">{d.name}</TableCell>
-                        <TableCell>{extractCourse(d)}</TableCell>
-                        <TableCell>{extractTeacher(d).name}</TableCell>
+                        <TableCell className="text-blue-600 hover:underline whitespace-normal break-words">{d.name}</TableCell>
+                        <TableCell className="whitespace-normal break-words">{extractCourse(d)}</TableCell>
+                        <TableCell className="whitespace-normal break-words">{extractTeacher(d).name}</TableCell>
                         <TableCell className="text-sm text-slate-600">{new Date(d.created_at).toLocaleString()}</TableCell>
                         <TableCell><Badge variant="outline">{d.status}</Badge></TableCell>
                       </TableRow>

--- a/src/pages/AppStore.tsx
+++ b/src/pages/AppStore.tsx
@@ -306,11 +306,15 @@ export function AppStore({ onDeploy }: AppStoreProps) {
               return (
                 <Card key={template.id} className="border-slate-200 shadow-sm hover:shadow-md transition-all hover:border-teal-200 flex flex-col h-full">
                   <CardHeader className="flex-shrink-0">
-                    <div className="flex items-start justify-between mb-3">
-                      <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${style.color} flex items-center justify-center text-white shadow-lg`}>
+                    <div className="flex items-start justify-between gap-3 mb-3">
+                      <div className={`flex-shrink-0 w-12 h-12 rounded-xl bg-gradient-to-br ${style.color} flex items-center justify-center text-white shadow-lg`}>
                         <Icon className="w-6 h-6" />
                       </div>
-                      <div className="flex gap-2">
+                      {/* flex-wrap: in der schmalen Karten-Spalte (3-col-Grid)
+                          passen „einsatzbereit" + „Öffentlich (offen)" oft
+                          nicht nebeneinander — ohne wrap überlaufen die
+                          shrink-0/whitespace-nowrap-Badges die Karte. */}
+                      <div className="flex flex-wrap justify-end gap-2 min-w-0">
                         <ApprovalBadge
                           status={deriveTemplateOverallStatus(template)}
                           variant="overall"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -257,42 +257,42 @@
                     <Button
                       variant="outline"
                       onClick={() => navigate('/appstore')}
-                      className="group w-full justify-start gap-3 h-auto py-3 px-4 border-slate-200 hover:bg-teal-50 hover:border-teal-200 transition-colors"
+                      className="group w-full justify-start gap-3 h-auto py-3 px-4 border-slate-200 hover:bg-teal-50 hover:border-teal-200 transition-colors whitespace-normal"
                     >
-                      <div className="bg-teal-50 text-teal-600 p-2 rounded-md group-hover:bg-teal-100 transition-colors">
+                      <div className="bg-teal-50 text-teal-600 p-2 rounded-md group-hover:bg-teal-100 transition-colors flex-shrink-0">
                         <Rocket className="w-4 h-4" />
                       </div>
-                      <div className="text-left">
-                        <p className="text-sm font-medium text-slate-900 group-hover:text-teal-700 transition-colors">Neue App deployen</p>
-                        <p className="text-xs text-slate-500">Anwendung bereitstellen</p>
+                      <div className="text-left min-w-0 flex-1">
+                        <p className="text-sm font-medium text-slate-900 group-hover:text-teal-700 transition-colors break-words">Neue App deployen</p>
+                        <p className="text-xs text-slate-500 break-words">Anwendung bereitstellen</p>
                       </div>
                     </Button>
 
                     <Button
                       variant="outline"
                       onClick={() => navigate('/appstore')}
-                      className="group w-full justify-start gap-3 h-auto py-3 px-4 border-slate-200 hover:bg-teal-50 hover:border-teal-200 transition-colors"
+                      className="group w-full justify-start gap-3 h-auto py-3 px-4 border-slate-200 hover:bg-teal-50 hover:border-teal-200 transition-colors whitespace-normal"
                     >
-                      <div className="bg-blue-50 text-blue-600 p-2 rounded-md group-hover:bg-blue-100 transition-colors">
+                      <div className="bg-blue-50 text-blue-600 p-2 rounded-md group-hover:bg-blue-100 transition-colors flex-shrink-0">
                         <BookTemplate className="w-4 h-4" />
                       </div>
-                      <div className="text-left">
-                        <p className="text-sm font-medium text-slate-900 group-hover:text-blue-700 transition-colors">Neues Template hinzufügen</p>
-                        <p className="text-xs text-slate-500">Template erstellen</p>
+                      <div className="text-left min-w-0 flex-1">
+                        <p className="text-sm font-medium text-slate-900 group-hover:text-blue-700 transition-colors break-words">Neues Template hinzufügen</p>
+                        <p className="text-xs text-slate-500 break-words">Template erstellen</p>
                       </div>
                     </Button>
 
                     <Button
                       variant="outline"
                       onClick={() => navigate('/courses')}
-                      className="group w-full justify-start gap-3 h-auto py-3 px-4 border-slate-200 hover:bg-teal-50 hover:border-teal-200 transition-colors"
+                      className="group w-full justify-start gap-3 h-auto py-3 px-4 border-slate-200 hover:bg-teal-50 hover:border-teal-200 transition-colors whitespace-normal"
                     >
-                      <div className="bg-purple-50 text-purple-600 p-2 rounded-md group-hover:bg-purple-100 transition-colors">
+                      <div className="bg-purple-50 text-purple-600 p-2 rounded-md group-hover:bg-purple-100 transition-colors flex-shrink-0">
                         <BookOpen className="w-4 h-4" />
                       </div>
-                      <div className="text-left">
-                        <p className="text-sm font-medium text-slate-900 group-hover:text-purple-700 transition-colors">Kurse verwalten</p>
-                        <p className="text-xs text-slate-500">Kurse einsehen</p>
+                      <div className="text-left min-w-0 flex-1">
+                        <p className="text-sm font-medium text-slate-900 group-hover:text-purple-700 transition-colors break-words">Kurse verwalten</p>
+                        <p className="text-xs text-slate-500 break-words">Kurse einsehen</p>
                       </div>
                     </Button>
               </CardContent>

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -508,8 +508,8 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
 
         <div className="flex items-start justify-between">
           <div>
-            <h1 className="text-slate-900 mb-2">{deployment.name}</h1>
-            <p className="text-slate-600">{deployment.course}</p>
+            <h1 className="text-slate-900 mb-2 break-words">{deployment.name}</h1>
+            <p className="text-slate-600 break-words">{deployment.course}</p>
             {deployment.templateName && (
               <p className="text-sm text-slate-500 mt-1">
                 Template: {deployment.templateName}{deployment.templateVersion ? ` (${deployment.templateVersion})` : ''}

--- a/src/pages/StudentDeploymentDetails.tsx
+++ b/src/pages/StudentDeploymentDetails.tsx
@@ -215,10 +215,10 @@ export function StudentDeploymentDetails({
       {!deploymentLoading && !deploymentError && deployment && (
         <>
           <header className="space-y-1">
-            <h1 className="text-2xl font-semibold text-slate-900">
+            <h1 className="text-2xl font-semibold text-slate-900 break-words">
               {deployment.name}
             </h1>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-500 break-words">
               {deployment.template.name || "Template"}
               {deployment.template.version
                 ? ` · v${deployment.template.version}`


### PR DESCRIPTION
…d of overflow

- AppStore template card: badge row gets flex-wrap + min-w-0 so 'einsatzbereit' + 'Öffentlich (offen)' don't shove past the card edge in the 3-col grid; outer row gains gap-3 and the icon block shrink-0.
- Dashboard 'Aktionen' card: each action Button overrides the base whitespace-nowrap, icon box becomes flex-shrink-0, and the text column gets min-w-0 flex-1 + break-words so long labels wrap instead of spilling past the (lg:col-span-1) card.
- AdminMonitoring: h3 'Deployments von {teacher}' / 'im Kurs {course}' get break-words; user-data TableCells override the TableCell base whitespace-nowrap with whitespace-normal break-words so long names don't push other columns off-screen.
- DeploymentDetails + StudentDeploymentDetails: deployment-name h1 and the template/course caption get break-words.
- GroupToStackAssigner stack header: classic flex trap fixed — parent row gets min-w-0, surrounding icons flex-shrink-0, and the stack-name span gets truncate min-w-0 so the trailing whitespace-nowrap badges stay inside the card.
- TemplateOwnerDetailDialog: same flex trap on DialogTitle — the shrink-0 'eigenes Template' badge no longer gets pushed out by long template names.