### PR TITLE
Fix #29: Admin-Routen per requireAdmin-Guard schützen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { OpenStackConfig } from "./pages/OpenStackConfig";
 import { AdminProjectOverview } from "./pages/AdminProjectOverview";
 import { AdminTemplateApprovals } from "./pages/AdminTemplateApprovals";
 import { LecturerManagement } from "./pages/LecturerManagement";
+import { ProtectedRoute } from "./components/ProtectedRoute";
 import { Sidebar } from "./layouts/Sidebar";
 import { MobileTopBar } from "./layouts/MobileTopBar";
 import { Login } from "./pages/Login";
@@ -200,9 +201,30 @@ export default function App() {
               <Route path="/deploy/:templateId" element={<DeploymentWizardPage />} />
               <Route path="/deployment/:deploymentId" element={<DeploymentDetailsPage />} />
               <Route path="/config" element={<OpenStackConfig />} />
-              <Route path="/admin/projects" element={<AdminProjectOverview />} />
-              <Route path="/admin/templates" element={<AdminTemplateApprovals />} />
-              <Route path="/admin/lecturers" element={<LecturerManagement />} />
+              <Route
+                path="/admin/projects"
+                element={
+                  <ProtectedRoute requireAdmin>
+                    <AdminProjectOverview />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin/templates"
+                element={
+                  <ProtectedRoute requireAdmin>
+                    <AdminTemplateApprovals />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/admin/lecturers"
+                element={
+                  <ProtectedRoute requireAdmin>
+                    <LecturerManagement />
+                  </ProtectedRoute>
+                }
+              />
               {/* Lecturer/Admin auf /student/* → zurück aufs Dashboard. */}
               <Route path="/student/*" element={<Navigate to="/dashboard" replace />} />
             </Routes>


### PR DESCRIPTION
Closes #29

## Problem
Die drei `/admin/*`-Routen in `src/App.tsx` (`/admin/projects`, `/admin/templates`, `/admin/lecturers`) wurden für **alle** Nicht-Studenten gerendert — also auch für Lecturer. Zwar blendet die Sidebar (`Sidebar.tsx:70-79`) den Admin-Nav für Nicht-Admins aus, aber der Route-Level-Guard fehlte: Ein Lecturer konnte die Admin-Seiten per direkter URL-Eingabe erreichen.

## Change
Jede Admin-Route wird jetzt mit dem bereits existierenden (bislang ungenutzten) `<ProtectedRoute requireAdmin>` umschlossen. `ProtectedRoute` wird in `App.tsx` importiert.

Ein Nicht-Admin (Lecturer) läuft über den `requireAdmin && !user.isAdmin`-Zweig und wird sauber auf `/dashboard` umgeleitet — eine im Nicht-Studenten-Branch registrierte, existierende Route. Der `/no-role`-Zweig von `ProtectedRoute` greift nur für komplett rollenlose User und ist für diesen Fall irrelevant (er ist nicht als Route registriert, wird hier aber nie erreicht).

## Hinweis
Das Backend erzwingt diese Berechtigung bereits (403 für Nicht-Admins auf Admin-Endpoints). Dies schließt die Lücke in der UI-Shell — reine Routing-Härtung, **kein** Daten-Leak und **keine** Layout-Änderung (Desktop/Mobile unverändert).

## Verifikation
- `npm run build` grün (der CSS-Minify-Warning ist vorbestehend und unabhängig)
- Manuelle Prüfung: Lecturer (`isAdmin=false`) kann `AdminProjectOverview` / `AdminTemplateApprovals` / `LecturerManagement` nicht mehr rendern