### PR TITLE
Fix #221: Unsichtbarer Lösch-Button + Dialog-Overflow (Dozenten-Verwaltung)

### DIFF
--- a/src/components/LecturerDetailDialog.tsx
+++ b/src/components/LecturerDetailDialog.tsx
@@ -180,8 +180,12 @@ export function LecturerDetailDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={closeIfIdle}>
-        <DialogContent className="max-w-3xl max-h-[85vh] overflow-y-auto">
-          <DialogHeader>
+        {/* Flex-Column mit fixem Header + Footer und nur mittig scrollendem
+            Body. Vorher scrollte der GESAMTE Dialog (inkl. Footer) als eine
+            Einheit — bei vielen Templates rutschte der „Account löschen"-
+            Button unter die Falz und war unauffindbar (Issue #221). */}
+        <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
+          <DialogHeader className="shrink-0">
             <DialogTitle className="flex items-center gap-2 break-words">
               <User className="w-5 h-5 text-slate-500" />
               {displayName}
@@ -191,6 +195,9 @@ export function LecturerDetailDialog({
               Vor einem Cascade-Delete bitte prüfen was mitgelöscht wird.
             </DialogDescription>
           </DialogHeader>
+
+          {/* Scrollbarer Body */}
+          <div className="flex-1 overflow-y-auto min-h-0 space-y-4 pr-1">
 
           {/* Metadaten-Panel */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 border rounded-lg p-4 bg-slate-50 text-sm">
@@ -377,8 +384,10 @@ export function LecturerDetailDialog({
               </ResourceSection>
             </div>
           )}
+          </div>
+          {/* Ende scrollbarer Body */}
 
-          <DialogFooter className="gap-2 sm:justify-between">
+          <DialogFooter className="shrink-0 gap-2 sm:flex-row sm:justify-between border-t border-slate-100 pt-4">
             <Button
               variant="outline"
               onClick={() => onOpenChange(false)}

--- a/src/index.css
+++ b/src/index.css
@@ -3655,6 +3655,22 @@ html {
   .max-h-\[85vh\] {
     max-height: 85vh;
   }
+  .min-h-0 {
+    min-height: calc(var(--spacing) * 0);
+  }
+  /* Destruktive Buttons (z.B. „Account löschen" im LecturerDetailDialog)
+     nutzen bg-red-600 + hover:bg-red-700 + text-white. bg-red-600/700
+     fehlten in der prebuilt CSS → der Button rendert weiß-auf-transparent
+     und war damit UNSICHTBAR (Issue #221: „wo löscht man die jetzt?"). */
+  .bg-red-600 {
+    background-color: var(--color-red-600);
+  }
+  .bg-red-700 {
+    background-color: var(--color-red-700);
+  }
+  .bg-red-500 {
+    background-color: var(--color-red-500);
+  }
 
   /* md: Breakpoint = 48rem (768px) */
   @media (width >= 48rem) {
@@ -3708,6 +3724,19 @@ html {
     }
     .sm\:max-w-sm {
       max-width: calc(var(--spacing) * 96);
+    }
+    .sm\:justify-between {
+      justify-content: space-between;
+    }
+  }
+
+  /* Hover-Variante für den destruktiven Button (s.o.). */
+  @media (hover: hover) {
+    .hover\:bg-red-700:hover {
+      background-color: var(--color-red-700);
+    }
+    .hover\:bg-red-600:hover {
+      background-color: var(--color-red-600);
     }
   }
 }


### PR DESCRIPTION
Behebt #221 — unsichtbarer roter Lösch-Button (bg-red-500/600/700 fehlten in der prebuilt src/index.css → weiß auf transparent) + Dialog-Overflow (ganzer Dialog scrollte, Button unter der Falz). Fix: fehlende Utilities ergänzt + DialogContent auf flex-col mit fixem Header/Footer umgestellt. Verifiziert per Playwright (27/27) + funktionalem Lösch-Flow (DELETE 202 → Poll 404 → Toast).