### PR TITLE
feat: Lecturer-Verwaltung (Admin: Liste + Detail + Cascade-Delete)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { Courses } from "./pages/Courses";
 import { OpenStackConfig } from "./pages/OpenStackConfig";
 import { AdminMonitoring } from "./pages/AdminMonitoring";
+import { LecturerManagement } from "./pages/LecturerManagement";
 import { Sidebar } from "./layouts/Sidebar";
 import { Login } from "./pages/Login";
 import { DashboardPage } from "./pages/DashboardPage";
@@ -251,6 +252,14 @@ export default function App() {
               element={
                 <ProtectedRoute requireAdmin>
                   <AdminMonitoring />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/admin/lecturers"
+              element={
+                <ProtectedRoute requireAdmin>
+                  <LecturerManagement />
                 </ProtectedRoute>
               }
             />

--- a/src/api/lecturers.ts
+++ b/src/api/lecturers.ts
@@ -1,0 +1,125 @@
+// Admin-only endpoints für die Lecturer-Verwaltung. Backend-Routen:
+// GET  /api/v1/lecturers               — paginierte Liste (nur User mit
+//                                        Templates ODER OpenStack-Projekten)
+// GET  /api/v1/lecturers/{user_id}     — Detail mit vollständigen Ressourcen
+// DEL  /api/v1/lecturers/{user_id}     — 202 Accepted; Cascade-Delete läuft
+//                                        asynchron via Celery, das UI muss
+//                                        die Detail-View pollen um Erfolg zu
+//                                        detektieren (User verschwindet aus
+//                                        der Liste bzw. 404 auf Detail).
+//
+// Alle Endpoints prüfen die admin-Rolle serverseitig. Ein Non-Admin bekommt
+// 403 — das UI gate’t die Route zusätzlich via <ProtectedRoute requireAdmin>.
+
+import { apiFetch } from "./http";
+
+export type LecturerListItem = {
+  id: string;
+  external_id: string;
+  display_name: string | null;
+  email: string | null;
+  username: string | null;
+  last_login_at: string | null;
+  template_count: number;
+  deployment_count: number;
+  openstack_project_count: number;
+};
+
+export type LecturerTemplateSummary = {
+  id: string;
+  name: string;
+  visibility: string;
+  version_count: number;
+};
+
+export type LecturerDeploymentSummary = {
+  id: string;
+  name: string;
+  status: string;
+  course_id: string | null;
+  expires_at: string | null;
+  created_at: string;
+};
+
+export type LecturerOpenstackProjectSummary = {
+  id: string;
+  openstack_project_name: string;
+  region_name: string;
+};
+
+export type LecturerDetail = LecturerListItem & {
+  templates: LecturerTemplateSummary[];
+  deployments: LecturerDeploymentSummary[];
+  openstack_projects: LecturerOpenstackProjectSummary[];
+};
+
+export type LecturersResponse = {
+  success: boolean;
+  message: string;
+  data: LecturerListItem[];
+  pagination: {
+    page: number;
+    page_size: number;
+    total_items: number;
+    total_pages: number;
+  };
+  errors: unknown;
+  timestamp: string;
+  request_id: string;
+};
+
+export type LecturerDetailResponse = {
+  success: boolean;
+  message: string;
+  data: LecturerDetail;
+  errors: unknown;
+  timestamp: string;
+  request_id: string;
+};
+
+export type LecturerDeleteResponse = {
+  success: boolean;
+  message: string;
+  data: {
+    task_id: string;
+    user_id: string;
+    deployment_count: number;
+    template_count: number;
+  };
+  errors: unknown;
+  timestamp: string;
+  request_id: string;
+};
+
+export async function listLecturers(params?: {
+  skip?: number;
+  limit?: number;
+  search?: string;
+}) {
+  const sp = new URLSearchParams();
+  if (params?.skip !== undefined) sp.set("skip", String(params.skip));
+  if (params?.limit !== undefined) sp.set("limit", String(params.limit));
+  if (params?.search) sp.set("search", params.search);
+  const qs = sp.toString();
+  return apiFetch<LecturersResponse>(
+    `/api/v1/lecturers${qs ? `?${qs}` : ""}`,
+  );
+}
+
+export async function getLecturer(userId: string) {
+  return apiFetch<LecturerDetailResponse>(`/api/v1/lecturers/${userId}`);
+}
+
+/**
+ * Startet den asynchronen Cascade-Delete eines Lecturer-Accounts. Backend
+ * antwortet direkt mit 202 Accepted und einer Celery-Task-ID. Die
+ * tatsächliche Löschung (Deployments mit Heat-Cleanup, Templates,
+ * OSP-Zeilen, User-Zeile) läuft im Hintergrund — Erfolg detektiert das UI
+ * per Polling der Detail-View (404 = weg).
+ */
+export async function deleteLecturer(userId: string) {
+  return apiFetch<LecturerDeleteResponse>(
+    `/api/v1/lecturers/${userId}`,
+    { method: "DELETE" },
+  );
+}

--- a/src/components/DeleteLecturerConfirmDialog.tsx
+++ b/src/components/DeleteLecturerConfirmDialog.tsx
@@ -1,0 +1,190 @@
+// Bestätigungs-Dialog vor dem Cascade-Delete eines Lecturer-Accounts.
+//
+// Der Delete ist unwiderruflich und löscht cascading:
+//   • alle Deployments des Users (inkl. Heat-Stacks in OpenStack)
+//   • alle Templates + Versionen
+//   • alle OpenStack-Projekt-Rows (nur unsere DB — nicht Keystone!)
+//   • zuletzt den User-Row selbst
+// Deshalb typische destruktive-Aktion-UX: der Admin muss den Namen (oder
+// den Username / die Email — Fallback in dieser Reihenfolge) des Users
+// exakt eintippen, bevor der Button aktiv wird.
+//
+// Der Backend-Delete ist asynchron (202 + Celery-Task-ID). Erfolg wird
+// deshalb NICHT hier detektiert — dieser Dialog schließt lediglich sobald
+// der 202 zurückkommt. Das Polling passiert im aufrufenden Detail-View.
+
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Trash2 } from "lucide-react";
+import { toast } from "sonner@2.0.3";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { deleteLecturer, type LecturerDetail } from "../api/lecturers";
+import { ApiError } from "../api/http";
+
+interface Props {
+  lecturer: LecturerDetail;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Callback nach 202 Accepted — der aufrufende Detail-View startet dann
+   *  das Polling. Bekommt die Task-ID mit, damit man sie z.B. für einen
+   *  Toast oder späteren Debug-Log verwenden könnte. */
+  onDeleteEnqueued: (taskId: string) => void;
+}
+
+export function DeleteLecturerConfirmDialog({
+  lecturer,
+  open,
+  onOpenChange,
+  onDeleteEnqueued,
+}: Props) {
+  const [typedName, setTypedName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  // Was muss der Admin abtippen? display_name ist der bevorzugte Wert, weil
+  // er in der Tabelle auch groß angezeigt wird. Fallback in derselben
+  // Reihenfolge wie im Rest des UIs — sonst wären User ohne
+  // Display-Name/Username nicht löschbar.
+  const expected = useMemo(
+    () =>
+      lecturer.display_name?.trim() ||
+      lecturer.username?.trim() ||
+      lecturer.email?.trim() ||
+      lecturer.id,
+    [lecturer],
+  );
+
+  // Beim Öffnen/Schließen den Zustand zurücksetzen, damit ein zweiter Delete
+  // nicht mit halb-getipptem Namen startet.
+  useEffect(() => {
+    if (open) {
+      setTypedName("");
+      setBusy(false);
+    }
+  }, [open, lecturer.id]);
+
+  const nameMatches = typedName.trim() === expected;
+  const canDelete = nameMatches && !busy;
+
+  const handleDelete = async () => {
+    if (!canDelete) return;
+    setBusy(true);
+    try {
+      const resp = await deleteLecturer(lecturer.id);
+      onDeleteEnqueued(resp.data.task_id);
+      onOpenChange(false);
+    } catch (err) {
+      // Häufigste Fehlerfälle laut Backend: 400 (Admin löscht sich selbst),
+      // 404 (User ist kein Lecturer mehr — z.B. wenn parallel schon
+      // gelöscht). Beide sind für den Admin über die Message klar genug.
+      const message =
+        err instanceof ApiError || err instanceof Error
+          ? err.message
+          : "Löschen konnte nicht ausgelöst werden.";
+      toast.error(message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2 text-red-700">
+            <AlertTriangle className="w-5 h-5" />
+            Lecturer-Account löschen?
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3 text-sm">
+              <p>
+                Dies wird <span className="font-semibold">permanent</span> die
+                folgenden Ressourcen von{" "}
+                <span className="font-semibold">{expected}</span> entfernen:
+              </p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>
+                  <span className="font-semibold">
+                    {lecturer.deployment_count}
+                  </span>{" "}
+                  Deployment
+                  {lecturer.deployment_count === 1 ? "" : "s"} (inkl.
+                  Heat-Stacks in OpenStack)
+                </li>
+                <li>
+                  <span className="font-semibold">
+                    {lecturer.template_count}
+                  </span>{" "}
+                  Template
+                  {lecturer.template_count === 1 ? "" : "s"} mit allen Versionen
+                </li>
+                <li>
+                  <span className="font-semibold">
+                    {lecturer.openstack_project_count}
+                  </span>{" "}
+                  OpenStack-Projekt
+                  {lecturer.openstack_project_count === 1 ? "" : "e"} (nur
+                  DB-Zeile, das Projekt bleibt in Keystone)
+                </li>
+              </ul>
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-800">
+                <p className="font-semibold flex items-center gap-1">
+                  <AlertTriangle className="w-4 h-4" />
+                  Kein Keycloak-Sync
+                </p>
+                <p className="mt-1">
+                  Der Keycloak-Account bleibt bestehen und kann sich weiter
+                  einloggen — er wird beim nächsten Login als leerer User neu
+                  angelegt.
+                </p>
+              </div>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="lecturer-confirm-name" className="text-sm">
+            Zur Bestätigung <span className="font-semibold">{expected}</span>{" "}
+            eintippen:
+          </Label>
+          <Input
+            id="lecturer-confirm-name"
+            value={typedName}
+            onChange={(e) => setTypedName(e.target.value)}
+            placeholder={expected}
+            autoComplete="off"
+            autoFocus
+            disabled={busy}
+          />
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Abbrechen</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              // Radix schließt den Dialog per Default beim Click auf Action —
+              // wir wollen bei Fehlern (z.B. 400) offen bleiben und den Toast
+              // sichtbar lassen. handleDelete schließt selbst bei Erfolg.
+              e.preventDefault();
+              void handleDelete();
+            }}
+            disabled={!canDelete}
+            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            {busy ? "Wird gelöscht…" : "Endgültig löschen"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/LecturerDetailDialog.tsx
+++ b/src/components/LecturerDetailDialog.tsx
@@ -1,0 +1,464 @@
+// Detail-View für einen Lecturer-Account. Zeigt Metadaten (Name/Email/last
+// login) und die drei Ressourcen-Kategorien (Templates, Deployments,
+// OpenStack-Projekte) mit allen relevanten Feldern, damit der Admin vor dem
+// Cascade-Delete sieht was er kaputtmacht.
+//
+// Nach dem Delete pollt dieser Dialog die Detail-View im 2-Sekunden-Takt,
+// bis das Backend 404 liefert (= User weg → Erfolg) oder ein Timeout
+// erreicht ist. Bei Timeout bleibt der Modal offen und zeigt einen
+// „refreshen"-Hinweis — die Löschung läuft weiter, aber vermutlich ist an
+// einem Deployment ein Heat-Stack hängen geblieben und der Admin muss
+// nachschauen.
+
+import { useEffect, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Calendar,
+  CheckCircle2,
+  Cloud,
+  Layers,
+  Loader2,
+  Mail,
+  RefreshCw,
+  Server,
+  Trash2,
+  User,
+} from "lucide-react";
+import { toast } from "sonner@2.0.3";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { ApiError } from "../api/http";
+import {
+  getLecturer,
+  type LecturerDetail,
+  type LecturerListItem,
+} from "../api/lecturers";
+import { DeleteLecturerConfirmDialog } from "./DeleteLecturerConfirmDialog";
+
+interface Props {
+  /** Die Zeilendaten aus der Liste — dienen als initiale Anzeige, während
+   *  die vollständigen Ressourcen-Listen geladen werden. */
+  lecturer: LecturerListItem;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Wird aufgerufen, sobald der Delete-Task erfolgreich durchgelaufen
+   *  ist (Polling hat 404 gesehen). Die aufrufende Liste sollte dann
+   *  neuladen. */
+  onDeleted: () => void;
+}
+
+const POLL_INTERVAL_MS = 2000;
+// Nach ~30s soll der Modal aufgeben und den Admin auf „manuell prüfen"
+// verweisen — Backend-Dokumentation sagt genau das für den Fall dass ein
+// Heat-Stack sich nicht abbauen lässt.
+const POLL_TIMEOUT_MS = 30_000;
+
+export function LecturerDetailDialog({
+  lecturer,
+  open,
+  onOpenChange,
+  onDeleted,
+}: Props) {
+  const [detail, setDetail] = useState<LecturerDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  // deletionState fasst den Post-Delete-Polling-Lebenszyklus zusammen. `idle`
+  // = kein Delete läuft; `polling` = wir warten aufs Verschwinden; `timeout`
+  // = 30s ohne 404 → Backend ist noch dran, Admin soll refreshen.
+  const [deletionState, setDeletionState] =
+    useState<"idle" | "polling" | "timeout">("idle");
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollDeadlineRef = useRef<number>(0);
+
+  const clearPollTimer = () => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  };
+
+  const loadDetail = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await getLecturer(lecturer.id);
+      setDetail(resp.data);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        // Kann passieren, wenn zwischen Liste und Detail parallel gelöscht
+        // wurde. Für die Detail-Öffnung ist das ein Fehler, für ein aktives
+        // Polling-Ergebnis dagegen der Erfolgsfall — der Polling-Handler
+        // fängt 404 separat ab.
+        setError("Dieser Lecturer existiert nicht (mehr).");
+      } else if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("Detail konnte nicht geladen werden.");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Beim Öffnen den Detail-Endpoint anziehen. Bei jedem Reopen frisch
+  // ziehen, weil sich zwischenzeitlich Ressourcen geändert haben können.
+  useEffect(() => {
+    if (!open) return;
+    setDeletionState("idle");
+    clearPollTimer();
+    void loadDetail();
+    return () => {
+      clearPollTimer();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, lecturer.id]);
+
+  // Ein enqueue’ter Delete startet das Polling. Wir prüfen mit getLecturer:
+  // 404 → User weg → Erfolg. Alles andere = Backend arbeitet noch.
+  const startPolling = () => {
+    setDeletionState("polling");
+    pollDeadlineRef.current = Date.now() + POLL_TIMEOUT_MS;
+    clearPollTimer();
+    pollTimerRef.current = setInterval(async () => {
+      try {
+        await getLecturer(lecturer.id);
+        // 200 — User existiert noch. Weiter warten bis Deadline.
+        if (Date.now() > pollDeadlineRef.current) {
+          clearPollTimer();
+          setDeletionState("timeout");
+        }
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) {
+          clearPollTimer();
+          setDeletionState("idle");
+          toast.success("Lecturer-Account wurde gelöscht.");
+          onDeleted();
+          onOpenChange(false);
+        } else if (Date.now() > pollDeadlineRef.current) {
+          clearPollTimer();
+          setDeletionState("timeout");
+        }
+      }
+    }, POLL_INTERVAL_MS);
+  };
+
+  const handleDeleteEnqueued = (taskId: string) => {
+    toast.info(
+      `Löschung läuft im Hintergrund (Task ${taskId.slice(0, 8)}…). ` +
+        "Der Modal aktualisiert sich automatisch.",
+    );
+    startPolling();
+  };
+
+  const closeIfIdle = (nextOpen: boolean) => {
+    // Modal darf nicht während des Pollings zugeklickt werden — sonst geht
+    // der Refresh-State verloren. Der Admin kann via „Abbrechen" trotzdem
+    // zurück, aber er soll bewusst entscheiden.
+    if (!nextOpen && deletionState === "polling") return;
+    onOpenChange(nextOpen);
+  };
+
+  const displayName =
+    detail?.display_name ??
+    lecturer.display_name ??
+    lecturer.username ??
+    lecturer.email ??
+    lecturer.id;
+  const email = detail?.email ?? lecturer.email;
+  const username = detail?.username ?? lecturer.username;
+  const lastLoginAt = detail?.last_login_at ?? lecturer.last_login_at;
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={closeIfIdle}>
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 break-words">
+              <User className="w-5 h-5 text-slate-500" />
+              {displayName}
+            </DialogTitle>
+            <DialogDescription>
+              Vollständige Übersicht der Ressourcen dieses Lecturer-Accounts.
+              Vor einem Cascade-Delete bitte prüfen was mitgelöscht wird.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Metadaten-Panel */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 border rounded-lg p-4 bg-slate-50 text-sm">
+            <div className="flex items-center gap-2">
+              <Mail className="w-4 h-4 text-slate-400" />
+              <span className="text-slate-500">Email:</span>
+              <span className="text-slate-900 break-all">{email ?? "—"}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <User className="w-4 h-4 text-slate-400" />
+              <span className="text-slate-500">Username:</span>
+              <span className="text-slate-900 break-all">
+                {username ?? "—"}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Calendar className="w-4 h-4 text-slate-400" />
+              <span className="text-slate-500">Letzter Login:</span>
+              <span className="text-slate-900">
+                {lastLoginAt ? new Date(lastLoginAt).toLocaleString() : "—"}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-slate-500 shrink-0">Keycloak-Sub:</span>
+              <span className="text-slate-900 font-mono text-xs break-all">
+                {detail?.external_id ?? lecturer.external_id}
+              </span>
+            </div>
+          </div>
+
+          {/* Post-Delete Feedback */}
+          {deletionState === "polling" && (
+            <div className="flex items-center gap-3 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-blue-800">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <div>
+                <p className="font-semibold">Cascade-Delete läuft…</p>
+                <p>
+                  Wir prüfen alle {POLL_INTERVAL_MS / 1000}s ob der Account
+                  weg ist. Dieser Modal schließt sich automatisch bei Erfolg.
+                </p>
+              </div>
+            </div>
+          )}
+          {deletionState === "timeout" && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+              <p className="font-semibold flex items-center gap-2">
+                <AlertTriangle className="w-4 h-4" />
+                Löschung nicht abgeschlossen
+              </p>
+              <p className="mt-1">
+                Der Account existiert nach {POLL_TIMEOUT_MS / 1000}s immer noch.
+                Wahrscheinlich hängt ein Heat-Stack — bitte die betroffenen
+                Deployments unten öffnen und ggf. manuell abbauen. Danach kann
+                der Delete erneut ausgelöst werden.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => {
+                  setDeletionState("idle");
+                  void loadDetail();
+                }}
+              >
+                <RefreshCw className="w-4 h-4 mr-1" />
+                Neu laden
+              </Button>
+            </div>
+          )}
+
+          {/* Body */}
+          {loading && !detail && (
+            <div className="p-6 text-sm text-slate-500 flex items-center gap-2">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Lade Ressourcen…
+            </div>
+          )}
+          {error && (
+            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+          {detail && (
+            <div className="space-y-6">
+              {/* Templates */}
+              <ResourceSection
+                icon={<Layers className="w-4 h-4 text-teal-600" />}
+                title="Templates"
+                count={detail.template_count}
+                emptyLabel="Keine Templates"
+              >
+                {detail.templates.map((t) => (
+                  <div
+                    key={t.id}
+                    className="flex items-center justify-between gap-3 py-2 border-b last:border-b-0"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-slate-900 break-words">{t.name}</p>
+                      <p className="text-xs text-slate-500 font-mono break-all">
+                        {t.id}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <Badge
+                        variant="outline"
+                        className={
+                          t.visibility === "public"
+                            ? "bg-blue-50 text-blue-700 border-blue-200"
+                            : "bg-slate-50 text-slate-600"
+                        }
+                      >
+                        {t.visibility === "public" ? "Öffentlich" : "Privat"}
+                      </Badge>
+                      <Badge variant="outline">
+                        {t.version_count} Version
+                        {t.version_count === 1 ? "" : "en"}
+                      </Badge>
+                    </div>
+                  </div>
+                ))}
+              </ResourceSection>
+
+              {/* Deployments */}
+              <ResourceSection
+                icon={<Server className="w-4 h-4 text-blue-600" />}
+                title="Deployments"
+                count={detail.deployment_count}
+                emptyLabel="Keine Deployments"
+              >
+                {detail.deployments.map((d) => (
+                  <div
+                    key={d.id}
+                    className="flex items-center justify-between gap-3 py-2 border-b last:border-b-0"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-slate-900 break-words">{d.name}</p>
+                      <p className="text-xs text-slate-500">
+                        Erstellt {new Date(d.created_at).toLocaleDateString()}
+                        {d.expires_at && (
+                          <>
+                            {" · Läuft ab "}
+                            {new Date(d.expires_at).toLocaleDateString()}
+                          </>
+                        )}
+                      </p>
+                    </div>
+                    <div className="shrink-0">
+                      <Badge
+                        variant="outline"
+                        className={statusColor(d.status)}
+                      >
+                        {d.status}
+                      </Badge>
+                    </div>
+                  </div>
+                ))}
+              </ResourceSection>
+
+              {/* OpenStack-Projekte */}
+              <ResourceSection
+                icon={<Cloud className="w-4 h-4 text-purple-600" />}
+                title="OpenStack-Projekte"
+                count={detail.openstack_project_count}
+                emptyLabel="Keine OpenStack-Projekte"
+              >
+                {detail.openstack_projects.map((p) => (
+                  <div
+                    key={p.id}
+                    className="flex items-center justify-between gap-3 py-2 border-b last:border-b-0"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-slate-900 break-words">
+                        {p.openstack_project_name}
+                      </p>
+                      <p className="text-xs text-slate-500 font-mono break-all">
+                        {p.id}
+                      </p>
+                    </div>
+                    <Badge variant="outline" className="shrink-0">
+                      {p.region_name}
+                    </Badge>
+                  </div>
+                ))}
+              </ResourceSection>
+            </div>
+          )}
+
+          <DialogFooter className="gap-2 sm:justify-between">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={deletionState === "polling"}
+            >
+              Schließen
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => setConfirmOpen(true)}
+              disabled={
+                !detail || loading || deletionState !== "idle"
+              }
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              <Trash2 className="w-4 h-4 mr-2" />
+              Account löschen
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {detail && (
+        <DeleteLecturerConfirmDialog
+          lecturer={detail}
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          onDeleteEnqueued={handleDeleteEnqueued}
+        />
+      )}
+    </>
+  );
+}
+
+// -- Sub-Komponenten -------------------------------------------------------
+
+function ResourceSection({
+  icon,
+  title,
+  count,
+  emptyLabel,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  count: number;
+  emptyLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="border rounded-lg p-4">
+      <div className="flex items-center gap-2 mb-2">
+        {icon}
+        <h4 className="text-slate-900">{title}</h4>
+        <Badge variant="outline">{count}</Badge>
+      </div>
+      {count === 0 ? (
+        <p className="text-sm text-slate-500 flex items-center gap-1">
+          <CheckCircle2 className="w-4 h-4 text-slate-400" />
+          {emptyLabel}
+        </p>
+      ) : (
+        <div className="text-sm">{children}</div>
+      )}
+    </section>
+  );
+}
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "running":
+      return "bg-green-50 text-green-700 border-green-200";
+    case "failed":
+    case "error":
+      return "bg-red-50 text-red-700 border-red-200";
+    case "creating":
+    case "updating":
+    case "deleting":
+      return "bg-blue-50 text-blue-700 border-blue-200";
+    default:
+      return "bg-slate-50 text-slate-600";
+  }
+}

--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   LogOut,
   Shield,
   Server,
+  Users,
 } from "lucide-react";
 import { useMemo } from "react";
 import { useKeycloak } from "@react-keycloak/web";
@@ -52,6 +53,20 @@ export function Sidebar({ logo }: SidebarProps) {
         { id: "courses", label: "Kurse", icon: BookOpen, path: "/courses" },
         { id: "appstore", label: "App Store", icon: Store, path: "/appstore" },
         { id: "admin", label: "Admin Monitoring", icon: Shield, path: "/admin" },
+        // Lecturer-Verwaltung ist Admin-only — der Link wird unten beim
+        // Rendern anhand von `isAdmin` gefiltert. Wir listen ihn hier statt
+        // in einem separaten Array, damit das Rendering unten einheitlich
+        // bleibt.
+        ...(isAdmin
+          ? [
+              {
+                id: "admin-lecturers",
+                label: "Lecturer-Verwaltung",
+                icon: Users,
+                path: "/admin/lecturers",
+              },
+            ]
+          : []),
       ];
 
   const displayName = useMemo(() => {

--- a/src/pages/LecturerManagement.tsx
+++ b/src/pages/LecturerManagement.tsx
@@ -1,0 +1,301 @@
+// Admin-Bereich: Übersicht + Löschung von Lecturer-Accounts.
+//
+// Backend-Endpoints (alle admin-only via router-guard):
+//   • GET /api/v1/lecturers?skip=…&limit=…&search=…
+//   • GET /api/v1/lecturers/{id}
+//   • DEL /api/v1/lecturers/{id} → 202 Accepted (async Celery-Task)
+//
+// „Lecturer" wird nicht per Rolle definiert, sondern über Ressourcen-Besitz
+// (Template ODER OpenStack-Projekt). Wer sich zwar in Keycloak einloggt aber
+// noch nichts erstellt hat, taucht bewusst nicht auf — das verhindert dass
+// die Liste mit Studenten oder Karteileichen geflutet wird.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  Loader2,
+  RefreshCw,
+  Search,
+  Users,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../components/ui/card";
+import { Input } from "../components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../components/ui/table";
+import { listLecturers, type LecturerListItem } from "../api/lecturers";
+import { LecturerDetailDialog } from "../components/LecturerDetailDialog";
+
+const PAGE_SIZE = 50;
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function LecturerManagement() {
+  const navigate = useNavigate();
+
+  const [rows, setRows] = useState<LecturerListItem[]>([]);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+  const [page, setPage] = useState(1); // 1-indexed für die Anzeige
+  const [searchInput, setSearchInput] = useState("");
+  // Debounced-Wert, den wir tatsächlich ans Backend schicken. Anleitung sagt
+  // mind. 300ms — kürzere Werte lösen einen Storm aus während der Admin tippt.
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<LecturerListItem | null>(null);
+
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounce Search-Input → debouncedSearch
+  useEffect(() => {
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedSearch(searchInput.trim());
+      // Bei neuer Suche zurück auf Seite 1 — sonst laufen wir potenziell auf
+      // einer leeren Seite hinter der neuen Trefferzahl.
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, [searchInput]);
+
+  const fetchLecturers = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await listLecturers({
+        skip: (page - 1) * PAGE_SIZE,
+        limit: PAGE_SIZE,
+        search: debouncedSearch || undefined,
+      });
+      setRows(resp.data);
+      setTotalItems(resp.pagination.total_items);
+      setTotalPages(resp.pagination.total_pages || 1);
+    } catch (err) {
+      setRows([]);
+      setError(err instanceof Error ? err.message : "Liste konnte nicht geladen werden.");
+    } finally {
+      setLoading(false);
+    }
+  }, [page, debouncedSearch]);
+
+  useEffect(() => {
+    void fetchLecturers();
+  }, [fetchLecturers]);
+
+  const showingRangeLabel = useMemo(() => {
+    if (totalItems === 0) return "0 Einträge";
+    const from = (page - 1) * PAGE_SIZE + 1;
+    const to = Math.min(page * PAGE_SIZE, totalItems);
+    return `${from}–${to} von ${totalItems}`;
+  }, [page, totalItems]);
+
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
+
+  return (
+    <div className="p-8 space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-slate-500 mb-1">
+            <button
+              type="button"
+              onClick={() => navigate("/admin")}
+              className="hover:text-slate-700 inline-flex items-center gap-1"
+            >
+              <ArrowLeft className="w-3 h-3" />
+              Administration
+            </button>
+            <span>/</span>
+            <span>Lecturer-Verwaltung</span>
+          </div>
+          <h1 className="text-slate-900 mb-2 flex items-center gap-2">
+            <Users className="w-6 h-6 text-teal-600" />
+            Lecturer-Verwaltung
+          </h1>
+          <p className="text-slate-600 max-w-3xl">
+            Alle User mit Templates oder OpenStack-Projekten. Löschen entfernt
+            User + Ressourcen — der Keycloak-Account bleibt aber bestehen und
+            legt beim nächsten Login einen leeren User neu an.
+          </p>
+        </div>
+      </div>
+
+      <Card className="border-slate-200 shadow-sm">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-4 flex-wrap">
+            <div>
+              <CardTitle>Alle Lecturer</CardTitle>
+              <CardDescription className="mt-1">
+                {showingRangeLabel}
+                {debouncedSearch ? ` · Filter: „${debouncedSearch}"` : ""}
+              </CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative">
+                <Search className="w-4 h-4 text-slate-400 absolute left-2.5 top-1/2 -translate-y-1/2" />
+                <Input
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  placeholder="Name, Email, Username…"
+                  className="pl-8 w-64"
+                  aria-label="Lecturer suchen"
+                />
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void fetchLecturers()}
+                disabled={loading}
+              >
+                <RefreshCw
+                  className={`w-4 h-4 mr-1 ${loading ? "animate-spin" : ""}`}
+                />
+                Neu laden
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Letzter Login</TableHead>
+                  <TableHead className="text-right">Templates</TableHead>
+                  <TableHead className="text-right">Deployments</TableHead>
+                  <TableHead className="text-right">OSPs</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading && rows.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-8 text-slate-500">
+                      <Loader2 className="w-4 h-4 animate-spin inline-block mr-2" />
+                      Lade Lecturer…
+                    </TableCell>
+                  </TableRow>
+                )}
+                {!loading && rows.length === 0 && !error && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-8 text-slate-500">
+                      {debouncedSearch
+                        ? "Kein Lecturer passt zu diesem Filter."
+                        : "Es gibt aktuell keine Lecturer mit Ressourcen."}
+                    </TableCell>
+                  </TableRow>
+                )}
+                {rows.map((row) => {
+                  const displayName =
+                    row.display_name || row.username || row.email || row.id;
+                  return (
+                    <TableRow
+                      key={row.id}
+                      className="cursor-pointer hover:bg-slate-50"
+                      onClick={() => setSelected(row)}
+                    >
+                      <TableCell className="text-slate-900">
+                        <div className="flex flex-col">
+                          <span className="text-blue-600 hover:underline break-words">
+                            {displayName}
+                          </span>
+                          {row.username && row.username !== displayName && (
+                            <span className="text-xs text-slate-500 break-all">
+                              @{row.username}
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-slate-600 break-all">
+                        {row.email ?? "—"}
+                      </TableCell>
+                      <TableCell className="text-slate-600 text-sm">
+                        {row.last_login_at
+                          ? new Date(row.last_login_at).toLocaleString()
+                          : "—"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Badge variant="outline">{row.template_count}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Badge variant="outline">{row.deployment_count}</Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Badge variant="outline">
+                          {row.openstack_project_count}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Pagination — nur anzeigen, wenn > 1 Seite. */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between mt-4">
+              <p className="text-sm text-slate-500">
+                Seite {page} von {totalPages}
+              </p>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!canPrev || loading}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Zurück
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={!canNext || loading}
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                >
+                  Weiter
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {selected && (
+        <LecturerDetailDialog
+          lecturer={selected}
+          open={Boolean(selected)}
+          onOpenChange={(open) => {
+            if (!open) setSelected(null);
+          }}
+          onDeleted={() => {
+            // Erfolgreiche Löschung → Liste neu laden. Wenn wir gerade auf
+            // der letzten Seite waren und der eben gelöschte User der letzte
+            // war, geht `page` nach dem Reload möglicherweise ins Leere;
+            // wir korrigieren das defensiv nach dem Reload.
+            setSelected(null);
+            void fetchLecturers();
+          }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Neuer Admin-Bereich unter /admin/lecturers zum Löschen von Lecturer-Accounts inklusive kompletter Ressourcen (Deployments mit Heat-Cleanup, Templates, OpenStack-Projekt-Rows, User-Row).

- api/lecturers.ts: typed Client für GET/GET-detail/DELETE
- pages/LecturerManagement.tsx: paginierte Tabelle mit 300ms-debounced Search, Refresh, Empty-/Loading-/Error-States
- components/LecturerDetailDialog.tsx: Vollansicht mit Templates/Deployments/OpenStack-Projekten. Nach dem enqueue'ten Delete pollt der Modal alle 2s die Detail-View bis 404 (Erfolg) oder 30s-Timeout (Heat-Stack hängt vermutlich → Admin soll manuell prüfen)
- components/DeleteLecturerConfirmDialog.tsx: destruktive-Aktion-UX, Admin muss Display-Name/Username/Email exakt eintippen. Warnt dass der Keycloak-Account bestehen bleibt.
- App.tsx: neue Route /admin/lecturers mit requireAdmin
- Sidebar.tsx: Nav-Item 'Lecturer-Verwaltung' (Users-Icon), nur für Admins