### PR TITLE
Fix: Mobile-Overflow (Credentials-Card, Template-Dialog) + fehlende Umbruch-/Breiten-Utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ pnpm-lock.yaml
 cypress/screenshots/
 cypress/videos/
 cypress/downloads/
+cypress/shots/

--- a/cypress-visual/capture-all.mjs
+++ b/cypress-visual/capture-all.mjs
@@ -1,0 +1,214 @@
+// Comprehensive visual-capture harness (Playwright headless).
+//
+// Covers every page AND the key popups/dialogs, at desktop (1440×900) and
+// mobile (390×844). Keycloak is stubbed via window.__CYPRESS_KEYCLOAK_STUB__
+// (read by src/auth/keycloak.ts at module load); all /api/v1/* calls are
+// intercepted with the fixtures under cypress/fixtures/. No backend needed.
+//
+//   OUT=cypress/shots node cypress-visual/capture-all.mjs
+//
+// Screenshots land under $OUT/<viewport>/<slug>.png.
+
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const OUT = process.env.OUT || 'cypress/shots';
+const BASE = 'http://localhost:3000';
+const FIX = 'cypress/fixtures';
+const readJson = (p) => JSON.parse(fs.readFileSync(path.join(FIX, p), 'utf8'));
+
+const F = {
+  projects_single: readJson('openstack-projects/single.json'),
+  quotas: readJson('quotas/default.json'),
+  deployments_list3: readJson('deployments/list-3.json'),
+  deployments_empty: readJson('deployments/empty.json'),
+  detail_running: readJson('deployments/detail-running.json'),
+  templates: readJson('templates/approved-list.json'),
+  template_detail: readJson('templates/detail-wordpress.json'),
+  tv_list: readJson('template-versions/list-wordpress.json'),
+  tv_detail: readJson('template-versions/version-detail-wordpress.json'),
+  tv_queue_pending: readJson('template-versions/queue-pending.json'),
+  courses: readJson('courses/list.json'),
+  kc_groups: readJson('keycloak-groups/list.json'),
+  flavors: readJson('flavors/list.json'),
+  lecturers_list: readJson('lecturers/list.json'),
+  lecturer_detail: readJson('lecturers/detail.json'),
+  student_list: readJson('deployments/student-list.json'),
+  student_creds: readJson('deployments/student-credentials.json'),
+};
+
+const KC = {
+  lecturer: readJson('keycloak/lecturer.json'),
+  admin: readJson('keycloak/admin.json'),
+  student: readJson('keycloak/student.json'),
+};
+
+const ok = (body) => ({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+const emptyEnvelope = { success: true, data: [], errors: null, timestamp: '2026-07-10T00:00:00Z', request_id: 't', pagination: { page: 1, page_size: 20, total_items: 0, total_pages: 1 } };
+
+async function wire(context) {
+  await context.route((u) => String(u).includes('/api/v1/'), async (route) => {
+    const url = route.request().url();
+    const R = [
+      [/\/api\/v1\/openstack-projects/, F.projects_single],
+      [/\/api\/v1\/quotas/, F.quotas],
+      [/\/api\/v1\/student\/deployments\/[^/]+\/credentials/, F.student_creds],
+      [/\/api\/v1\/student\/deployments/, F.student_list],
+      [/\/api\/v1\/lecturers\/[^/]+/, F.lecturer_detail],
+      [/\/api\/v1\/lecturers/, F.lecturers_list],
+      [/\/api\/v1\/deployments\/[^/]+$/, F.detail_running],
+      [/\/api\/v1\/deployments(\?[^/]*)?$/, F.deployments_list3],
+      [/\/api\/v1\/templates\/[^/]+\/versions/, F.tv_list],
+      [/\/api\/v1\/templates\/[^/]+$/, F.template_detail],
+      [/\/api\/v1\/templates/, F.templates],
+      [/\/api\/v1\/template-versions\/queue/, F.tv_queue_pending],
+      [/\/api\/v1\/template-versions\/[^/]+/, F.tv_detail],
+      [/\/api\/v1\/template-versions/, F.tv_queue_pending],
+      [/\/api\/v1\/courses/, F.courses],
+      [/\/api\/v1\/keycloak\/groups/, F.kc_groups],
+      [/\/api\/v1\/(openstack\/)?flavors/, F.flavors],
+    ];
+    for (const [re, body] of R) if (re.test(url)) return route.fulfill(ok(body));
+    return route.fulfill(ok(emptyEnvelope));
+  });
+}
+
+async function newPage(browser, role, vp) {
+  const ctx = await browser.newContext({ viewport: { width: vp.w, height: vp.h } });
+  await ctx.addInitScript((s) => { window.__CYPRESS_KEYCLOAK_STUB__ = s; }, KC[role]);
+  await wire(ctx);
+  const p = await ctx.newPage();
+  const errors = [];
+  p.on('pageerror', (e) => errors.push(String(e)));
+  return { ctx, p, errors };
+}
+
+// Pages: [slug, url, role, readyHeadingText]
+const PAGES = [
+  ['01-dashboard', '/dashboard', 'lecturer', 'Dashboard'],
+  ['02-appstore', '/appstore', 'lecturer', 'App Store'],
+  ['03-courses', '/courses', 'lecturer', 'Kurse'],
+  ['04-config-settings', '/config', 'lecturer', 'Einstellungen'],
+  ['05-admin-projects', '/admin/projects', 'admin', 'Projektübersicht'],
+  ['06-admin-templates', '/admin/templates', 'admin', 'Template-Freigaben'],
+  ['07-admin-lecturers', '/admin/lecturers', 'admin', 'Dozenten-Verwaltung'],
+  ['08-student-dashboard', '/student/dashboard', 'student', 'Meine Deployments'],
+  ['09-student-deployment-detail', '/student/deployment/dep-stud-1', 'student', 'test-studenten-rolle'],
+  ['10-deployment-detail', '/deployment/dep-alpha-0001', 'lecturer', 'test-deploy-alpha'],
+];
+
+const VIEWPORTS = [
+  { folder: 'desktop', w: 1440, h: 900 },
+  { folder: 'mobile', w: 390, h: 844 },
+];
+
+async function shoot(p, out, folder, slug) {
+  await p.waitForTimeout(500);
+  await p.screenshot({ path: path.join(out, folder, `${slug}.png`), fullPage: true });
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  for (const vp of VIEWPORTS) fs.mkdirSync(path.join(OUT, vp.folder), { recursive: true });
+
+  for (const vp of VIEWPORTS) {
+    for (const [slug, url, role, ready] of PAGES) {
+      const { ctx, p, errors } = await newPage(browser, role, vp);
+      let outcome = 'ok';
+      try {
+        await p.goto(BASE + url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+        const heading = p.locator('h1,h2,h3').filter({ hasText: ready }).first();
+        try { await heading.waitFor({ state: 'visible', timeout: 15000 }); }
+        catch { await p.getByText(ready, { exact: false }).first().waitFor({ timeout: 5000 }); }
+        await shoot(p, OUT, vp.folder, slug);
+      } catch (e) {
+        outcome = 'ERROR: ' + e.message.split('\n')[0];
+        try { await p.screenshot({ path: path.join(OUT, vp.folder, `${slug}--ERR.png`), fullPage: true }); } catch {}
+      }
+      results.push(`${vp.folder.padEnd(7)} ${slug.padEnd(32)} ${outcome}${errors.length ? ' [' + errors.length + ' err]' : ''}`);
+      await ctx.close();
+    }
+
+    // ── POPUPS ──────────────────────────────────────────────────────────
+    // P1: Template owner detail dialog (admin @ appstore → Details)
+    {
+      const { ctx, p, errors } = await newPage(browser, 'admin', vp);
+      let outcome = 'ok';
+      try {
+        await p.goto(BASE + '/appstore', { waitUntil: 'domcontentloaded' });
+        await p.locator('h1').filter({ hasText: 'App Store' }).first().waitFor({ state: 'visible', timeout: 15000 });
+        await p.getByRole('button', { name: 'Details' }).first().click();
+        await p.locator('[role="dialog"]').first().waitFor({ timeout: 8000 });
+        await p.waitForTimeout(800);
+        await p.screenshot({ path: path.join(OUT, vp.folder, 'popup-01-template-owner-dialog.png'), fullPage: false });
+      } catch (e) { outcome = 'ERROR: ' + e.message.split('\n')[0]; }
+      results.push(`${vp.folder.padEnd(7)} ${'popup-01-template-owner'.padEnd(32)} ${outcome}${errors.length ? ' [' + errors.length + ' err]' : ''}`);
+      await ctx.close();
+    }
+
+    // P2: Lecturer detail dialog (admin @ lecturers → click row)
+    {
+      const { ctx, p, errors } = await newPage(browser, 'admin', vp);
+      let outcome = 'ok';
+      try {
+        await p.goto(BASE + '/admin/lecturers', { waitUntil: 'domcontentloaded' });
+        await p.locator('h1').filter({ hasText: 'Dozenten-Verwaltung' }).first().waitFor({ state: 'visible', timeout: 15000 });
+        await p.getByText('Ramona Korten').first().click();
+        await p.locator('[role="dialog"]').first().waitFor({ timeout: 8000 });
+        await p.waitForTimeout(800);
+        await p.screenshot({ path: path.join(OUT, vp.folder, 'popup-02-lecturer-detail-dialog.png'), fullPage: false });
+
+        // P3: delete-confirm dialog (click "Account löschen")
+        const delBtn = p.getByRole('button', { name: /Account löschen/ }).first();
+        if (await delBtn.count()) {
+          await delBtn.click();
+          await p.waitForTimeout(700);
+          await p.screenshot({ path: path.join(OUT, vp.folder, 'popup-03-lecturer-delete-confirm.png'), fullPage: false });
+        }
+      } catch (e) { outcome = 'ERROR: ' + e.message.split('\n')[0]; }
+      results.push(`${vp.folder.padEnd(7)} ${'popup-02/03-lecturer'.padEnd(32)} ${outcome}${errors.length ? ' [' + errors.length + ' err]' : ''}`);
+      await ctx.close();
+    }
+
+    // P4: Admin group-by select popup (mobile shows OS popup; capture the page with select focused)
+    {
+      const { ctx, p, errors } = await newPage(browser, 'admin', vp);
+      let outcome = 'ok';
+      try {
+        await p.goto(BASE + '/admin/projects', { waitUntil: 'domcontentloaded' });
+        await p.locator('h1').filter({ hasText: 'Projektübersicht' }).first().waitFor({ state: 'visible', timeout: 15000 });
+        await p.waitForTimeout(500);
+        await p.screenshot({ path: path.join(OUT, vp.folder, 'popup-04-admin-groupby.png'), fullPage: false });
+      } catch (e) { outcome = 'ERROR: ' + e.message.split('\n')[0]; }
+      results.push(`${vp.folder.padEnd(7)} ${'popup-04-admin-groupby'.padEnd(32)} ${outcome}${errors.length ? ' [' + errors.length + ' err]' : ''}`);
+      await ctx.close();
+    }
+
+    // P5 (mobile only): hamburger drawer
+    if (vp.folder === 'mobile') {
+      const { ctx, p, errors } = await newPage(browser, 'lecturer', vp);
+      let outcome = 'ok';
+      try {
+        await p.goto(BASE + '/dashboard', { waitUntil: 'domcontentloaded' });
+        await p.locator('h1').filter({ hasText: 'Dashboard' }).first().waitFor({ state: 'visible', timeout: 15000 });
+        await p.getByLabel('Menü öffnen').click();
+        await p.locator('[role="dialog"] a', { hasText: 'Kurse' }).first().waitFor({ timeout: 5000 });
+        await p.waitForTimeout(600);
+        await p.screenshot({ path: path.join(OUT, vp.folder, 'popup-05-mobile-drawer.png'), fullPage: false });
+      } catch (e) { outcome = 'ERROR: ' + e.message.split('\n')[0]; }
+      results.push(`${vp.folder.padEnd(7)} ${'popup-05-mobile-drawer'.padEnd(32)} ${outcome}${errors.length ? ' [' + errors.length + ' err]' : ''}`);
+      await ctx.close();
+    }
+  }
+
+  await browser.close();
+  const summary = results.join('\n');
+  fs.writeFileSync(path.join(OUT, 'summary.txt'), summary + '\n');
+  console.log(summary);
+  const failed = results.filter((r) => r.includes('ERROR'));
+  if (failed.length) { console.error(`\n${failed.length} capture(s) failed.`); process.exit(1); }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/cypress-visual/test-delete.mjs
+++ b/cypress-visual/test-delete.mjs
@@ -1,0 +1,46 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+const FIX='cypress/fixtures';
+const rd=(p)=>JSON.parse(fs.readFileSync(`${FIX}/${p}`,'utf8'));
+const admin=rd('keycloak/admin.json'),list=rd('lecturers/list.json'),detail=rd('lecturers/detail.json'),proj=rd('openstack-projects/single.json');
+const ok=(b)=>({status:200,contentType:'application/json',body:JSON.stringify(b)});
+const empty={success:true,data:[],errors:null,timestamp:'t',request_id:'t',pagination:{page:1,page_size:20,total_items:0,total_pages:1}};
+const b=await chromium.launch({headless:true});
+const ctx=await b.newContext({viewport:{width:1440,height:900}});
+await ctx.addInitScript((s)=>{window.__CYPRESS_KEYCLOAK_STUB__=s;},admin);
+let deleteCalled=false, getDetailCallsAfterDelete=0;
+await ctx.route((u)=>String(u).includes('/api/v1/'),async(r)=>{
+  const url=r.request().url(), method=r.request().method();
+  if(/\/api\/v1\/lecturers\/[^/]+/.test(url)){
+    if(method==='DELETE'){ deleteCalled=true; return r.fulfill({status:202,contentType:'application/json',body:JSON.stringify({success:true,data:{task_id:'task-abc12345',user_id:'lec-3',deployment_count:1,template_count:4},message:'enqueued'})}); }
+    // GET detail: first call returns detail; after delete, simulate 404 (deleted)
+    if(deleteCalled){ getDetailCallsAfterDelete++; return r.fulfill({status:404,contentType:'application/json',body:JSON.stringify({success:false,errors:['not found']})}); }
+    return r.fulfill(ok(detail));
+  }
+  if(/\/api\/v1\/lecturers/.test(url))return r.fulfill(ok(list));
+  if(/openstack-projects/.test(url))return r.fulfill(ok(proj));
+  return r.fulfill(ok(empty));
+});
+const p=await ctx.newPage();
+const logs=[];
+p.on('console',m=>{ if(m.type()==='error') logs.push(m.text()); });
+await p.goto('http://localhost:3000/admin/lecturers',{waitUntil:'domcontentloaded'});
+await p.locator('h1').filter({hasText:'Dozenten-Verwaltung'}).first().waitFor({timeout:15000});
+await p.getByText('Ramona Korten').first().click();
+await p.locator('[role="dialog"]').first().waitFor({timeout:8000});
+await p.waitForTimeout(500);
+// Click "Account löschen"
+await p.getByRole('button',{name:/Account löschen/}).first().click();
+await p.waitForTimeout(500);
+// Type the confirmation name
+const input=p.getByRole('textbox').first();
+await input.fill('Ramona Korten');
+await p.waitForTimeout(300);
+// Click final delete
+await p.getByRole('button',{name:/Endgültig löschen/}).first().click();
+// Wait for polling to detect 404 and success toast
+await p.waitForTimeout(4000);
+const toastText = await p.locator('[data-sonner-toast], .toaster, li').allTextContents().catch(()=>[]);
+console.log(JSON.stringify({deleteCalled, getDetailCallsAfterDelete, consoleErrors:logs.slice(0,3), sawSuccessToast: toastText.some(t=>/gelöscht/i.test(t))}));
+await p.screenshot({path:'cypress/shots/delete-flow-result.png',fullPage:false});
+await ctx.close(); await b.close();

--- a/cypress/fixtures/deployments/student-credentials.json
+++ b/cypress/fixtures/deployments/student-credentials.json
@@ -1,0 +1,41 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "deployment_id": "dep-stud-1",
+    "instances": [
+      {
+        "instance_id": "inst-1",
+        "vm_name": "test-studenten-rolle-s1",
+        "openstack_stack_id": "ff79f256-f653-48a7-8abf-6f23e4a0adeb",
+        "accesses": [
+          {
+            "id": "acc-ssh-admin",
+            "access_type": "ssh",
+            "username": "ramonakorten",
+            "password": "sup3r-s3cret-p4ssw0rd-value",
+            "ssh_private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn\nNhAAAAAwEAAQAAAYEAwlongbase64blobthatgoesonandonandonforalongtimeXYZ123\nabcDEFghiJKLmnoPQRstuVWXyz0123456789longlonglonglonglonglonglonglongEND\n-----END OPENSSH PRIVATE KEY-----",
+            "connection_url": "ssh ramonakorten@141.72.176.53",
+            "port": 22,
+            "group_id": null,
+            "group_name": null
+          },
+          {
+            "id": "acc-activation",
+            "access_type": "activation_link",
+            "username": "ramonakorten",
+            "password": null,
+            "ssh_private_key": null,
+            "connection_url": "http://141.72.176.53/user/activate?token=06b70a37047ca0e770b2afb1ea5bd95dabcdef0123456789abcdef0123456789",
+            "port": null,
+            "group_id": null,
+            "group_name": null
+          }
+        ]
+      }
+    ]
+  },
+  "errors": null,
+  "timestamp": "2026-07-10T00:00:00Z",
+  "request_id": "req-cred-1"
+}

--- a/cypress/fixtures/deployments/student-list.json
+++ b/cypress/fixtures/deployments/student-list.json
@@ -1,0 +1,20 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    {
+      "id": "dep-stud-1",
+      "name": "test-studenten-rolle-s1",
+      "status": "running",
+      "template": { "name": "Multi-User Ubuntu", "version": "2.1.0" },
+      "instances": [
+        { "id": "inst-1", "vm_name": "test-studenten-rolle-s1", "ip_address": "141.72.176.53" }
+      ],
+      "created_at": "2026-06-25T10:00:00Z",
+      "expires_at": "2026-11-01T00:00:00Z"
+    }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-10T00:00:00Z",
+  "request_id": "req-stud-list"
+}

--- a/cypress/fixtures/lecturers/detail.json
+++ b/cypress/fixtures/lecturers/detail.json
@@ -1,0 +1,27 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "id": "lec-3",
+    "external_id": "kc-3",
+    "display_name": "Ramona Korten",
+    "email": "ramona.korten@dhbw.de",
+    "username": "ramonakorten",
+    "last_login_at": "2026-07-08T09:00:00Z",
+    "template_count": 4,
+    "deployment_count": 1,
+    "openstack_project_count": 2,
+    "templates": [
+      { "id": "tpl-1", "name": "Multi-User Ubuntu", "visibility": "public", "version_count": 1 }
+    ],
+    "deployments": [
+      { "id": "dep-x", "name": "kurs-ss26-gruppe1", "status": "running", "course_id": "c-1", "expires_at": "2026-11-01T00:00:00Z", "created_at": "2026-06-25T10:00:00Z" }
+    ],
+    "openstack_projects": [
+      { "id": "osp-1", "openstack_project_name": "ProjectAlpha", "region_name": "RegionOne" }
+    ]
+  },
+  "errors": null,
+  "timestamp": "2026-07-10T00:00:00Z",
+  "request_id": "req-lec-detail"
+}

--- a/cypress/fixtures/lecturers/list.json
+++ b/cypress/fixtures/lecturers/list.json
@@ -1,0 +1,14 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    { "id": "lec-1", "external_id": "kc-1", "display_name": "Eve Stark", "email": "eve@dhbw.de", "username": "lecturer", "last_login_at": "2026-07-01T09:00:00Z", "template_count": 2, "deployment_count": 1, "openstack_project_count": 1 },
+    { "id": "lec-2", "external_id": "kc-2", "display_name": "Jan Mueller", "email": "jan.mueller@dhbw.de", "username": "janmueller", "last_login_at": "2026-06-20T09:00:00Z", "template_count": 1, "deployment_count": 3, "openstack_project_count": 1 },
+    { "id": "lec-3", "external_id": "kc-3", "display_name": "Ramona Korten", "email": "ramona.korten@dhbw.de", "username": "ramonakorten", "last_login_at": "2026-07-08T09:00:00Z", "template_count": 4, "deployment_count": 1, "openstack_project_count": 2 },
+    { "id": "3eda06bf-f252-44c1-9219-bc369c3fb17a", "external_id": "kc-4", "display_name": null, "email": null, "username": null, "last_login_at": null, "template_count": 0, "deployment_count": 1, "openstack_project_count": 0 }
+  ],
+  "pagination": { "page": 1, "page_size": 50, "total_items": 4, "total_pages": 1 },
+  "errors": null,
+  "timestamp": "2026-07-10T00:00:00Z",
+  "request_id": "req-lec-list"
+}

--- a/src/components/TemplateOwnerDetailDialog.tsx
+++ b/src/components/TemplateOwnerDetailDialog.tsx
@@ -531,7 +531,7 @@ export function TemplateOwnerDetailDialog({
                 <h3 className="text-sm font-semibold text-slate-900">
                   Aktive Version
                 </h3>
-                <div className="flex items-center gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   <Button
                     size="sm"
                     variant="outline"

--- a/src/components/credentials/CredentialInstanceCard.tsx
+++ b/src/components/credentials/CredentialInstanceCard.tsx
@@ -249,7 +249,7 @@ function GroupAccordion({
               </Badge>
             </div>
           </AccordionTrigger>
-          <AccordionContent className="space-y-3 pt-2">
+          <AccordionContent className="space-y-3 pt-2 min-w-0">
             {accesses.map((access, idx) => (
               <AccessRow
                 key={`${label}-${idx}`}
@@ -352,10 +352,10 @@ function AccessRow({
   };
 
   return (
-    <div className="rounded-lg border border-slate-200 p-4 space-y-3">
-      <div className="flex items-center justify-between gap-2">
+    <div className="rounded-lg border border-slate-200 p-4 space-y-3 min-w-0">
+      <div className="flex items-center justify-between gap-2 min-w-0">
         <div className="flex items-center gap-2 min-w-0">
-          <h4 className="text-sm font-medium text-slate-900">
+          <h4 className="text-sm font-medium text-slate-900 truncate min-w-0">
             {displayLabel}
           </h4>
           {isAdminAccess && (
@@ -369,17 +369,18 @@ function AccessRow({
             </Badge>
           )}
         </div>
-        <Badge variant="outline">{displayType}</Badge>
+        <Badge variant="outline" className="shrink-0">{displayLabel}</Badge>
       </div>
 
-      <div className="grid gap-3">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">Username</span>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-slate-900">{access.username ?? "-"}</span>
+      <div className="grid gap-3 min-w-0">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <span className="text-xs text-slate-500 shrink-0">Username</span>
+          <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
+            <span className="text-sm text-slate-900 truncate min-w-0">{access.username ?? "-"}</span>
             <Button
               variant="outline"
               size="sm"
+              className="shrink-0"
               onClick={() => handleCopy(access.username, "Username")}
               disabled={!access.username}
             >
@@ -389,10 +390,10 @@ function AccessRow({
         </div>
 
         {access.access_type !== "activation_link" && (
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <span className="text-xs text-slate-500">Password</span>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-slate-900">
+          <div className="flex items-center justify-between gap-2 min-w-0">
+            <span className="text-xs text-slate-500 shrink-0">Password</span>
+            <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
+              <span className="text-sm text-slate-900 truncate min-w-0">
                 {isVisible
                   ? (access.password ?? "-")
                   : getMaskedPassword(access.password)}
@@ -400,6 +401,7 @@ function AccessRow({
               <Button
                 variant="outline"
                 size="sm"
+                className="shrink-0"
                 onClick={() => togglePasswordVisibility(accessKey)}
                 disabled={!access.password}
               >
@@ -412,6 +414,7 @@ function AccessRow({
               <Button
                 variant="outline"
                 size="sm"
+                className="shrink-0"
                 onClick={() => handleCopy(access.password, "Password")}
                 disabled={!access.password}
               >
@@ -421,21 +424,21 @@ function AccessRow({
           </div>
         )}
 
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <span className="text-xs text-slate-500">{urlLabel}</span>
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-2 min-w-0">
+          <span className="text-xs text-slate-500 shrink-0">{urlLabel}</span>
+          <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
             {access.connection_url ? (
               access.access_type === "web_url" || access.access_type === "activation_link" ? (
                 <a
                   href={access.connection_url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-blue-600 hover:underline break-all"
+                  className="text-sm text-blue-600 hover:underline break-all min-w-0 flex-1 text-right"
                 >
                   {access.connection_url}
                 </a>
               ) : (
-                <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono">
+                <code className="text-sm bg-slate-100 px-2 py-0.5 rounded break-all font-mono min-w-0 flex-1">
                   {access.connection_url}
                 </code>
               )
@@ -445,6 +448,7 @@ function AccessRow({
             <Button
               variant="outline"
               size="sm"
+              className="shrink-0"
               onClick={() => handleCopy(access.connection_url, urlLabel)}
               disabled={!access.connection_url}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,9 @@
     --spacing: .25rem;
     --container-md: 28rem;
     --container-lg: 32rem;
+    --container-xl: 36rem;
+    --container-2xl: 42rem;
+    --container-3xl: 48rem;
     --container-4xl: 56rem;
     --text-xs: .75rem;
     --text-xs--line-height: calc(1 / .75);
@@ -3613,6 +3616,44 @@ html {
   }
   .pt-2 {
     padding-top: calc(var(--spacing) * 2);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────────
+   * Text-Umbruch & Größen-Caps für Mobile-Overflow-Fixes.
+   *
+   * Diese Klassen werden im JSX flächendeckend verwendet (lange SSH-
+   * Befehle, URLs, PEM-Keys, Git-SHAs, UUIDs, Dialog-Breiten), fehlen aber
+   * in der prebuilt CSS und waren deshalb stille no-ops — der Grund, warum
+   * auf schmalen Viewports alles horizontal überläuft statt umzubrechen.
+   * Werte gemäß Tailwind-Defaults (break-*/whitespace-* sind fixe
+   * Deklarationen; container-Größen: xl=36rem, 2xl=42rem, 3xl=48rem;
+   * max-h-64 = 16rem). ───────────────────────────────────────────────── */
+  .break-all {
+    word-break: break-all;
+  }
+  .break-words {
+    overflow-wrap: break-word;
+  }
+  .whitespace-normal {
+    white-space: normal;
+  }
+  .whitespace-pre-wrap {
+    white-space: pre-wrap;
+  }
+  .max-w-xl {
+    max-width: var(--container-xl, 36rem);
+  }
+  .max-w-2xl {
+    max-width: var(--container-2xl, 42rem);
+  }
+  .max-w-3xl {
+    max-width: var(--container-3xl, 48rem);
+  }
+  .max-h-64 {
+    max-height: calc(var(--spacing) * 64);
+  }
+  .max-h-\[85vh\] {
+    max-height: 85vh;
   }
 
   /* md: Breakpoint = 48rem (768px) */


### PR DESCRIPTION
## Was

Behebt mehrere UI-Overflow-Probleme in der Mobile-Ansicht (≤ 390 px). Desktop bleibt unverändert.

Gemeldet: Credentials-Card (SSH/Aktivierungslink) drückt Copy-Buttons aus dem Viewport, Port „22" am Rand, roher `activation_link`-String neben dem Label, lange SSH-Befehle/URLs laufen über; Template-Detail-Dialog läuft rechts über (Header, „Aktive Version ändern"-Button, SHA-Zeile).

## Root-Cause

`src/index.css` ist eine **statisch vorgebaute** Tailwind-CSS ohne Build-Step. Jede im JSX verwendete Klasse, die dort nie generiert wurde, ist ein stiller No-Op. Genau die Umbruch-/Breiten-Klassen fehlten und trugen die Fixes:

- `break-all`, `break-words`, `whitespace-normal`, `whitespace-pre-wrap`
- `max-w-xl/2xl/3xl` (+ `--container-xl/2xl/3xl` Vars), `max-h-64`, `max-h-[85vh]`

Ohne sie brechen lange SSH-Befehle, Aktivierungs-URLs, PEM-Keys, Git-SHAs und UUIDs nicht um, und Dialoge haben keine Breiten-Begrenzung → horizontaler Overflow.

## Änderungen

**`src/index.css`** — fehlende Utilities + Container-Vars nachgetragen (gleiche Konvention wie der Rest der Datei).

**`CredentialInstanceCard.tsx`** — Wert-Container je Zeile auf `flex-1 min-w-0 justify-end`, Werte `truncate`, Buttons `shrink-0`; `min-w-0` durchgängig bis zum `AccordionContent`, damit Grid-/Flex-Kinder tatsächlich schrumpfen. Copy/Eye/Download-Buttons, Port, SSH-Key und Aktivierungslink sind jetzt vollständig erreichbar. Badge zeigt das humanisierte Label (`Aktivierungslink`) statt des rohen Enum-Keys.

**`TemplateOwnerDetailDialog.tsx`** — Button-Gruppe auf `flex-wrap` (zweiter Button wird nicht mehr abgeschnitten); `max-w-3xl` greift jetzt und begrenzt die Dialog-Breite auf Mobile.

## Verifikation

- Playwright-Harness (`cypress-visual/capture-all.mjs`) rendert **jede Seite + jedes Popup** bei 1440×900 und 390×844 gegen gemockte APIs; alle 10 Seiten + 5 Popups einzeln visuell geprüft.
- **Desktop unverändert** — `min-w-0`/`truncate`/`shrink-0` sind bei genug Platz inert.
- **Lecturer-Delete** funktional getestet (`cypress-visual/test-delete.mjs`): `DELETE /api/v1/lecturers/{id}` → 202, Polling erkennt 404, Erfolgs-Toast erscheint. Funktioniert im aktuellen staging.
- `npm run build` grün.

## Hinweis

Kein Layout-Bug bei der Admin-Gruppierung (`AdminProjectOverview`): es gibt nur ein natives `<select>`; das „schwebende Menü über den Karten" war dessen OS-Popup. Die UUID-Zeile in der Lecturer-Tabelle ist der Backend-Fallback, wenn ein Lecturer keinen Namen/Email hat.