### PR TITLE
Fix #210: "Account löschen"-Button sichtbar machen (destructive-Variante statt Silent-No-Op-Klassen)

### DIFF
--- a/src/components/DeleteLecturerConfirmDialog.tsx
+++ b/src/components/DeleteLecturerConfirmDialog.tsx
@@ -178,7 +178,7 @@ export function DeleteLecturerConfirmDialog({
               void handleDelete();
             }}
             disabled={!canDelete}
-            className="bg-red-600 hover:bg-red-700 focus:ring-red-600"
+            className="bg-destructive text-white hover:bg-destructive/90"
           >
             <Trash2 className="w-4 h-4 mr-2" />
             {busy ? "Wird gelöscht…" : "Endgültig löschen"}

--- a/src/components/LecturerDetailDialog.tsx
+++ b/src/components/LecturerDetailDialog.tsx
@@ -401,7 +401,6 @@ export function LecturerDetailDialog({
               disabled={
                 !detail || loading || deletionState !== "idle"
               }
-              className="bg-red-600 hover:bg-red-700 text-white"
             >
               <Trash2 className="w-4 h-4 mr-2" />
               Account löschen


### PR DESCRIPTION
Closes #210

## Problem (Demo-Feedback Dozenten-Verwaltung)
- "wo kann man die Dozenten löschen?"
- "Dozenten löschen fehlt noch"

Das Delete-Feature ist tatsächlich **vollständig implementiert**: Liste → `LecturerDetailDialog` → `DeleteLecturerConfirmDialog` (Namens-Bestätigung) → async Cascade-Delete. Der "Account löschen"-Button war nur **praktisch unsichtbar** (weiß-auf-transparent), deshalb konnte der Reviewer ihn nicht finden.

## Root Cause — der wiederkehrende Gotcha dieses Repos
`src/index.css` ist eine handgepflegte, **prebuilt** Tailwind-Datei **ohne Build-Step**. Jede in JSX genutzte Utility-Klasse, die dort fehlt, ist ein **stiller No-Op**.

Beide Delete-Buttons überschrieben die Button-Variante hart per `className="bg-red-600 hover:bg-red-700 text-white"`. Da die Standard-App-Farbe für destruktive Aktionen aber `--destructive` (`#d4183d`) ist, weicht das nicht nur optisch ab — der Button rendert im Ergebnis unauffindbar. `focus:ring-red-600` ist ebenfalls ein No-Op (nicht in index.css).

## Fix
Beide Buttons nutzen jetzt die reguläre destruktive-Variante-Optik (`bg-destructive` = `#d4183d` + `text-white`), konsistent mit allen anderen destruktiven Buttons der App:

| Datei | vorher | nachher |
|---|---|---|
| `LecturerDetailDialog.tsx` | `variant="destructive"` **+** `className="bg-red-600 hover:bg-red-700 text-white"` | `variant="destructive"` (Override entfernt — Variante setzt bg + text-white selbst) |
| `DeleteLecturerConfirmDialog.tsx` | `className="bg-red-600 hover:bg-red-700 focus:ring-red-600"` | `className="bg-destructive text-white hover:bg-destructive/90"` |

Anmerkung zum zweiten Button: `AlertDialogAction` hat keine `variant`-Prop (default = `bg-primary`), daher werden die destruktiven Klassen explizit gesetzt — alle drei sind in `index.css` vorhanden. Der No-Op `focus:ring-red-600` wurde entfernt statt tote Klasse stehenzulassen.

## Padding (Item 3)
Der DialogFooter (`justify-between`, `gap-2`, `pt-4`-Border) ist bereits sauber und nicht gedrängt — kein struktureller Padding-Eingriff nötig, um das Desktop-Layout nicht zu verändern. Die Lupen-Padding (Item 1) ist per Triage ebenfalls in Ordnung (`pl-8` Input + `left-2.5` Icon) und wurde nicht angefasst.

## Verifikation
Playwright gegen einen lokalen Vite-Build der Worktree (Auth-Stub + gemockte `/api/v1/lecturers`-Fixtures):
- **"Account löschen"**: `backgroundColor` = `rgb(212, 24, 61)` (#d4183d), `color` = `rgb(255, 255, 255)` — **nicht** mehr `rgba(0,0,0,0)`. Im Screenshot ein solider roter Button unten rechts im Dialog.
- **"Endgültig löschen"** (Confirm-Dialog): `backgroundColor` = `rgb(212, 24, 61)`.
- `npm run build` grün.