### PR TITLE
Fix #126: Deployment-Aktionen nur für Besitzer (Admin-Bypass entfernt)

### DIFF
--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -101,11 +101,11 @@ interface Deployment {
    * Keycloak UUID of the deployment owner (lecturer who created it). Populated
    * by DeploymentDetailsPage from `DeploymentDto.owner_id`. Compared against
    * `useCurrentUser().userId` (== Keycloak `sub`) to gate the Aktionen card
-   * buttons — non-owners (including lecturers with read access via course
-   * membership and viewing admins who explicitly want to act as a regular
-   * user) see the buttons disabled with an explanatory tooltip. Admins
-   * always bypass the check. Null on legacy rows that pre-date the
-   * teacher-info migration — treated as non-owner.
+   * buttons — any non-owner (including lecturers with read access via course
+   * membership AND admins browsing a deployment they don't own) sees the
+   * buttons disabled with an explanatory tooltip but keeps full read access.
+   * Null on legacy rows that pre-date the teacher-info migration — treated as
+   * non-owner.
    */
   ownerId?: string | null;
   course: string;
@@ -177,11 +177,12 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
   // via `authorize_deployment_access` (403 for non-owner non-admins), so this
   // is a pure UX layer — it just prevents a guaranteed-403 click.
   //
-  // Admins keep their full toolbox; legacy rows without `ownerId` fall back
-  // to non-owner for everyone except admins (safe default).
+  // Ownership is the ONLY criterion: admins get their toolbox on deployments
+  // they own, but see disabled actions (with tooltip) on any deployment they
+  // don't own — while keeping full read access. Legacy rows without `ownerId`
+  // fall back to non-owner for everyone (safe default).
   const canManageDeployment =
-    currentUser.isAdmin ||
-    (deployment.ownerId != null && deployment.ownerId === currentUser.userId);
+    deployment.ownerId != null && deployment.ownerId === currentUser.userId;
   const ownerTooltip =
     "Diese Aktion kann nur vom Besitzer des Deployments ausgeführt werden.";
   const [credentialsVisible, setCredentialsVisible] = useState(false);


### PR DESCRIPTION
Closes #126

## Was

Das Gate für die Aktionen-Karte (Abbrechen/Löschen/Aufräumen/Erneut versuchen) in `src/pages/DeploymentDetails.tsx` ist jetzt rein besitzbasiert. Der explizite Admin-Bypass wurde entfernt:

```diff
-const canManageDeployment =
-  currentUser.isAdmin ||
-  (deployment.ownerId != null && deployment.ownerId === currentUser.userId);
+const canManageDeployment =
+  deployment.ownerId != null && deployment.ownerId === currentUser.userId;
```

## Verhalten

- Ein Admin (oder anderer Nicht-Besitzer), der ein fremdes Deployment öffnet, sieht die Aktions-Buttons **ausgegraut mit Tooltip**, behält aber **vollen Lesezugriff** (Logs, Credentials, Details) — diese Bereiche sind nicht durch `canManageDeployment` gegated.
- Admins, die ein Deployment **selbst besitzen**, behalten ihre Aktionen.
- Die vorhandene UX (disabled-Buttons + Tooltip) wurde nicht neu gebaut — sie keyt bereits auf `canManageDeployment`.

## Hinweise

- Das Backend erzwingt dies bereits auf den Mutations-Endpunkten (DELETE/extend/restart, 403 für Nicht-Besitzer-Nicht-Admins) via `authorize_deployment_access`. Dies ist somit eine **reine UX-Schicht**, die einen garantierten 403-Klick verhindert.
- Der veraltete Doc-Kommentar ("Admins always bypass the check") wurde aktualisiert.
- **Produkt-Nuance:** Das Issue formuliert "aus Administration". Da `AdminProjectOverview` dieselbe `DeploymentDetails`-Route ohne Source-Flag wiederverwendet, ist die Regel auf "**jedes Deployment, das der Admin nicht besitzt**" verallgemeinert — funktional deckungsgleich mit der Absicht des Issues.

## Build

`npm run build` grün (nur vorbestehende, unabhängige CSS-Minify-Warnung).