### PR TITLE
Feat #179: 36 Monate (3 Jahre) Laufzeit im Wizard + Verlängern

### DIFF
--- a/src/api/deployments.ts
+++ b/src/api/deployments.ts
@@ -125,7 +125,7 @@ export type DeploymentLogDto = {
 
 // Allowed deployment runtimes in months. Must mirror the backend's
 // ALLOWED_RUNTIME_MONTHS — wizard <Select> options must stay in sync.
-export type RuntimeMonths = 1 | 3 | 4 | 6 | 12 | 24;
+export type RuntimeMonths = 1 | 3 | 4 | 6 | 12 | 24 | 36;
 
 export type DeploymentCreateRequest = {
   name?: string;

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -297,14 +297,14 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
   }, [deployment.id, activeProjectId, selectedExtendMonths, extendInFlight]);
 
   const getAvailableExtendMonths = useCallback(() => {
-    if (!deployment.expires_at) return [1, 3, 4, 6, 12, 24];
+    if (!deployment.expires_at) return [1, 3, 4, 6, 12, 24, 36];
     const today = new Date();
     const expiresDate = new Date(deployment.expires_at);
     const monthsDiff =
       (expiresDate.getFullYear() - today.getFullYear()) * 12 +
       (expiresDate.getMonth() - today.getMonth());
-    const maxExtension = 24 - Math.max(0, monthsDiff);
-    return [1, 3, 4, 6, 12, 24].filter(m => m <= maxExtension);
+    const maxExtension = 36 - Math.max(0, monthsDiff);
+    return [1, 3, 4, 6, 12, 24, 36].filter(m => m <= maxExtension);
   }, [deployment.expires_at]);
 
   const accessTypeLabels: Record<AccessType, string> = {
@@ -641,11 +641,11 @@ export function DeploymentDetails({ deployment, onBack, onDelete, onRetry }: Dep
                   <AlertDialogHeader>
                     <AlertDialogTitle>Deployment verlängern</AlertDialogTitle>
                     <AlertDialogDescription>
-                      Wählen Sie aus, um wie viele Monate Sie das Deployment verlängern möchten. Maximal 24 Monate ab heute.
+                      Wählen Sie aus, um wie viele Monate Sie das Deployment verlängern möchten. Maximal 36 Monate ab heute.
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <div className="grid grid-cols-2 gap-2 py-4">
-                    {[1, 3, 4, 6, 12, 24].map((months) => {
+                    {[1, 3, 4, 6, 12, 24, 36].map((months) => {
                       const availableMonths = getAvailableExtendMonths();
                       const isAvailable = availableMonths.includes(months);
                       return (

--- a/src/pages/DeploymentDetailsPage.tsx
+++ b/src/pages/DeploymentDetailsPage.tsx
@@ -307,7 +307,7 @@ export function DeploymentDetailsPage() {
       // doesn't store the original choice on the row, only the resulting
       // expires_at. We round to the nearest allowed value so the wizard's
       // <Select> can show it without the user reseating the field.
-      const ALLOWED: Array<1 | 3 | 4 | 6 | 12 | 24> = [1, 3, 4, 6, 12, 24];
+      const ALLOWED: Array<1 | 3 | 4 | 6 | 12 | 24 | 36> = [1, 3, 4, 6, 12, 24, 36];
       let runtimeMonths: number | undefined;
       if (raw.expires_at && raw.created_at) {
         const createdMs = new Date(raw.created_at).getTime();

--- a/src/pages/DeploymentWizard.tsx
+++ b/src/pages/DeploymentWizard.tsx
@@ -1243,6 +1243,7 @@ export function DeploymentWizard({
                     <SelectItem value="6">6 Monate</SelectItem>
                     <SelectItem value="12">1 Jahr</SelectItem>
                     <SelectItem value="24">2 Jahre</SelectItem>
+                    <SelectItem value="36">3 Jahre</SelectItem>
                   </SelectContent>
                 </Select>
                 <p className="text-xs text-slate-500 mt-2 flex items-center gap-1">
@@ -1519,6 +1520,7 @@ export function DeploymentWizard({
         "6": "6 Monate",
         "12": "1 Jahr",
         "24": "2 Jahre",
+        "36": "3 Jahre",
       };
 
       return (


### PR DESCRIPTION
Closes #179

Frontend-Seite des Two-Repo-Changes: Deployments koennen jetzt fuer bis zu **36 Monate (3 Jahre, Dauer des Studiums)** angelegt und verlaengert werden. Bisher war ueberall bei 24 Monaten / "2 Jahre" Schluss.

## Aenderungen (Frontend)
- `src/api/deployments.ts` (Z. 128): `RuntimeMonths`-Typ um `| 36` erweitert.
- `src/pages/DeploymentWizard.tsx`: `<SelectItem value="36">3 Jahre</SelectItem>` nach der 24-Option ergaenzt; `runtimeLabels`-Map um `"36": "3 Jahre"` erweitert.
- `src/pages/DeploymentDetails.tsx`: beide Runtime-Arrays (`getAvailableExtendMonths`) und die Verlaengern-Button-Liste um `36` ergaenzt; `maxExtension = 24 - ...` -> `36 - ...`; Dialog-Text "Maximal 24 Monate" -> "Maximal 36 Monate".
- `src/pages/DeploymentDetailsPage.tsx`: das `ALLOWED`-Snap-Array (Prefill fuers Redeploy in den Wizard) um `36` erweitert, damit ein 36-Monats-Deployment nicht faelschlich auf 24 gerundet wird. (War nicht in der urspruenglichen Aufgabenliste, per Grep gefunden und mitgezogen.)

## Verifikation
- `npm run build` -> gruen (die CSS-`css-syntax-error`-Warnung stammt aus der vorgebauten `src/index.css` und ist unabhaengig von dieser Aenderung).

## Gepaarter Backend-PR
- https://github.com/DoziLab/appstore-backend/pull/184 (`ALLOWED_RUNTIME_MONTHS` um 36 erweitert). Muss zuerst deployt sein, sonst wird der create/extend-Call weiterhin mit 422 abgelehnt.

## Produkt-Frage an das Team
36 wurde bewusst sowohl beim **Erstellen** als auch beim **Verlaengern** hinzugefuegt (Konsistenz zwischen Wizard und Verlaengern-Dialog). Hinweis: die 24-Grenze war ein kuerzlich bewusst gesetzter Cap — bitte bestaetigen, ob 36 wirklich fuer beide Flows gelten soll oder nur fuers Verlaengern.