### PR TITLE
Feat #207: Gruppenlose Kurs-Mitglieder in DeploymentDetails nachträglich zuweisen

### DIFF
--- a/cypress/e2e/detail/detail-issue-207-ungrouped-members.cy.ts
+++ b/cypress/e2e/detail/detail-issue-207-ungrouped-members.cy.ts
@@ -1,0 +1,118 @@
+/// <reference path="../../support/index.d.ts" />
+
+// issue-207-ungrouped-members
+// ───────────────────────────
+// Visual repro for issue #207: a course member who is in NO group must appear
+// in an "Ohne Gruppe" section of the CourseGroupsCard ("Gruppen & Mitglieder"),
+// with a group <Select> + "Hinzufügen" button that POSTs to
+// /api/v1/courses/{id}/groups/{groupId}/members (addGroupMembers).
+//
+// Fixture setup: course-alpha has 3 active members (cm-1, cm-2, cm-3). cm-1 is
+// in grp-1, cm-2 is in grp-2 — so cm-3 (user u3-neu) is ungrouped and must
+// surface in the amber "Ohne Gruppe" block.
+
+describe("DeploymentDetails · issue #207 ungrouped course members", () => {
+  beforeEach(() => {
+    cy.mockApi();
+
+    cy.intercept("GET", "/api/v1/deployments/dep-alpha-0001*", (req) => {
+      if (req.url.includes("/logs")) return;
+      req.reply({ fixture: "deployments/detail-running.json" });
+    }).as("getDeployment");
+
+    cy.intercept("GET", "/api/v1/deployments/dep-alpha-0001/logs*", {
+      fixture: "deployments/logs-heat-ansible.json",
+    }).as("getLogs");
+    cy.intercept("GET", "/api/v1/deployments/dep-alpha-0001/logs/stream*", {
+      statusCode: 200,
+      body: "",
+    }).as("getLogsStream");
+    cy.intercept("GET", "/api/v1/openstack/flavors*", {
+      statusCode: 200,
+      body: { flavors: [] },
+    }).as("getOpenstackFlavors");
+    cy.intercept("GET", "**/admin/realms/*/groups*", {
+      fixture: "keycloak/groups-direct.json",
+    }).as("getKeycloakAdminGroups");
+
+    // Course endpoints driving CourseGroupsCard.
+    cy.intercept("GET", "/api/v1/courses/course-alpha/groups", {
+      fixture: "courses/groups-two.json",
+    }).as("getCourseGroups");
+    cy.intercept("GET", "/api/v1/courses/course-alpha/members", {
+      fixture: "courses/members-with-ungrouped.json",
+    }).as("getCourseMembers");
+    cy.intercept(
+      "GET",
+      "/api/v1/courses/course-alpha/groups/grp-1/members",
+      { fixture: "courses/group-members-grp1.json" },
+    ).as("getGrp1Members");
+    cy.intercept(
+      "GET",
+      "/api/v1/courses/course-alpha/groups/grp-2/members",
+      { fixture: "courses/group-members-grp2.json" },
+    ).as("getGrp2Members");
+
+    // POST add-to-group — echo back a created group member for cm-3.
+    cy.intercept(
+      "POST",
+      "/api/v1/courses/course-alpha/groups/grp-1/members",
+      {
+        statusCode: 201,
+        body: {
+          success: true,
+          message: "Added 1 member(s) to group successfully",
+          data: [
+            {
+              id: "gm-new",
+              group_id: "grp-1",
+              course_member_id: "cm-3",
+              joined_at: "2026-07-24T12:00:00Z",
+            },
+          ],
+          errors: null,
+          timestamp: "2026-07-24T12:00:00Z",
+          request_id: "req-add",
+        },
+      },
+    ).as("addGroupMembers");
+  });
+
+  it("shows the 'Ohne Gruppe' section and adds the member to a group", () => {
+    cy.loginAs("lecturer", "/deployment/dep-alpha-0001");
+    cy.wait(["@getDeployment", "@getLogs"]);
+    cy.contains("h1", "test-deploy-alpha").should("be.visible");
+
+    // Expand the card.
+    cy.contains("Gruppen & Mitglieder").should("be.visible");
+    cy.contains("button", "Anzeigen").click();
+    cy.wait(["@getCourseGroups", "@getCourseMembers"]);
+
+    // The ungrouped section must appear with the new member.
+    cy.contains("Ohne Gruppe").scrollIntoView().should("be.visible");
+    cy.contains(
+      "Der Student erhält erst Zugriff, wenn er einer zugewiesenen Gruppe hinzugefügt wird.",
+    ).should("be.visible");
+    cy.contains("u3-neu").should("be.visible");
+
+    cy.screenshot("issue-207-ohne-gruppe-section", { capture: "viewport" });
+
+    // Choose a group and add.
+    cy.contains("li", "u3-neu").within(() => {
+      cy.get("button").contains("Hinzufügen").should("be.disabled");
+      cy.get("[role='combobox']").click();
+    });
+    cy.get("[role='option']").contains("Gruppe A").click();
+    cy.contains("li", "u3-neu").within(() => {
+      cy.get("button").contains("Hinzufügen").click();
+    });
+
+    cy.wait("@addGroupMembers").its("request.body").should("deep.equal", {
+      member_ids: ["cm-3"],
+    });
+
+    // After the add, the ungrouped member is gone from "Ohne Gruppe".
+    cy.contains("Ohne Gruppe").should("not.exist");
+    cy.screenshot("issue-207-after-add", { capture: "viewport" });
+  });
+});

--- a/cypress/fixtures/courses/group-members-grp1.json
+++ b/cypress/fixtures/courses/group-members-grp1.json
@@ -1,0 +1,10 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    { "id": "gm-1", "group_id": "grp-1", "course_member_id": "cm-1", "user_id": "u1", "joined_at": "2026-01-01T00:00:00Z" }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-24T00:00:00Z",
+  "request_id": "req-gm1"
+}

--- a/cypress/fixtures/courses/group-members-grp2.json
+++ b/cypress/fixtures/courses/group-members-grp2.json
@@ -1,0 +1,10 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    { "id": "gm-2", "group_id": "grp-2", "course_member_id": "cm-2", "user_id": "u2", "joined_at": "2026-01-02T00:00:00Z" }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-24T00:00:00Z",
+  "request_id": "req-gm2"
+}

--- a/cypress/fixtures/courses/groups-two.json
+++ b/cypress/fixtures/courses/groups-two.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    { "id": "grp-1", "course_id": "course-alpha", "name": "Gruppe A", "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z" },
+    { "id": "grp-2", "course_id": "course-alpha", "name": "Gruppe B", "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z" }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-24T00:00:00Z",
+  "request_id": "req-groups"
+}

--- a/cypress/fixtures/courses/members-with-ungrouped.json
+++ b/cypress/fixtures/courses/members-with-ungrouped.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    { "id": "cm-1", "user_id": "u1", "course_id": "course-alpha", "joined_at": "2026-01-01T00:00:00Z", "left_at": null },
+    { "id": "cm-2", "user_id": "u2", "course_id": "course-alpha", "joined_at": "2026-01-02T00:00:00Z", "left_at": null },
+    { "id": "cm-3", "user_id": "u3-neu", "course_id": "course-alpha", "joined_at": "2026-07-20T00:00:00Z", "left_at": null }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-24T00:00:00Z",
+  "request_id": "req-members"
+}

--- a/src/pages/DeploymentDetails.tsx
+++ b/src/pages/DeploymentDetails.tsx
@@ -64,9 +64,12 @@ import {
 } from "../components/ui/select";
 import {
   getCourseGroups,
+  getCourseMembers,
   getGroupMembers,
+  addGroupMembers,
   moveGroupMember,
   type CourseGroupDto,
+  type CourseMemberDto,
   type GroupMemberDto,
 } from "../api/courses";
 import {
@@ -1396,6 +1399,14 @@ function CourseGroupsCard({
   );
   // groupMemberId currently being moved → disables its select + shows spinner.
   const [movingMemberId, setMovingMemberId] = useState<string | null>(null);
+  // All active course members (needed to detect who is in NO group).
+  const [courseMembers, setCourseMembers] = useState<CourseMemberDto[]>([]);
+  // ungrouped course_member_id → target group chosen in its <Select>.
+  const [ungroupedTarget, setUngroupedTarget] = useState<
+    Record<string, string>
+  >({});
+  // course_member_id currently being added → disables its row + shows spinner.
+  const [addingMemberId, setAddingMemberId] = useState<string | null>(null);
 
   const loadAll = useCallback(async () => {
     setLoading(true);
@@ -1405,14 +1416,20 @@ function CourseGroupsCard({
       const groupsResp = await getCourseGroups(courseId);
       const groupList = groupsResp.data ?? [];
 
-      // 2. Members per group — parallel
-      const memberLists = await Promise.all(
-        groupList.map((g) =>
-          getGroupMembers(courseId, g.id)
-            .then((r) => r.data ?? [])
-            .catch(() => [] as GroupMemberDto[]),
+      // 2. Members per group — parallel. Also fetch all active course
+      //    members so we can detect who is in NO group (issue #207).
+      const [memberLists, courseMembersResp] = await Promise.all([
+        Promise.all(
+          groupList.map((g) =>
+            getGroupMembers(courseId, g.id)
+              .then((r) => r.data ?? [])
+              .catch(() => [] as GroupMemberDto[]),
+          ),
         ),
-      );
+        getCourseMembers(courseId)
+          .then((r) => r.data ?? [])
+          .catch(() => [] as CourseMemberDto[]),
+      ]);
 
       // 3. Keycloak user lookup (best-effort — if it fails we render user_ids)
       let index = new Map<string, KeycloakUser>();
@@ -1440,6 +1457,7 @@ function CourseGroupsCard({
 
       setGroups(groupList);
       setMembersByGroup(byGroup);
+      setCourseMembers(courseMembersResp);
       setUserIndex(index);
     } catch (err) {
       const e = err as Error & { status?: number };
@@ -1513,6 +1531,71 @@ function CourseGroupsCard({
     0,
   );
 
+  // Course members who are in NO group at all (issue #207). A student added
+  // to the course after a deployment already exists lands here: the backend
+  // grants deployment visibility only via a group's DeploymentInstanceAccess,
+  // so an ungrouped member sees nothing until added to a group. De-dup by
+  // course_member_id, which is the id `addGroupMembers` expects.
+  const groupedMemberIds = useMemo(() => {
+    const ids = new Set<string>();
+    Object.values(membersByGroup).forEach((arr) =>
+      arr.forEach((m) => ids.add(m.course_member_id)),
+    );
+    return ids;
+  }, [membersByGroup]);
+
+  const ungroupedMembers = useMemo(
+    () => courseMembers.filter((cm) => !groupedMemberIds.has(cm.id)),
+    [courseMembers, groupedMemberIds],
+  );
+
+  const handleAddToGroup = useCallback(
+    async (member: CourseMemberDto, toGroupId: string) => {
+      if (addingMemberId) return;
+      if (!toGroupId) return;
+      setAddingMemberId(member.id);
+      try {
+        const resp = await addGroupMembers(courseId, toGroupId, [member.id]);
+        // Optimistically move the member into the chosen group bucket so the
+        // "Ohne Gruppe" list shrinks and the member shows up under the group.
+        const created = resp.data?.[0];
+        setMembersByGroup((cur) => {
+          const next = { ...cur };
+          next[toGroupId] = [
+            ...(next[toGroupId] ?? []),
+            {
+              id: created?.id ?? `${toGroupId}:${member.id}`,
+              group_id: toGroupId,
+              course_member_id: member.id,
+              user_id: member.user_id,
+              joined_at: created?.joined_at ?? new Date().toISOString(),
+              user: userIndex.get(member.user_id),
+            },
+          ];
+          return next;
+        });
+        setUngroupedTarget((cur) => {
+          const next = { ...cur };
+          delete next[member.id];
+          return next;
+        });
+        toast.success("Mitglied zur Gruppe hinzugefügt.");
+      } catch (err) {
+        const e = err as Error & { status?: number };
+        if (e.status === 403) {
+          toast.error("Keine Berechtigung, Mitglieder hinzuzufügen.");
+        } else if (e.status === 404) {
+          toast.error("Gruppe oder Mitglied nicht gefunden.");
+        } else {
+          toast.error(e.message || "Hinzufügen fehlgeschlagen.");
+        }
+      } finally {
+        setAddingMemberId(null);
+      }
+    },
+    [courseId, addingMemberId, userIndex],
+  );
+
   return (
     <Card className="border-slate-200 shadow-sm">
       <CardHeader>
@@ -1522,8 +1605,8 @@ function CourseGroupsCard({
             <div>
               <CardTitle>Gruppen & Mitglieder</CardTitle>
               <CardDescription>
-                Gruppen dieses Kurses anzeigen und Mitglieder zwischen Gruppen
-                verschieben.
+                Gruppen dieses Kurses anzeigen, Mitglieder zwischen Gruppen
+                verschieben und gruppenlose Mitglieder einer Gruppe zuweisen.
               </CardDescription>
             </div>
           </div>
@@ -1648,6 +1731,85 @@ function CourseGroupsCard({
               </div>
             </>
           )}
+
+          {/* Issue #207: course members in NO group. They have no deployment
+              visibility until added to a group that carries this deployment's
+              DeploymentInstanceAccess. The target dropdown is scoped to the
+              groups already listed above (i.e. this deployment's groups). */}
+          {!loading && !error && ungroupedMembers.length > 0 && (
+            <div className="border border-amber-200 rounded-lg p-3 bg-amber-50">
+              <div className="flex items-center gap-2 mb-2">
+                <AlertTriangle className="w-4 h-4 text-amber-600" />
+                <span className="text-sm text-amber-900">Ohne Gruppe</span>
+                <Badge variant="outline" className="text-xs">
+                  {ungroupedMembers.length}{" "}
+                  {ungroupedMembers.length === 1 ? "Mitglied" : "Mitglieder"}
+                </Badge>
+              </div>
+              <p className="text-xs text-amber-700 mb-2">
+                Der Student erhält erst Zugriff, wenn er einer zugewiesenen
+                Gruppe hinzugefügt wird.
+              </p>
+              {groups.length === 0 ? (
+                <p className="text-xs text-slate-500">
+                  Für diesen Kurs sind keine Gruppen angelegt, denen Mitglieder
+                  zugewiesen werden könnten.
+                </p>
+              ) : (
+                <ul className="space-y-1">
+                  {ungroupedMembers.map((cm) => {
+                    const target = ungroupedTarget[cm.id] ?? "";
+                    const busy = addingMemberId === cm.id;
+                    return (
+                      <li
+                        key={cm.id}
+                        className="flex items-center justify-between gap-3 px-2 py-1 rounded hover:bg-slate-100"
+                      >
+                        <span className="text-sm text-slate-700 truncate">
+                          {courseMemberDisplayName(cm, userIndex)}
+                        </span>
+                        <div className="flex items-center gap-2 shrink-0">
+                          {busy && (
+                            <Loader2 className="w-3.5 h-3.5 animate-spin text-slate-400" />
+                          )}
+                          <Select
+                            value={target}
+                            disabled={addingMemberId !== null}
+                            onValueChange={(gid) =>
+                              setUngroupedTarget((cur) => ({
+                                ...cur,
+                                [cm.id]: gid,
+                              }))
+                            }
+                          >
+                            <SelectTrigger className="h-7 text-xs w-[160px]">
+                              <SelectValue placeholder="Gruppe wählen…" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {groups.map((g) => (
+                                <SelectItem key={g.id} value={g.id}>
+                                  {g.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs"
+                            disabled={!target || addingMemberId !== null}
+                            onClick={() => void handleAddToGroup(cm, target)}
+                          >
+                            Hinzufügen
+                          </Button>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
         </CardContent>
       )}
     </Card>
@@ -1659,6 +1821,17 @@ function memberDisplayName(
   userIndex: Map<string, KeycloakUser>,
 ): string {
   const u = m.user ?? userIndex.get(m.user_id);
+  if (!u) return m.user_id;
+  const full = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
+  if (full && u.username) return `${full} (${u.username})`;
+  return full || u.username || m.user_id;
+}
+
+function courseMemberDisplayName(
+  m: CourseMemberDto,
+  userIndex: Map<string, KeycloakUser>,
+): string {
+  const u = userIndex.get(m.user_id);
   if (!u) return m.user_id;
   const full = [u.firstName, u.lastName].filter(Boolean).join(" ").trim();
   if (full && u.username) return `${full} (${u.username})`;


### PR DESCRIPTION
Closes #207

## Problem
Ein Student, der einem Kurs **nach** einem bereits bestehenden Deployment hinzugefügt wird, landet in **keiner Gruppe** und sieht das Deployment nicht. Das Backend gewährt Deployment-Sichtbarkeit ausschließlich über `GroupMember → CourseGroup → DeploymentInstanceAccess` (`appstore-backend/src/api/student.py:56-88`, staging). Die "Gruppen & Mitglieder"-Karte (`CourseGroupsCard`) listete bisher nur Mitglieder, die bereits einer Gruppe angehören — gruppenlose Kurs-Mitglieder waren unsichtbar.

## Was hinzugefügt wurde
Eine **"Ohne Gruppe"**-Sektion in `CourseGroupsCard` (`src/pages/DeploymentDetails.tsx`):
- lädt zusätzlich `getCourseMembers(courseId)` parallel zu den Gruppen-Mitgliedern
- berechnet die Kurs-Mitglieder, die in **keiner** Gruppe sind (De-Dup über `course_member_id`)
- rendert die Sektion nur, wenn ≥1 gruppenloses Mitglied existiert
- pro Mitglied: Gruppen-`<Select>` + **"Hinzufügen"**-Button → `addGroupMembers(courseId, groupId, [courseMemberId])` (bestehender, backend-gestützter POST)
- Ziel-Dropdown ist auf die in der Karte gelisteten Gruppen des Deployments beschränkt; Hinweistext: _"Der Student erhält erst Zugriff, wenn er einer zugewiesenen Gruppe hinzugefügt wird."_
- nach Erfolg: optimistisches Verschieben ins Gruppen-Bucket + Erfolgs-Toast; Fehlerbehandlung (403/404/generisch)

## Verifizierte Backend-Routen (staging)
- `GET /api/v1/courses/{course_id}/members` — `courses.py:260`, liefert `CourseMemberResponse[]` (`id`, `user_id`, `course_id`, `joined_at`, `left_at`) → passt zu `getCourseMembers`
- `POST /api/v1/courses/{course_id}/groups/{group_id}/members` — `courses.py:429`, Body `GroupMemberAdd` = `{ "member_ids": [...] }` (course_member_ids) → passt exakt zu `addGroupMembers`. Keine Mismatches.

## Scope
Die Mitglieder-**VERSCHIEBEN**-Funktion (PATCH) bleibt **out of scope** — der Endpoint existiert auf staging nicht.

## Verifizierung
- `npm run build` grün, eslint 0 errors
- **Visueller Repro** (Playwright, vite auf Port 3007, Keycloak-Stub lecturer, gemockte Endpoints): "Ohne Gruppe"-Sektion rendert korrekt; Add-Flow sendet `{"member_ids":["cm-3"]}`, Mitglied wandert in die gewählte Gruppe, Sektion verschwindet, Erfolgs-Toast erscheint.
- Cypress-Spec + Fixtures für CI ergänzt (`cypress/e2e/detail/detail-issue-207-ungrouped-members.cy.ts`).

## Hinweis für Produkt
Das Issue war als **Frage** formuliert ("wie kann es nachbearbeitet werden?"). Bitte bestätigen, dass "gruppenlosen Studenten einer zugewiesenen Gruppe hinzufügen" die gewünschte Lösung ist.