### PR TITLE
test(cypress): Suite auf staging-Stand aktualisieren — Reparaturen + neue Feature-Tests

### DIFF
--- a/cypress/REPORT-STAGING-UPDATE.md
+++ b/cypress/REPORT-STAGING-UPDATE.md
@@ -1,0 +1,101 @@
+# Abschlussbericht — Cypress-Suite-Update auf staging-Stand (2026-07)
+
+> Aktualisierung der bestehenden Cypress-Integrationstest-Suite an den neuen `origin/staging`-Stand (~7.800 geänderte `src/`-Zeilen seit der ursprünglichen Test-Baseline `d1af1a7`). Reparatur veralteter Tests + neue Feature-Abdeckung. Arbeitsstand: Worktree-Branch `integrationstests-staging-update`.
+
+## Ergebnis
+
+| Check | Ergebnis |
+| --- | --- |
+| **Cypress-Suite** | **46/46 Tests grün** über **30 Specs**, 0 failing (~61s) |
+| **TypeScript** (`tsc --noEmit -p cypress/tsconfig.json`) | 0 Fehler |
+| **ESLint** | 0 Fehler, 40 Warnings (alle pre-existing) |
+| **Build** (`vite build`) | success |
+
+## Zahlen
+
+| Metrik | Wert |
+| --- | --- |
+| Commits in dieser Session | **21** |
+| Reparierte bestehende Tests | **5** |
+| Reaktivierte Tests (vorher `skip`) | **1** (Admin-Guard) |
+| Neue Feature-Tests | **11** (2× P0, 7× P1, 2× P2) |
+| Neue Fixtures | ~12 (Student, Lecturer, Admin-Deployments, Redeploy-Params, Course-Filter, …) |
+| Produktivcode-Änderungen | **0** |
+| Neue `data-testid` | **0** (alle Tests über role/text/id/aria-Selektoren) |
+
+## Kontext des Updates
+
+`origin/staging` hatte sich seit der ersten Suite massiv weiterentwickelt. Der aktuelle Checkout (`feature/192`) und die alte `integrationstests`-Arbeit waren bereits nach `staging` gemerged. Neu hinzugekommen: Student-Self-Service, Lecturer-Verwaltung (Admin), Admin-Rework (Split von `/admin`), Redeploy/VM-Config-Override, Kurs-Filter, 36-Monate-Laufzeit, Expiry-Farbstufen, Owner-Only-Gating, `ProtectedRoute`, `MobileTopBar`, `CredentialInstanceCard`.
+
+## Teil A — Reparaturen (6)
+
+| Test | Ursache | Fix | Commit |
+| --- | --- | --- | --- |
+| `auth-admin-bypasses-setup-gate` | `/admin` gesplittet | Ziel → `/admin/projects`, Heading „Projektübersicht" | e762bc2 |
+| `admin-approve-template-version` | Queue nach `/admin/templates` verschoben | Route angepasst | a3d1705 |
+| `detail-delete-confirmation-flow` | Owner-Only-Gate (fix/126) | `owner_id` in Fixture | a14815f |
+| `auth-non-admin-cannot-access-admin-route` | war geskippt; Befund via `ProtectedRoute` behoben | neu geschrieben (Redirect-Assertion) + reaktiviert | 265a90d |
+| `detail-issue-207-ungrouped-members` (fremd) | Card-Titel off-screen | `scrollIntoView()` | e04c570 |
+| `visual-capture` (fremd) | Mobile: `cy.contains` traf versteckten Sidebar-Link; falscher Reference-Pfad | `cy.contains("h1", …)` + Pfad-Fix | 6d58f9f, 20477c3 |
+
+## Teil B — Neue Feature-Tests (11)
+
+### Student-Self-Service
+- `student-dashboard-lists-deployments` **[P0]** (1ca72d3) — Routing `/` → `/student/dashboard` + Deployment-Karten
+- `student-role-routing-guard` **[P0]** (134f4e1) — Student auf `/dashboard`/`/appstore` → Redirect; keine Lecturer-Calls
+- `student-deployment-details-credentials` **[P1]** (60fec05) — VMs + Credentials (CredentialInstanceCard mode=student)
+
+### Admin-Bereich
+- `lecturer-management-lists` **[P1]** (f35a9ed) — Lecturer-Tabelle + Detail-Dialog
+- `lecturer-delete-cascade-poll` **[P1]** (13fb357) — Type-to-confirm + DELETE 202 + Poll 200→404
+- `admin-project-overview-renders` **[P1]** (b231c48) — Stat-Cards + View-Selector (Dozent/Kurs/Datum)
+- `admin-reject-template-with-reason` **[P1]** (93bc5cb) — Reject-Flow mit Begründung im Payload
+
+### Deployment / Courses
+- `redeploy-deployment-config-override` **[P1]** (ce5e739) — RedeployDialog, nur geänderte Params im Override
+- `course-filters-toggle-chip` **[P1]** (317482c) — client-seitige Chip-Filterung
+- `course-filters-admin-crud` **[P1]** (aac5a7d) — Admin: Filter anlegen (POST) + löschen (DELETE)
+
+### Wizard / Dashboard
+- `wizard-36-months-runtime` **[P2]** (26fc782) — „3 Jahre"-Laufzeit → `runtime_months: 36`
+- `dashboard-expiry-color-tiers` **[P2]** (fde35a6) — warning/critical/expired-Indikatoren (relative Daten)
+
+## Infrastruktur-Anpassungen
+
+- **`Role`-Union** um `"student"` erweitert (commands.ts + index.d.ts, Commit 0115898) — nutzt bestehende `keycloak/student.json`.
+- **Delta-Matrix** `cypress/TEST-MATRIX-DELTA.md` (9f681f5) dokumentiert Reparaturen + neue Tests.
+- **`cy.mockApi`** deckte bereits `template-versions/queue` + `openstack/flavors` ab (aus der ersten Session).
+
+## Bestätigte Sicherheits-Verbesserung
+
+Der ursprünglich in `SECURITY-FINDINGS.md` dokumentierte Privilege-Escalation-Befund (`/admin` ohne Frontend-Rollen-Gate) ist auf `staging` **behoben**: `ProtectedRoute requireAdmin` leitet Nicht-Admins auf `/dashboard` um. Der zuvor geskippte Test ist reaktiviert und sichert den Guard; das Finding wurde auf **RESOLVED** aktualisiert.
+
+## Umgebungs-Hinweis (nicht committed)
+
+Auf diesem Rechner (Apple M2, aber **x64-node unter Rosetta**) kollidiert Cypress' gebündeltes arm64-esbuild mit dem x64-node beim Kompilieren der TS-Config. Lokaler Workaround: `ESBUILD_BINARY_PATH` auf ein passendes x64-esbuild-0.28.0-Binary setzen — **nur für Cypress**, nicht für Vite (das braucht 0.25.12). Ein lokales Runner-Skript `/tmp/local-cypress-run.sh` kapselt das. **Nichts davon wurde committed** — auf einer arch-konsistenten Maschine / in CI ist der Workaround unnötig und würde dort sogar stören. `node_modules` im Worktree ist ein Symlink auf den Haupt-Checkout.
+
+## Verbliebene Risiken / Nicht abgedeckt
+
+- **`TemplateIconUpload`** (Multipart-Icon-Upload im AppStore-Owner-Dialog) — nicht getestet (Datei-Upload + Multipart-Intercept aufwändig).
+- **SSH-Key-Download** im Student-Detail (Blob + Content-Disposition) — nur Anzeige getestet, nicht der Download.
+- **`NoRolePage`** — laut Analyse ist `/no-role` nicht als Route registriert (nur ProtectedRoute-Redirect-Ziel), landet über Catch-all bei `/dashboard`. Potenzielle Lücke, nicht durch Test fixiert.
+- **Rename-Flow** der Course-Filter (PATCH) — nur Create/Delete getestet.
+- **Fehlerpfade** vieler neuer Features (403/404/409) — überwiegend Happy-Path abgedeckt, analog zur bestehenden P0/P1-Tiefe.
+- **Redeploy pro VM** (Instance-Redeploy) — nur der Deployment-weite Redeploy getestet.
+
+## Mögliche zukünftige Testfälle
+
+1. `student-credentials-error-403/404` — Fehlerpfade der Credentials
+2. `redeploy-instance-per-vm` — VM-einzelner Redeploy
+3. `redeploy-only-owner-or-running` — Permission/Status-Gate des Redeploy-Buttons
+4. `course-filters-rename` — PATCH-Flow
+5. `course-filters-lecturer-readonly` — Lecturer sieht keine CRUD-Controls
+6. `template-icon-upload` — Multipart-Upload + Preview
+7. `lecturer-delete-timeout` — Poll läuft 30s ohne 404 → Timeout-State
+8. `admin-project-overview-drilldown` — Klick in Dozent/Kurs-Gruppe → Detailtabelle
+9. `mobile-topbar-drawer-nav` — Hamburger-Drawer-Navigation (Viewport-Test)
+10. `wizard-extend-runtime` — Laufzeit-Verlängerung (PATCH /extend) auf der Detailseite
+
+## Nächste Schritte
+
+Branch `integrationstests-staging-update` ist **21 Commits vor `origin/staging`**. Nach Freigabe: `git push` + PR nach `staging`. Für CI müsste `npm run test:e2e` (via `start-server-and-test`) noch als Pipeline-Schritt ergänzt werden, damit die Suite auf jedem PR läuft — auf arch-konsistenten Runnern ohne den esbuild-Workaround.

--- a/cypress/SECURITY-FINDINGS.md
+++ b/cypress/SECURITY-FINDINGS.md
@@ -8,13 +8,17 @@
 
 **Severity**: High (privilege escalation, defence-in-depth)
 **Discovered while writing**: `cypress/e2e/auth/auth-non-admin-cannot-access-admin-route.cy.ts`
-**State**: Test is `describe.skip(...)` until the fix lands.
+**State**: ✅ **RESOLVED on `staging`** (admin-area rework). The test is now un-skipped and active — it passes against the fixed code and guards against regression.
 
-### Finding
+### Resolution
 
-`AdminMonitoring.tsx` has no role gate. `App.tsx` line 159 wires `<AdminMonitoring />` at `/admin` for any authenticated user. The Sidebar nav link IS gated (`Sidebar.tsx` line 121 checks `isAdmin`), but that is only a UI affordance, not a security boundary.
+The admin-area rework replaced the single ungated `/admin` route with three routes — `/admin/projects`, `/admin/templates`, `/admin/lecturers` — each wrapped in `<ProtectedRoute requireAdmin>` (`src/components/ProtectedRoute.tsx`). For a non-admin, `requireAdmin && !isAdmin` returns `<Navigate to="/dashboard" replace>`, so `AdminTemplateApprovals` / `AdminProjectOverview` never mount and their data effects never run. `AdminMonitoring.tsx` (the old ungated page) is now dead code. The regression test asserts: lecturer → `/admin/templates` redirects to `/dashboard`, the "Template-Freigaben" H1 is absent, and the approval-queue fetch never fires.
 
-A user authenticated with `roles=["lecturer"]` (no admin role) who navigates directly to `/admin` sees:
+### Original finding (for the record)
+
+`AdminMonitoring.tsx` had no role gate. `App.tsx` wired `<AdminMonitoring />` at `/admin` for any authenticated user. The Sidebar nav link IS gated (`Sidebar.tsx` checks `isAdmin`), but that is only a UI affordance, not a security boundary.
+
+A user authenticated with `roles=["lecturer"]` (no admin role) who navigated directly to `/admin` saw:
 
 - the full `Administration` heading and tabbed UI;
 - `getAllDeployments(null)` is fired — returns the **global** deployment list (every lecturer's work), not just their own;

--- a/cypress/TEST-MATRIX-DELTA.md
+++ b/cypress/TEST-MATRIX-DELTA.md
@@ -1,0 +1,68 @@
+# Cypress Delta Test Matrix — staging update (2026-07)
+
+> Ergänzung zur ursprünglichen `TEST-MATRIX.md`. Erfasst (A) Reparaturen bestehender Tests nach dem großen staging-Update (~7.800 geänderte src-Zeilen) und (B) neue Feature-Tests. Konventionen wie zuvor: Keycloak gestubbt, alle API via `cy.intercept` + Fixtures, keine festen Waits, stabile Selektoren.
+
+## Kontext des Updates
+
+Zwischen der Test-Baseline (`d1af1a7`) und `origin/staging` kamen u.a. hinzu: Student-Self-Service, Lecturer-Verwaltung (Admin), Admin-Rework (Split von `/admin` in `/admin/projects|templates|lecturers` mit `ProtectedRoute`), Redeploy/VM-Config-Override, Kurs-Filter, 36-Monate-Laufzeit, Expiry-Farbstufen, Owner-Only-Gating für Deployment-Aktionen, `NoRolePage`, `MobileTopBar`, `TemplateIconUpload`, `CredentialInstanceCard`.
+
+## Teil A — Reparaturen (erledigt)
+
+| Test | Ursache der Regression | Fix | Status |
+| --- | --- | --- | --- |
+| `auth-admin-bypasses-setup-gate` | `/admin` existiert nicht mehr (Split) | Ziel-Route → `/admin/projects`, Heading → „Projektübersicht" | ✅ e762bc2 |
+| `admin-approve-template-version` | Approval-Queue nach `AdminTemplateApprovals` (`/admin/templates`) verschoben | `cy.loginAs("admin","/admin/templates")` | ✅ a3d1705 |
+| `detail-delete-confirmation-flow` | Owner-Only-Gate (`fix/126`): Delete-Button ohne `owner_id` disabled | `owner_id: user-lec-1` in Fixture | ✅ a14815f |
+| `auth-non-admin-cannot-access-admin-route` | War geskippt (Befund); jetzt via `ProtectedRoute requireAdmin` behoben | Neu geschrieben: Redirect `/admin/templates`→`/dashboard`, reaktiviert | ✅ 265a90d |
+| `detail-issue-207-ungrouped-members` (fremd) | CourseGroupsCard-Rendering/Selektor geändert | in Arbeit (Sub-Agent) | 🔧 |
+
+## Teil B — Neue Feature-Tests (geplant, P0/P1-Tiefe wie Bestand)
+
+```
+Bereich
+└── Funktion
+    └── Testfall [Prio · Typ] — Ziel · Risiko bei Regression
+```
+
+### student · self-service
+- `student-dashboard-lists-deployments` **[P0 · success]** — Pure Student → `/student/dashboard`, `GET /api/v1/student/deployments` rendert Karten. Risiko: Studenten sehen ihre Umgebungen nicht.
+- `student-dashboard-empty-state` **[P1 · edge]** — leere Liste → „Aktuell keine Deployments für dich verfügbar." Risiko: kaputter Erstkontakt.
+- `student-role-routing-guard` **[P0 · permission]** — Pure Student auf `/dashboard`/`/appstore` → Redirect `/student/dashboard`. Risiko: Student sieht Lecturer-UI.
+- `student-deployment-details-credentials` **[P1 · success]** — `/student/deployment/:id` lädt Credentials, `CredentialInstanceCard` (mode=student) rendert. Risiko: Zugangsdaten unerreichbar.
+
+### admin · lecturer-management
+- `lecturer-management-lists` **[P1 · success]** — `/admin/lecturers`, `GET /api/v1/lecturers` Tabelle. Risiko: Admin-Verwaltung tot.
+- `lecturer-delete-cascade-poll` **[P1 · success]** — Detail-Dialog → „Account löschen" → Type-to-confirm → DELETE 202 → Poll 200→404 → Erfolg. Risiko: Cascade-Delete-Feedback bricht.
+
+### admin · project-overview
+- `admin-project-overview-renders` **[P1 · success]** — `/admin/projects`, Stat-Cards + View-Selector. Risiko: globale Übersicht kaputt.
+
+### admin · template-approvals (reject)
+- `admin-reject-template-with-reason` **[P1 · success]** — „Ablehnen" → Reason → POST `/reject` `{reason}`. Risiko: Autoren ohne Feedback.
+
+### deployment · redeploy
+- `redeploy-deployment-config-override` **[P1 · success]** — „Neu deployen" (running+owner) → Param ändern → POST `/redeploy` mit `deployment_parameter_overrides`+`preserve_credentials`. Risiko: Redeploy-Feature tot.
+- `redeploy-only-owner-running` **[P1 · permission]** — Button disabled für Nicht-Owner / nicht-running. Risiko: unautorisierter Redeploy.
+
+### courses · course-filters
+- `course-filters-toggle-chip` **[P1 · state]** — Chip klicken filtert Kursliste client-seitig. Risiko: Filter unbenutzbar.
+- `course-filters-admin-crud` **[P1 · success]** — Admin: Filter hinzufügen (POST) / löschen (DELETE). Risiko: Filterverwaltung kaputt.
+- `course-filters-lecturer-readonly` **[P2 · permission]** — Lecturer sieht keine Add/Edit/Delete-Controls. Risiko: Nicht-Admin ändert Filter.
+
+### wizard · runtime
+- `wizard-36-months-runtime` **[P2 · edge]** — 36-Monate-Option („3 Jahre") wählbar, `runtime_months:36` im POST. Risiko: neue Laufzeit nicht buchbar.
+
+### dashboard · expiry-tiers
+- `dashboard-expiry-color-tiers` **[P2 · state]** — critical/warning/expired via dynamischen `expires_at` zeigen korrektes Icon. Risiko: verpasste Ablaufwarnungen.
+
+### cross-cutting · mobile-nav
+- `mobile-topbar-drawer-nav` **[P2 · state]** — `cy.viewport(375,667)` → Hamburger öffnet Sidebar-Drawer. Risiko: Mobile-Navigation kaputt.
+```
+
+## Priorisierung
+
+- **P0**: student-dashboard-lists, student-role-routing-guard (Kern-Sicherheit + Kernpfad des neuen größten Bereichs)
+- **P1**: student-details/-empty, lecturer-mgmt (2), admin-project-overview, admin-reject, redeploy (2), course-filters (2)
+- **P2**: course-filters-readonly, 36-months, expiry-tiers, mobile-nav
+
+Umfang orientiert sich am Bestand (P0/P1-Tiefe): kritische Happy-Paths + wichtigste Guards/Fehlerfälle pro Feature, keine erschöpfende Rollen-/Edge-Matrix.

--- a/cypress/e2e/admin/admin-approve-template-version.cy.ts
+++ b/cypress/e2e/admin/admin-approve-template-version.cy.ts
@@ -2,9 +2,9 @@
 
 // admin-approve-template-version
 // ──────────────────────────────
-// P0 success-path test: an admin on /admin sees the Template-Freigaben card
-// populated with pending public template-versions (loaded via GET
-// /api/v1/template-versions/queue). Clicking "Schnell genehmigen" on a row
+// P0 success-path test: an admin on /admin/templates sees the Template-
+// Freigaben card populated with pending public template-versions (loaded via
+// GET /api/v1/template-versions/queue). Clicking "Schnell genehmigen" on a row
 // must fire POST /api/v1/template-versions/<id>/approve and the row must
 // disappear from the queue UI on success.
 //
@@ -15,11 +15,13 @@
 //   versions pile up indefinitely and the AppStore stops growing — both real
 //   user-visible regressions.
 //
-//   AdminMonitoring.tsx renders one card per pending TemplateVersionQueueItem
-//   (template name + version pill + "Schnell genehmigen" / "Details prüfen"
-//   buttons). handleApprove() calls approveTemplateVersion() from
-//   src/api/github.ts and then removes the version from local state. The
-//   per-row removal is the user-visible signal that the action succeeded.
+//   AdminTemplateApprovals.tsx (route /admin/templates, split out of the old
+//   AdminMonitoring.tsx during the admin rework) renders one card per pending
+//   TemplateVersionQueueItem (template name + version pill + "Schnell
+//   genehmigen" / "Ablehnen" buttons). handleApprove() calls
+//   approveTemplateVersion() from src/api/github.ts and then removes the
+//   version from local state. The per-row removal is the user-visible signal
+//   that the action succeeded.
 //
 // Fixture
 //   queue-pending.json mirrors the QueueResponse shape from
@@ -53,7 +55,7 @@ describe("Admin · approves a pending template-version from the queue", () => {
   });
 
   it("clicks 'Schnell genehmigen' on the first pending version and the row disappears", () => {
-    cy.loginAs("admin", "/admin");
+    cy.loginAs("admin", "/admin/templates");
 
     // The queue load is the load-bearing fetch for the Template-Freigaben
     // card. Waiting on it proves the GET fired AND that the response landed
@@ -77,7 +79,7 @@ describe("Admin · approves a pending template-version from the queue", () => {
     }).as("getQueueEmpty");
 
     // Click the "Schnell genehmigen" button scoped to the WordPress row.
-    // The button text is exact (AdminMonitoring.tsx line ~900). We scope to
+    // The button text is exact (AdminTemplateApprovals.tsx:350). We scope to
     // the row by locating the template-name <h3> and walking up to the
     // surrounding Card (`data-slot="card"`) — both pending rows render the
     // same button text, so unscoped cy.contains would race between them.

--- a/cypress/e2e/admin/admin-project-overview-renders.cy.ts
+++ b/cypress/e2e/admin/admin-project-overview-renders.cy.ts
@@ -1,0 +1,110 @@
+/// <reference path="../../support/index.d.ts" />
+
+// admin-project-overview-renders
+// ──────────────────────────────
+// P1 success-path test: an admin on /admin/projects sees the global
+// project/deployment overview — three stat cards plus the grouping view
+// selector — populated from getAllDeployments(null).
+//
+// Why this test exists
+//   AdminProjectOverview.tsx (route /admin/projects, gated by
+//   <ProtectedRoute requireAdmin>) is the central admin monitoring surface
+//   after the admin rework. On mount it calls getAllDeployments(null) which
+//   hits GET /api/v1/deployments WITHOUT an openstack_project_id query — the
+//   admin bypasses the per-project filter and sees every deployment across
+//   all lecturers. The page derives three stat cards (Gesamt / Aktiv=running /
+//   Inaktiv=non-running) and a "Ansicht wählen" selector that regroups the
+//   list by lecturer / course / date. If the global fetch or the grouping
+//   breaks, the admin loses the fleet-wide overview.
+//
+// deployment_parameters.teacher shape
+//   extractTeacher() JSON.parses deployment.deployment_parameters (a STRING)
+//   and reads parsed.teacher.{id,first_name,last_name,email}; the rendered
+//   name is `${first_name} ${last_name}`, falling back to "Unbekannt" when the
+//   field is missing/unparsable. The fixture therefore stores
+//   deployment_parameters as a JSON string embedding a teacher object — this
+//   matches the task hint.
+//
+// Fixture (deployments/admin-list.json)
+//   Envelope { success, data:[...] } with 3 deployments: 2 running + 1 failed
+//   → Gesamt 3, Aktiv 2, Inaktiv 1. Two distinct teachers (Petra Professorin
+//   ×2 incl. the failed one, Dieter Dozent ×1) and three course.name values so
+//   both the lecturer and course groupings have something to render. The
+//   courses list is mockApi's default (empty), so extractCourse falls back to
+//   deployment.course.name.
+
+describe("Admin · project overview renders the global deployment fleet", () => {
+  beforeEach(() => {
+    // Default GETs (projects/quotas/deployments/courses/keycloak-groups/...)
+    // so the admin shell bootstraps. We override the deployments list below.
+    cy.mockApi();
+
+    // getAllDeployments(null) → GET /api/v1/deployments with NO
+    // openstack_project_id. The regex matches the bare path or a query string
+    // but not deeper /deployments/<id> paths. Registered AFTER mockApi so it
+    // wins on Cypress' reverse-registration stack.
+    cy.intercept("GET", /\/api\/v1\/deployments(\?[^/]*)?$/, {
+      fixture: "deployments/admin-list.json",
+    }).as("getAdminDeployments");
+
+    // getKeycloakGroups() hits the Keycloak admin REST API directly
+    // (GET /admin/realms/{realm}/groups), not the backend proxy — intercept it
+    // so the mount effect resolves instead of erroring.
+    cy.intercept("GET", "**/admin/realms/*/groups*", {
+      fixture: "keycloak/groups-direct.json",
+    }).as("getKcAdminGroups");
+  });
+
+  it("shows stat cards and switches the grouping view, all from getAllDeployments(null)", () => {
+    cy.loginAs("admin", "/admin/projects");
+
+    // The fleet-wide fetch is the load-bearing request for this page.
+    // Waiting on it proves the GET fired AND asserts the admin variant sends
+    // no openstack_project_id filter.
+    cy.wait("@getAdminDeployments")
+      .its("request.url")
+      .should("not.include", "openstack_project_id");
+
+    // Header.
+    cy.contains("h1", "Projektübersicht").should("be.visible");
+
+    // Three stat cards. Gesamt reflects the 3 fixture rows, Aktiv the 2
+    // running, Inaktiv the 1 failed. Scope the count assertion to each card
+    // so we prove the label ↔ number pairing rather than "some 3 on screen".
+    cy.contains("p", "Gesamte Deployments")
+      .parent()
+      .should("contain.text", "3");
+    cy.contains("p", "Aktive Deployments")
+      .parent()
+      .should("contain.text", "2");
+    cy.contains("p", "Inaktive Deployments")
+      .parent()
+      .should("contain.text", "1");
+
+    // Default "Nach Dozent" view: teacher names extracted from
+    // deployment_parameters.teacher are the grouping rows. Deployment NAMES
+    // are NOT shown in this aggregate view — that is the tell that lets us
+    // prove the date view later actually changes the grouping.
+    cy.get('select[aria-label="Ansicht wählen"]').should("have.value", "lecturer");
+    cy.contains("Petra Professorin").should("be.visible");
+    cy.contains("Dieter Dozent").should("be.visible");
+    cy.contains("admin-deploy-alpha").should("not.exist");
+
+    // Switch to "Nach Kurs": rows are now course names (from course.name,
+    // since the courses list is empty). The "Kurs" column header appears and
+    // the individual course names render.
+    cy.get('select[aria-label="Ansicht wählen"]').select("course");
+    cy.contains("th", "Kurs").should("be.visible");
+    cy.contains("Kurs Alpha").should("be.visible");
+    cy.contains("Kurs Beta").should("be.visible");
+
+    // Switch to "Nach Datum": the list flattens to individual deployments
+    // sorted by date, so the per-deployment NAME now appears — grouping-
+    // specific proof distinct from the lecturer/course aggregates.
+    cy.get('select[aria-label="Ansicht wählen"]').select("date");
+    cy.contains("admin-deploy-alpha").should("be.visible");
+    cy.contains("admin-deploy-gamma").should("be.visible");
+    // The failed row's status is surfaced only in the date view's Status cell.
+    cy.contains("failed").should("be.visible");
+  });
+});

--- a/cypress/e2e/admin/admin-reject-template-with-reason.cy.ts
+++ b/cypress/e2e/admin/admin-reject-template-with-reason.cy.ts
@@ -1,0 +1,111 @@
+/// <reference path="../../support/index.d.ts" />
+
+// admin-reject-template-with-reason
+// ─────────────────────────────────
+// P1 success-path test: an admin on /admin/templates rejects a pending public
+// template-version WITH a typed reason. The rejection must fire
+// POST /api/v1/template-versions/<id>/reject with { reason } in the body, and
+// the rejected row must disappear from the queue UI while the other pending
+// row stays visible.
+//
+// Why this test exists
+//   Without a working reject-with-reason flow, template authors (Dozenten) get
+//   no feedback about WHY their version was rejected — the rejection_reason is
+//   what the version overview shows them so they can submit a correction.
+//   Breaking this silently leaves authors stuck.
+//
+// ACTUAL reject interaction (verified against AdminTemplateApprovals.tsx)
+//   The reject flow is a TWO-STEP inline interaction, NOT an immediate POST and
+//   NOT a modal dialog:
+//     1. Each pending card starts with an "Ablehnen" button (+ "Schnell
+//        genehmigen"). Clicking "Ablehnen" only sets selectedVersionId — it
+//        reveals an inline <textarea> (placeholder "z. B. Heat-Template …") and
+//        swaps the action buttons to: "Abbrechen", "Ablehnen" (now the submit),
+//        "Genehmigen".
+//     2. You type the reason into the textarea, then click "Ablehnen" AGAIN —
+//        this second click calls handleReject(version.id) → rejectTemplateVersion.
+//   handleReject sends rejectionReason.trim() || undefined, i.e. the reason key
+//   is only present in the POST body when non-empty (github.ts:226 — body is
+//   JSON.stringify(reason ? { reason } : {})). Since we type a reason, the body
+//   is { reason: "<typed>" }. On success the version is filtered out of local
+//   state (no queue refetch), so the card vanishes.
+//
+// Fixture
+//   Reuses template-versions/queue-pending.json (two items: "WordPress Lab"
+//   tv-pending-1, "Nextcloud Workshop" tv-pending-2) so we can prove the
+//   correct row is rejected while the other stays.
+
+describe("Admin · rejects a pending template-version with a typed reason", () => {
+  const REASON = "Heat-Template referenziert undefinierten Parameter X";
+
+  beforeEach(() => {
+    // mockApi wires the default bootstrap GETs (templates/flavors/etc). The
+    // queue endpoint GET /api/v1/template-versions/queue is NOT covered by
+    // mockApi's glob (Cypress minimatch `*` doesn't cross `/`), so we register
+    // an explicit regex intercept that wins on the registration stack.
+    cy.mockApi();
+    cy.intercept("GET", /\/api\/v1\/template-versions\/queue(\?.*)?$/, {
+      fixture: "template-versions/queue-pending.json",
+    }).as("getQueuePending");
+
+    // Reject endpoint — match any version-id. Standard envelope response.
+    cy.intercept(
+      "POST",
+      "/api/v1/template-versions/*/reject",
+      {
+        statusCode: 200,
+        body: {
+          success: true,
+          message: "ok",
+          data: null,
+          errors: null,
+          timestamp: "2026-07-25T00:00:00Z",
+          request_id: "req-rej",
+        },
+      },
+    ).as("rejectVersion");
+  });
+
+  it("opens the reason textarea, submits, and the POST carries the reason while the row disappears", () => {
+    cy.loginAs("admin", "/admin/templates");
+
+    // The queue load is load-bearing for the Template-Freigaben card.
+    cy.wait("@getQueuePending");
+
+    // Both pending versions render as their own cards.
+    cy.contains("WordPress Lab").should("be.visible");
+    cy.contains("Nextcloud Workshop").should("be.visible");
+
+    // Scope to the WordPress row by walking from the template-name <h3> up to
+    // the surrounding per-version Card (data-slot="card"). Both rows share the
+    // same button text, so scoping avoids a race.
+    cy.contains("h3", "WordPress Lab")
+      .closest('[data-slot="card"]')
+      .within(() => {
+        // Step 1: reveal the rejection textarea (sets selectedVersionId).
+        cy.contains("button", "Ablehnen").click();
+
+        // Step 2: type the reason, then submit via the (now-)submit "Ablehnen".
+        cy.get("textarea").type(REASON);
+        cy.contains("button", "Ablehnen").click();
+      });
+
+    // The POST must hit /reject for the correct version id and carry the reason
+    // in the body. Narrow the URL beyond the glob so a regression hitting the
+    // wrong version (or /approve) is caught.
+    cy.wait("@rejectVersion").then((interception) => {
+      expect(interception.request.url).to.include(
+        "/api/v1/template-versions/tv-pending-1/reject",
+      );
+      expect(interception.request.body).to.deep.include({ reason: REASON });
+    });
+
+    // handleReject filters the version out of local state on success, so the
+    // WordPress Lab card must be gone.
+    cy.contains("WordPress Lab").should("not.exist");
+
+    // The other pending row must still be visible — proves we rejected the
+    // correct one rather than clearing the whole list.
+    cy.contains("Nextcloud Workshop").should("be.visible");
+  });
+});

--- a/cypress/e2e/admin/lecturer-delete-cascade-poll.cy.ts
+++ b/cypress/e2e/admin/lecturer-delete-cascade-poll.cy.ts
@@ -1,0 +1,118 @@
+/// <reference path="../../support/index.d.ts" />
+
+// lecturer-delete-cascade-poll
+// ────────────────────────────
+// P1 success-path test for the admin Lecturer cascade-delete flow.
+//
+// Why this test exists
+//   Deleting a lecturer (src/pages/LecturerManagement.tsx →
+//   LecturerDetailDialog.tsx → DeleteLecturerConfirmDialog.tsx) is the single
+//   most destructive admin action: it cascades over deployments (incl. Heat
+//   stacks), templates + versions and OpenStack-project rows before removing
+//   the user. The action is asynchronous — DELETE returns 202 + a Celery task
+//   id, and the UI only knows it succeeded once GET /lecturers/{id} answers
+//   404. Two safety mechanisms must hold:
+//     • the type-to-confirm gate (DeleteLecturerConfirmDialog): the destructive
+//       button stays disabled until the admin types the exact confirmation
+//       name (display_name || username || email || id — here "Eve Stark").
+//     • the post-delete poll (LecturerDetailDialog.startPolling): every 2000ms
+//       it re-fetches the detail; a 404 = success → success toast + list
+//       refetch (onDeleted) + modal close.
+//   If either regresses the admin either deletes without a real confirmation,
+//   or is left without feedback while a destructive job runs.
+//
+// Intercept layering / poll simulation
+//   Cypress evaluates intercepts in reverse-registration order (last wins).
+//   We first serve GET /api/v1/lecturers/lec-1 from the detail fixture so the
+//   dialog opens with a 200. After DELETE we RE-register the same GET to 404 —
+//   the next 2000ms poll then hits it and drives the success path. The success
+//   assertion uses an increased timeout to span the poll interval; that is an
+//   assertion timeout (allowed), not a fixed cy.wait(<number>).
+
+describe("Admin · Lecturer Cascade-Delete (Confirm + Poll bis 404)", () => {
+  beforeEach(() => {
+    cy.mockApi();
+
+    // Table listing (bare path, with/without query) — never matches /lec-1.
+    cy.intercept("GET", /\/api\/v1\/lecturers(\?.*)?$/, {
+      fixture: "lecturers/list.json",
+    }).as("getLecturers");
+
+    // Detail fetch for the opened dialog — 200 with the full resource fixture.
+    cy.intercept("GET", "/api/v1/lecturers/lec-1", {
+      fixture: "lecturers/detail-1.json",
+    }).as("getLecturerDetail");
+
+    // Async cascade-delete: 202 Accepted + task id (LecturerDeleteResponse).
+    cy.intercept("DELETE", "/api/v1/lecturers/lec-1", {
+      statusCode: 202,
+      body: {
+        success: true,
+        message: "enqueued",
+        data: {
+          task_id: "task-123",
+          user_id: "lec-1",
+          deployment_count: 1,
+          template_count: 2,
+        },
+        errors: null,
+        timestamp: "2026-07-25T00:00:00Z",
+        request_id: "req-del",
+      },
+    }).as("deleteLecturer");
+  });
+
+  it("bestätigt per Namen, sendet DELETE 202 und pollt bis 404 = Erfolg", () => {
+    cy.loginAs("admin", "/admin/lecturers");
+    cy.wait("@getLecturers");
+
+    // Open the detail dialog for Eve Stark (lec-1).
+    cy.contains("tr", "Eve Stark").click();
+    cy.wait("@getLecturerDetail")
+      .its("request.url")
+      .should("match", /\/api\/v1\/lecturers\/lec-1$/);
+
+    // Enter the confirm sub-dialog.
+    cy.contains("button", "Account löschen").click();
+    cy.contains("Lecturer-Account löschen?").should("be.visible");
+
+    // Type-to-confirm gate: button disabled until the exact name is typed.
+    // expected = display_name || username || email || id  → "Eve Stark".
+    cy.contains("button", "Endgültig löschen").should("be.disabled");
+    cy.get("#lecturer-confirm-name").type("Eve Stark");
+    cy.contains("button", "Endgültig löschen").should("not.be.disabled");
+    cy.contains("button", "Endgültig löschen").click();
+
+    // DELETE fired and returned 202 → confirm dialog closes, poll begins.
+    cy.wait("@deleteLecturer");
+
+    // Polling started: the persistent "Cascade-Delete läuft…" box renders in
+    // the still-open detail dialog. (The enqueue toast.info is transient and
+    // auto-dismisses, so we anchor on the persistent box instead.)
+    cy.contains("Cascade-Delete läuft").should("be.visible");
+
+    // Now the account is gone: re-register the detail GET to 404. Registered
+    // last, so the next 2000ms poll resolves against this and treats 404 as
+    // the success signal.
+    cy.intercept("GET", "/api/v1/lecturers/lec-1", {
+      statusCode: 404,
+      body: {
+        success: false,
+        message: "not found",
+        data: null,
+        errors: ["not found"],
+        timestamp: "2026-07-25T00:00:00Z",
+        request_id: "req-gone",
+      },
+    }).as("getLecturerGone");
+
+    // Success toast fires once the poll sees the 404. Increased assertion
+    // timeout spans the 2s poll interval (not a fixed wait).
+    cy.contains("Lecturer-Account wurde gelöscht", { timeout: 10000 }).should(
+      "be.visible",
+    );
+
+    // Modal closed on success (onDeleted → onOpenChange(false)).
+    cy.contains("Cascade-Delete läuft").should("not.exist");
+  });
+});

--- a/cypress/e2e/admin/lecturer-management-lists.cy.ts
+++ b/cypress/e2e/admin/lecturer-management-lists.cy.ts
@@ -1,0 +1,79 @@
+/// <reference path="../../support/index.d.ts" />
+
+// lecturer-management-lists
+// ─────────────────────────
+// P1 success-path test for the admin Lecturer-Verwaltung.
+//
+// Why this test exists
+//   /admin/lecturers (src/pages/LecturerManagement.tsx) is the admin's only
+//   window into "who owns resources" and the entry point for the cascade
+//   delete of an account. Two fetches carry the whole surface:
+//     • GET /api/v1/lecturers?skip=0&limit=50  → the table rows
+//     • GET /api/v1/lecturers/{id}             → the detail dialog, fired
+//       when a row is clicked (LecturerDetailDialog.tsx loadDetail()).
+//   If either fetch or its render pipeline regresses, the admin is blind:
+//   no user list, or an empty detail dialog before a destructive delete.
+//
+// Fixture notes
+//   - lecturers/list.json is the LecturersResponse envelope with four rows;
+//     the first is "Eve Stark" (id "lec-1"), the second "Jan Mueller".
+//     pagination.total_items = 4 (single page, so no pager controls).
+//   - lecturers/detail-1.json is the LecturerDetailResponse for "lec-1" with
+//     a couple of templates/deployments/openstack_projects so all three
+//     ResourceSection headers render with content.
+//
+// Intercept layering
+//   The list regex `/\/api\/v1\/lecturers(\?.*)?$/` matches the bare listing
+//   (with or without a query string) but NOT `/lecturers/lec-1` — that path
+//   has a trailing segment. The detail intercept `/api/v1/lecturers/*` only
+//   matches the sub-path. So the two never collide and each keeps its own
+//   alias. mockApi() registers no lecturers endpoint, so both are set here.
+
+describe("Admin · Lecturer-Verwaltung (Liste + Detail-Dialog)", () => {
+  beforeEach(() => {
+    cy.mockApi();
+    cy.intercept("GET", /\/api\/v1\/lecturers(\?.*)?$/, {
+      fixture: "lecturers/list.json",
+    }).as("getLecturers");
+    cy.intercept("GET", "/api/v1/lecturers/*", {
+      fixture: "lecturers/detail-1.json",
+    }).as("getLecturerDetail");
+  });
+
+  it("lädt die Tabelle und öffnet den Detail-Dialog per Zeilenklick", () => {
+    cy.loginAs("admin", "/admin/lecturers");
+
+    // Block until the list call resolves so the rows are painted.
+    cy.wait("@getLecturers");
+
+    // Page header + table headers prove the list surface rendered.
+    cy.contains("h1", "Dozenten-Verwaltung").should("be.visible");
+    cy.contains("th", "Name").should("be.visible");
+    cy.contains("th", "Email").should("be.visible");
+    cy.contains("th", "Letzter Login").should("be.visible");
+    cy.contains("th", "Templates").should("be.visible");
+    cy.contains("th", "Deployments").should("be.visible");
+    cy.contains("th", "OSPs").should("be.visible");
+
+    // Rows populated from the fixture.
+    cy.contains("Eve Stark").should("be.visible");
+    cy.contains("Jan Mueller").should("be.visible");
+
+    // Click the first lecturer's row → detail fetch fires for that id.
+    cy.contains("tr", "Eve Stark").click();
+    cy.wait("@getLecturerDetail")
+      .its("request.url")
+      .should("match", /\/api\/v1\/lecturers\/lec-1$/);
+
+    // Dialog opened with all three resource sections and the destructive
+    // action. The dialog title repeats the lecturer's display name.
+    cy.contains("h4", "Templates").should("be.visible");
+    cy.contains("h4", "Deployments").should("be.visible");
+    cy.contains("h4", "OpenStack-Projekte").should("be.visible");
+    cy.contains("Ubuntu Basis").should("be.visible");
+    cy.contains("eve-kurs-ss26").should("be.visible");
+    cy.contains("eve-project").should("be.visible");
+    cy.contains("button", "Account löschen").should("be.visible");
+    cy.contains("button", "Schließen").should("be.visible");
+  });
+});

--- a/cypress/e2e/auth/auth-admin-bypasses-setup-gate.cy.ts
+++ b/cypress/e2e/auth/auth-admin-bypasses-setup-gate.cy.ts
@@ -26,7 +26,13 @@
 //     1. /dashboard renders normally for the admin (URL + Dashboard heading).
 //     2. listOpenstackProjects() is NEVER called for the admin — proof that
 //        the non-lecturer branch of the effect actually ran.
-//     3. /admin is reachable and AdminMonitoring renders.
+//     3. An admin route is reachable and its page renders.
+//
+//   NOTE (staging update): the old single /admin route was split into
+//   /admin/projects, /admin/templates and /admin/lecturers (each wrapped in
+//   <ProtectedRoute requireAdmin>). Plain /admin no longer resolves to a page,
+//   so we now assert against /admin/projects (AdminProjectOverview, the admin
+//   landing page, <h1>Projektübersicht</h1>).
 
 describe("Auth · admin bypasses the OpenStack setup gate", () => {
   beforeEach(() => {
@@ -42,7 +48,7 @@ describe("Auth · admin bypasses the OpenStack setup gate", () => {
     }).as("getProjectsEmpty");
   });
 
-  it("renders /dashboard without calling listOpenstackProjects and lets /admin load", () => {
+  it("renders /dashboard without calling listOpenstackProjects and lets an admin route load", () => {
     cy.loginAs("admin", "/dashboard");
 
     // Final URL must be /dashboard — no redirect to /setup. The admin is past
@@ -65,18 +71,19 @@ describe("Auth · admin bypasses the OpenStack setup gate", () => {
     // length assertion would flip from 0 to 1.
     cy.get("@getProjectsEmpty.all").should("have.length", 0);
 
-    // Now verify /admin is reachable. We re-issue cy.loginAs so the Keycloak
-    // stub is re-installed via onBeforeLoad before the bundle re-evaluates on
-    // the fresh page load — a bare cy.visit would let the real keycloak-js
-    // module run and stall on its network init.
-    cy.loginAs("admin", "/admin");
-    cy.url().should("include", "/admin");
-    cy.location("pathname").should("eq", "/admin");
+    // Now verify an admin route is reachable. We re-issue cy.loginAs so the
+    // Keycloak stub is re-installed via onBeforeLoad before the bundle
+    // re-evaluates on the fresh page load — a bare cy.visit would let the real
+    // keycloak-js module run and stall on its network init.
+    cy.loginAs("admin", "/admin/projects");
+    cy.url().should("include", "/admin/projects");
+    cy.location("pathname").should("eq", "/admin/projects");
 
-    // AdminMonitoring.tsx renders <h1>Administration</h1> at the top of the
-    // page (line 395) — unconditional, present before any fetched data
-    // resolves. Good stable anchor.
-    cy.contains("h1", "Administration").should("be.visible");
+    // AdminProjectOverview.tsx renders <h1>Projektübersicht</h1> at the top of
+    // the page — unconditional, present before any fetched data resolves. Good
+    // stable anchor. (Also proves ProtectedRoute requireAdmin lets the admin
+    // through rather than bouncing to /dashboard.)
+    cy.contains("h1", "Projektübersicht").should("be.visible");
 
     // Still no project fetch — admin remains short-circuited across both
     // route visits.

--- a/cypress/e2e/auth/auth-non-admin-cannot-access-admin-route.cy.ts
+++ b/cypress/e2e/auth/auth-non-admin-cannot-access-admin-route.cy.ts
@@ -3,99 +3,69 @@
 // auth-non-admin-cannot-access-admin-route
 // ────────────────────────────────────────
 // P0 permission test: a lecturer (roles=["lecturer"], NOT "admin") navigating
-// directly to /admin must NOT see the AdminMonitoring page contents. The
-// "Administration" heading, the deployments/approval-queue UI, and any admin-
-// only data-fetches must all be absent for the non-admin user.
+// directly to an admin route (/admin/templates) must be redirected away and
+// must NOT see any admin page contents or trigger admin-only data fetches.
 //
-// ⚠️  CURRENTLY SKIPPED — see cypress/SECURITY-FINDINGS.md
+// History
+//   When this test was first written the app had NO route-level role gate:
+//   AdminMonitoring was wired at /admin for any authenticated user, so a
+//   lecturer who knew the URL got the full admin UI. That was recorded as a
+//   privilege-escalation finding in cypress/SECURITY-FINDINGS.md and the test
+//   was left as describe.skip.
 //
-//   Discovered while authoring this test: AdminMonitoring.tsx has no role
-//   gate, and App.tsx exposes /admin to any authenticated user. A lecturer
-//   who knows the URL gets the full admin UI (global deployments, template
-//   approval queue, approve/reject buttons). The Sidebar gate is the only
-//   defense and it's UI-only, not a security boundary.
+//   The staging rework FIXED it: admin pages now live at /admin/projects,
+//   /admin/templates and /admin/lecturers, each wrapped in
+//   <ProtectedRoute requireAdmin> (src/components/ProtectedRoute.tsx). For a
+//   non-admin, requireAdmin && !isAdmin → <Navigate to="/dashboard" replace>.
+//   The component never mounts, so its data effects never run. This test is
+//   now un-skipped and pins that guard.
 //
-//   The test below is the regression test you want once the gate is added
-//   to AdminMonitoring (a one-liner using useCurrentUser().isAdmin). It is
-//   left in the repo as `describe.skip` so:
-//     1. The expected behaviour is documented in executable form.
-//     2. A future contributor can drop the .skip the moment the prod fix
-//        lands and the assertions will pin the gate in place.
+//   We pin three invariants for a lecturer hitting /admin/templates:
+//     1. The browser is redirected to /dashboard (ProtectedRoute guard fired).
+//     2. The AdminTemplateApprovals "Template-Freigaben" H1 is NOT in the DOM.
+//     3. The admin-only approval-queue fetch (GET /template-versions/queue)
+//        NEVER fires — proof the page short-circuited before its effects ran.
 //
-//   See cypress/SECURITY-FINDINGS.md for the full write-up.
-//
-// Why this test exists
-//   App.tsx (line 159) wires <AdminMonitoring /> at /admin for ANY authenticated
-//   user — there is no route-level role check. The Sidebar.tsx admin link IS
-//   gated (only rendered when realm_access.roles contains "admin"), but a
-//   lecturer who knows the URL can still hit /admin directly.
-//
-//   The defense-in-depth invariant is therefore that AdminMonitoring itself
-//   must short-circuit for non-admins (via useCurrentUser().isAdmin) BEFORE it
-//   mounts the data effects that load the template-versions approval queue,
-//   the global deployments list, courses, keycloak groups, and flavors.
-//
-//   We pin three invariants:
-//     1. The admin "Administration" H1 is NOT in the DOM for a lecturer.
-//     2. The Sidebar admin nav link (<a href="/admin">) is NOT rendered for a
-//        lecturer — the Sidebar's own gate stays honest.
-//     3. The admin-only data fetch for the template-versions approval queue
-//        (`getTemplateVersions` alias) NEVER fires — proof that the page
-//        short-circuited before its useEffects ran.
-//
-//   If this test fails on assertion #1 or #3, AdminMonitoring is missing its
-//   role gate and lecturers can read (and act on) every deployment and
-//   template-approval in the system. That is a privilege-escalation finding
-//   that must NOT be silently weakened by relaxing the assertion.
+//   If any of these regress, the requireAdmin guard has been removed or
+//   weakened and lecturers regain access to the admin surface — a
+//   privilege-escalation regression.
 
-describe.skip("Auth · non-admin lecturer cannot access /admin (pending gate fix)", () => {
+describe("Auth · non-admin lecturer cannot access an admin route", () => {
   beforeEach(() => {
     // Defaults satisfy App.tsx's bootstrap: lecturer has a project (single.json),
-    // so `needsSetup === false` and the router actually mounts /admin instead
-    // of redirecting to /setup. Every other alias (getTemplateVersions,
-    // getDeployments, getCourses, …) gets its standard fixture so any rogue
-    // fetch is captured for the length assertions below.
+    // so needsSetup === false and the router evaluates the real route tree
+    // (including the ProtectedRoute guards) instead of the /setup gate.
     cy.mockApi();
+
+    // Dedicated alias for the admin-only approval-queue endpoint. If the guard
+    // regresses and AdminTemplateApprovals mounts, its loadQueue() effect would
+    // hit this — and the length-0 assertion below would flip.
+    cy.intercept("GET", /\/api\/v1\/template-versions\/queue(\?.*)?$/, {
+      fixture: "template-versions/queue-pending.json",
+    }).as("getQueuePending");
   });
 
-  it("does not render AdminMonitoring or its sidebar link for a lecturer", () => {
-    cy.loginAs("lecturer", "/admin");
+  it("redirects a lecturer off /admin/templates to /dashboard without mounting the admin page", () => {
+    cy.loginAs("lecturer", "/admin/templates");
 
-    // Wait for the bootstrap project-check to resolve. App.tsx fires
-    // listOpenstackProjects() for lecturers; once it returns single.json the
-    // needsSetup gate evaluates to false and the /admin route can mount (or
-    // — once the role gate is in place — short-circuit). Waiting here means
-    // any subsequent length-0 assertion is meaningful: the page has had its
-    // chance to mount and decide.
+    // Bootstrap project-check resolves first (lecturer path fetches projects).
     cy.wait("@getProjects");
 
-    // URL is still /admin — App.tsx does not redirect lecturers off the
-    // route (the gate, when added, should be component-internal: render
-    // nothing / a denied state instead of navigating away).
-    cy.location("pathname").should("eq", "/admin");
+    // Invariant #1 — ProtectedRoute requireAdmin bounces the lecturer to
+    // /dashboard. Cypress retries until the redirect settles, so no fixed wait.
+    cy.location("pathname").should("eq", "/dashboard");
 
-    // Invariant #1 — the AdminMonitoring "Administration" H1 (line 395 of
-    // AdminMonitoring.tsx) MUST NOT exist in the DOM. If a future gate
-    // renders a "Zugriff verweigert" message in its place, that's fine —
-    // this assertion only cares that the admin H1 itself is gone. Using
-    // .should("not.exist") rather than .should("not.be.visible") because
-    // the gate is expected to return null/empty for non-admins, not hide
-    // the element with CSS.
-    cy.contains(/^Administration$/).should("not.exist");
+    // The dashboard actually rendered (we landed somewhere real, not a blank).
+    cy.contains("h1", "Dashboard").should("be.visible");
 
-    // Invariant #2 — the Sidebar admin link is only rendered when
-    // `realm_access.roles` includes "admin" (Sidebar.tsx line 121). For a
-    // lecturer the <a href="/admin"> link must not be in the DOM at all.
-    // This is a stable selector — the icon-only link has no text but its
-    // href is fixed.
-    cy.get('a[href="/admin"]').should("not.exist");
+    // Invariant #2 — the AdminTemplateApprovals "Template-Freigaben" H1 must
+    // never be in the DOM for a lecturer. .should("not.exist") because the
+    // guard redirects rather than CSS-hiding.
+    cy.contains(/^Template-Freigaben$/).should("not.exist");
 
-    // Invariant #3 — load-bearing: the admin-only template-versions
-    // approval-queue fetch MUST NOT fire. AdminMonitoring's loadQueue()
-    // runs in a useEffect at mount; if the component short-circuits
-    // before mounting (because of the role gate), the effect never runs
-    // and the intercept is never matched. This is what proves the gate
-    // is real rather than a CSS hide.
-    cy.get("@getTemplateVersions.all").should("have.length", 0);
+    // Invariant #3 — load-bearing: the admin-only approval-queue fetch MUST
+    // NOT fire. If the guard let the component mount, loadQueue() would hit
+    // @getQueuePending. Zero calls proves the redirect happened before mount.
+    cy.get("@getQueuePending.all").should("have.length", 0);
   });
 });

--- a/cypress/e2e/courses/course-filters-admin-crud.cy.ts
+++ b/cypress/e2e/courses/course-filters-admin-crud.cy.ts
@@ -1,0 +1,149 @@
+/// <reference path="../../support/index.d.ts" />
+
+// course-filters-admin-crud
+// ─────────────────────────
+// On /courses an ADMIN gets the inline filter-management controls that a
+// lecturer never sees (gated by useCurrentUser().isAdmin in Courses.tsx):
+//   • a "Neuer Filter (z.B. SQL)" input + "Hinzufügen" button
+//     (aria-label "Filter hinzufügen")
+//   • per-chip pencil ("Filter <name> umbenennen") + X ("Filter <name> löschen")
+//
+// This spec drives the two mutations that keep the chip taxonomy in shape:
+//   CREATE  POST   /api/v1/course-filters      body {name} ONLY  → 201
+//   DELETE  DELETE /api/v1/course-filters/{id}                   → 200 data:null
+// After each mutation Courses.tsx calls loadFilters() again (another GET
+// /api/v1/course-filters), so we re-register the GET so the refetch reflects
+// the mutated set: "Docker" appears after add, "Web" is gone after delete.
+//
+// The displayed course titles come from the Keycloak admin API
+// (**/admin/realms/*/groups*), which we stub for determinism even though this
+// spec only cares about the chip-bar.
+
+// Two initial filters (SQL, Web) — mirrors course-filters/list.json.
+function filtersEnvelope(data: Array<{ id: string; name: string }>) {
+  return {
+    success: true,
+    message: "ok",
+    data: data.map((f) => ({
+      ...f,
+      created_at: "2026-06-01T00:00:00Z",
+      updated_at: "2026-06-01T00:00:00Z",
+    })),
+    pagination: {
+      page: 1,
+      page_size: 100,
+      total_items: data.length,
+      total_pages: 1,
+    },
+    errors: null,
+    timestamp: "2026-07-25T00:00:00Z",
+    request_id: "req-course-filters",
+  };
+}
+
+const INITIAL = [
+  { id: "cf-sql", name: "SQL" },
+  { id: "cf-web", name: "Web" },
+];
+
+describe("Courses · admin can add and delete course filters", () => {
+  beforeEach(() => {
+    cy.mockApi();
+
+    cy.intercept("GET", "/api/v1/courses*", {
+      fixture: "courses/list-with-deployments.json",
+    }).as("getCourses");
+
+    cy.intercept("GET", "**/admin/realms/*/groups*", {
+      fixture: "keycloak/groups-courses.json",
+    }).as("getKeycloakAdminGroups");
+
+    // Course filters GET. Re-registered mid-test to model the loadFilters()
+    // refetch after each mutation (later intercepts win in Cypress).
+    cy.intercept("GET", "/api/v1/course-filters*", {
+      statusCode: 200,
+      body: filtersEnvelope(INITIAL),
+    }).as("getCourseFilters");
+
+    // Create → 201 with the standard single-item envelope.
+    cy.intercept("POST", "/api/v1/course-filters", {
+      statusCode: 201,
+      body: {
+        success: true,
+        message: "ok",
+        data: {
+          id: "cf-new",
+          name: "Docker",
+          created_at: "2026-07-25T00:00:00Z",
+          updated_at: "2026-07-25T00:00:00Z",
+        },
+        errors: null,
+        timestamp: "2026-07-25T00:00:00Z",
+        request_id: "req-cf-add",
+      },
+    }).as("createFilter");
+
+    // Delete → 200 with data:null.
+    cy.intercept("DELETE", "/api/v1/course-filters/*", {
+      statusCode: 200,
+      body: {
+        success: true,
+        message: "ok",
+        data: null,
+        errors: null,
+        timestamp: "2026-07-25T00:00:00Z",
+        request_id: "req-cf-del",
+      },
+    }).as("deleteFilter");
+  });
+
+  it("adds a new filter (POST) and deletes an existing one (DELETE)", () => {
+    cy.loginAs("admin", "/courses");
+    cy.wait(["@getCourses", "@getCourseFilters"]);
+
+    // Admin-only controls are visible.
+    cy.get('input[placeholder="Neuer Filter (z.B. SQL)"]').should("be.visible");
+    cy.get('[aria-label="Filter hinzufügen"]').should("be.visible");
+    cy.get('[aria-label="Filter Web löschen"]').should("be.visible");
+    cy.get('[aria-label="Filter SQL umbenennen"]').should("exist");
+
+    // ── ADD ──────────────────────────────────────────────────────────────
+    // The loadFilters() refetch after create must show the new chip.
+    cy.intercept("GET", "/api/v1/course-filters*", {
+      statusCode: 200,
+      body: filtersEnvelope([...INITIAL, { id: "cf-new", name: "Docker" }]),
+    }).as("getCourseFiltersAfterAdd");
+
+    cy.get('input[placeholder="Neuer Filter (z.B. SQL)"]').type("Docker");
+    cy.get('[aria-label="Filter hinzufügen"]').click();
+
+    cy.wait("@createFilter").its("request.body").should("deep.equal", {
+      name: "Docker",
+    });
+
+    cy.wait("@getCourseFiltersAfterAdd");
+    cy.contains("button", "Docker").should("be.visible");
+
+    // ── DELETE ───────────────────────────────────────────────────────────
+    // The refetch after delete must drop the "Web" chip.
+    cy.intercept("GET", "/api/v1/course-filters*", {
+      statusCode: 200,
+      body: filtersEnvelope([
+        { id: "cf-sql", name: "SQL" },
+        { id: "cf-new", name: "Docker" },
+      ]),
+    }).as("getCourseFiltersAfterDelete");
+
+    cy.get('[aria-label="Filter Web löschen"]').click();
+
+    cy.wait("@deleteFilter")
+      .its("request.url")
+      .should("include", "/api/v1/course-filters/cf-web");
+
+    cy.wait("@getCourseFiltersAfterDelete");
+    cy.contains("button", "Web").should("not.exist");
+    // The surviving chips remain.
+    cy.contains("button", "SQL").should("be.visible");
+    cy.contains("button", "Docker").should("be.visible");
+  });
+});

--- a/cypress/e2e/courses/course-filters-toggle-chip.cy.ts
+++ b/cypress/e2e/courses/course-filters-toggle-chip.cy.ts
@@ -1,0 +1,66 @@
+/// <reference path="../../support/index.d.ts" />
+
+// course-filters-toggle-chip
+// ──────────────────────────
+// On /courses the admin-managed filter chips (loaded via listCourseFilters →
+// GET /api/v1/course-filters) drive a CLIENT-SIDE filter of the course list.
+// A lecturer toggles a chip and the list narrows: OR semantics across active
+// chips, case-INSENSITIVE substring match against a course's resolved keycloak
+// group name OR its course name (see Courses.tsx filteredCourses predicate).
+//
+// Only courses that HAVE deployments are ever shown, so the courses fixture
+// gives every course at least one deployment. Two courses ("WWI21 SQL",
+// "INF22 Web") are chosen so the "SQL" chip matches exactly one of them.
+//
+// NOTE: the displayed course title is the resolved keycloak GROUP name
+// (keycloakGroupName), fetched directly from Keycloak's admin API
+// (**/admin/realms/*/groups*), NOT the backend /api/v1/keycloak/groups proxy.
+// We intercept that group call so name resolution is deterministic; here the
+// group names equal the course names, so the substring match is unambiguous.
+
+describe("Courses · filter chips narrow the list client-side", () => {
+  beforeEach(() => {
+    cy.mockApi();
+
+    // Courses with deployments (so they render at all).
+    cy.intercept("GET", "/api/v1/courses*", {
+      fixture: "courses/list-with-deployments.json",
+    }).as("getCourses");
+
+    // Filter chips.
+    cy.intercept("GET", "/api/v1/course-filters*", {
+      fixture: "course-filters/list.json",
+    }).as("getCourseFilters");
+
+    // Keycloak group name resolution goes straight to the Keycloak admin API.
+    cy.intercept("GET", "**/admin/realms/*/groups*", {
+      fixture: "keycloak/groups-courses.json",
+    }).as("getKeycloakAdminGroups");
+  });
+
+  it("toggles a chip to narrow the list, then 'Alle anzeigen' resets it", () => {
+    cy.loginAs("lecturer", "/courses");
+    cy.wait(["@getCourses", "@getCourseFilters"]);
+
+    // Both courses (both have deployments) visible initially.
+    cy.contains(".text-slate-900", "WWI21 SQL").should("be.visible");
+    cy.contains(".text-slate-900", "INF22 Web").should("be.visible");
+
+    // Filter bar + both chips render.
+    cy.contains("Kurs-Filter:").should("be.visible");
+    cy.contains("button", "SQL").should("have.attr", "aria-pressed", "false");
+    cy.contains("button", "Web").should("exist");
+
+    // Activate the "SQL" chip → only the SQL-matching course remains.
+    cy.contains("button", "SQL").click();
+    cy.contains("button", "SQL").should("have.attr", "aria-pressed", "true");
+    cy.contains(".text-slate-900", "WWI21 SQL").should("be.visible");
+    cy.contains(".text-slate-900", "INF22 Web").should("not.exist");
+
+    // "Alle anzeigen" appears while a filter is active — clears the set.
+    cy.contains("button", "Alle anzeigen").should("be.visible").click();
+    cy.contains("button", "SQL").should("have.attr", "aria-pressed", "false");
+    cy.contains(".text-slate-900", "WWI21 SQL").should("be.visible");
+    cy.contains(".text-slate-900", "INF22 Web").should("be.visible");
+  });
+});

--- a/cypress/e2e/dashboard/dashboard-expiry-color-tiers.cy.ts
+++ b/cypress/e2e/dashboard/dashboard-expiry-color-tiers.cy.ts
@@ -1,0 +1,157 @@
+/// <reference path="../../support/index.d.ts" />
+
+// dashboard-expiry-color-tiers
+// ────────────────────────────
+// P2 state test for the #180 expiry indicator on the Dashboard. Each recent
+// deployment row runs its `expires_at` through getExpiryState() (see
+// src/utils/deployment.ts) and renders an icon ONLY for warning/critical/
+// expired — never for "ok" (far from expiry). This spec pins all four tiers.
+//
+// getExpiryState() thresholds, relative to Date.now():
+//   remaining <= 0        → "expired"   (AlertOctagon, red;   title "Wird in Kürze automatisch gelöscht")
+//   remaining <= 42 days  → "critical"  (AlertTriangle, red;  title "Läuft bald ab — am <date>")
+//   remaining <= 90 days  → "warning"   (AlertTriangle, amber;title "Läuft am <date> ab")
+//   otherwise             → "ok"        (no icon at all)
+//
+// Determinism
+//   The thresholds compare against Date.now(), so we do NOT freeze the clock
+//   (cy.clock can stall React/vite timers). Instead each row's expires_at is
+//   built relative to the real "now" at run time — +180d (ok), +60d (warning),
+//   +10d (critical), −5d (expired) — so the tiers stay correct on any day.
+//
+// Tier-distinguishing selectors
+//   - Row scope: cy.contains('p', <name>).parent() → the `.flex.items-center.gap-3`
+//     div that holds the name, status badge and (maybe) the expiry <span title>.
+//   - "ok" row: that scope has NO svg.text-amber-500 / svg.text-red-500.
+//   - warning: svg.text-amber-500 + title "Läuft am <date> ab".
+//   - critical: svg.text-red-500  + title "Läuft bald ab — am <date>".
+//   - expired: svg.text-red-500   + title "Wird in Kürze automatisch gelöscht".
+//   Warning vs critical share the AlertTriangle glyph but differ by colour
+//   class AND title copy — we assert both so a mix-up in either surfaces.
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// German date label exactly as Dashboard.tsx renders it via
+// toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' }).
+function deLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function deploymentRow(
+  id: string,
+  name: string,
+  expiresAt: string,
+) {
+  return {
+    id,
+    name,
+    template_version_id: `tv-${id}`,
+    course_id: `course-${id}`,
+    deployment_mode: "single",
+    status: "running",
+    openstack_stack_id: `stack-${id}`,
+    config_json: null,
+    deployment_parameters: null,
+    access_types_json: "[]",
+    expires_at: expiresAt,
+    expiry_warning_at: expiresAt,
+    created_at: "2026-06-20T10:00:00Z",
+    updated_at: "2026-06-26T10:00:00Z",
+    template_version: {
+      id: `tv-${id}`,
+      version: "1.0.0",
+      template_id: `tpl-${id}`,
+      template_name: `Template ${id}`,
+    },
+    course: {
+      id: `course-${id}`,
+      name: `Kurs ${id}`,
+      lecturer_id: "user-lec-1",
+    },
+    instances: [],
+  };
+}
+
+describe("Dashboard · expiry colour tiers", () => {
+  it("shows the correct expiry indicator per tier and none when far from expiry", () => {
+    const now = Date.now();
+    const okIso = new Date(now + 180 * DAY).toISOString();
+    const warnIso = new Date(now + 60 * DAY).toISOString();
+    const critIso = new Date(now + 10 * DAY).toISOString();
+    const expiredIso = new Date(now - 5 * DAY).toISOString();
+
+    const body = {
+      success: true,
+      message: "ok",
+      data: [
+        deploymentRow("ok01", "deploy-ok", okIso),
+        deploymentRow("warn02", "deploy-warning", warnIso),
+        deploymentRow("crit03", "deploy-critical", critIso),
+        deploymentRow("exp04", "deploy-expired", expiredIso),
+      ],
+      pagination: { page: 1, page_size: 20, total_items: 4, total_pages: 1 },
+      errors: null,
+      timestamp: new Date(now).toISOString(),
+      request_id: "req-expiry-tiers",
+    };
+
+    cy.mockApi();
+    // Override the deployments list AFTER mockApi so this registration wins on
+    // the intercept stack (later-registered intercepts take precedence).
+    cy.intercept("GET", /\/api\/v1\/deployments(\?[^/]*)?$/, { body }).as(
+      "getDeployments",
+    );
+
+    cy.loginAs("lecturer", "/dashboard");
+    cy.wait("@getDeployments");
+
+    // All four rows rendered (anchors the section + proves the list mapped).
+    cy.contains("Kürzliche Deployments").should("be.visible");
+    cy.contains("p", "deploy-ok").should("be.visible");
+    cy.contains("p", "deploy-warning").should("be.visible");
+    cy.contains("p", "deploy-critical").should("be.visible");
+    cy.contains("p", "deploy-expired").should("be.visible");
+
+    // ── ok (>90d out): NO expiry icon at all ────────────────────────────────
+    cy.contains("p", "deploy-ok")
+      .parent()
+      .within(() => {
+        cy.get("svg.text-amber-500").should("not.exist");
+        cy.get("svg.text-red-500").should("not.exist");
+        cy.get('[title*="Läuft"]').should("not.exist");
+      });
+
+    // ── warning (≤90d, >42d): amber AlertTriangle + "Läuft am <date> ab" ────
+    cy.contains("p", "deploy-warning")
+      .parent()
+      .within(() => {
+        cy.get("svg.text-amber-500").should("exist");
+        cy.get("svg.text-red-500").should("not.exist");
+        cy.get(`[title="Läuft am ${deLabel(warnIso)} ab"]`).should("exist");
+      });
+
+    // ── critical (≤42d, >0): red AlertTriangle + "Läuft bald ab — am <date>" ─
+    cy.contains("p", "deploy-critical")
+      .parent()
+      .within(() => {
+        cy.get("svg.text-red-500").should("exist");
+        cy.get("svg.text-amber-500").should("not.exist");
+        cy.get(`[title="Läuft bald ab — am ${deLabel(critIso)}"]`).should(
+          "exist",
+        );
+      });
+
+    // ── expired (past): red AlertOctagon + fixed deletion notice ────────────
+    cy.contains("p", "deploy-expired")
+      .parent()
+      .within(() => {
+        cy.get("svg.text-red-500").should("exist");
+        cy.get("svg.text-amber-500").should("not.exist");
+        cy.get('[title="Wird in Kürze automatisch gelöscht"]').should("exist");
+      });
+  });
+});

--- a/cypress/e2e/detail/detail-issue-207-ungrouped-members.cy.ts
+++ b/cypress/e2e/detail/detail-issue-207-ungrouped-members.cy.ts
@@ -83,9 +83,10 @@ describe("DeploymentDetails · issue #207 ungrouped course members", () => {
     cy.wait(["@getDeployment", "@getLogs"]);
     cy.contains("h1", "test-deploy-alpha").should("be.visible");
 
-    // Expand the card.
-    cy.contains("Gruppen & Mitglieder").should("be.visible");
-    cy.contains("button", "Anzeigen").click();
+    // Expand the card. The card sits far down the page inside a scroll
+    // container, so bring its title into view before asserting visibility.
+    cy.contains("Gruppen & Mitglieder").scrollIntoView().should("be.visible");
+    cy.contains("button", "Anzeigen").scrollIntoView().click();
     cy.wait(["@getCourseGroups", "@getCourseMembers"]);
 
     // The ungrouped section must appear with the new member.

--- a/cypress/e2e/detail/redeploy-deployment-config-override.cy.ts
+++ b/cypress/e2e/detail/redeploy-deployment-config-override.cy.ts
@@ -1,0 +1,142 @@
+/// <reference path="../../support/index.d.ts" />
+
+// redeploy-deployment-config-override
+// ─────────────────────────────────────
+// P1 success-path test for the Redeploy-with-config-override feature (#192).
+//
+// Flow under test
+//   The owner of a RUNNING deployment opens the "Aktionen" card, clicks
+//   "Neu deployen" (RefreshCw), which opens the RedeployDialog in
+//   kind:"deployment" mode. The dialog renders one editable field per key in
+//   deployment.deploymentParameters.parameters. The owner changes ONE text
+//   field, keeps the "Zugangsdaten beibehalten" checkbox (default checked),
+//   and submits. A POST /redeploy fires with ONLY the changed key in
+//   deployment_parameter_overrides plus preserve_credentials:true.
+//
+// deployment_parameters parsing (verified in DeploymentDetailsPage.tsx)
+//   backend `deployment_parameters` is a JSON *string*. buildDeploymentData
+//   JSON.parse()s it into `deploymentParameters`, and DeploymentDetails passes
+//   `deployment.deploymentParameters?.parameters` as `currentParameters` into
+//   RedeployDialog. So the fixture stores
+//     "deployment_parameters": "{\"parameters\":{\"hostname\":\"old-host\",\"replicas\":2}}"
+//   which yields dialog fields:
+//     - #redeploy-param-hostname  → text  (typeof "old-host" === "string")
+//     - #redeploy-param-replicas  → number (typeof 2 === "number")
+//   RedeployDialog.buildOverrides() diffs against the frozen initial values and
+//   emits ONLY changed keys — so changing just hostname yields
+//   { hostname: "new-host" } as the override.
+//
+// Why this test matters
+//   Redeploy-with-override is a new core feature. If the diff logic or the POST
+//   breaks, lecturers redeploy with the wrong parameters — this locks the wire
+//   contract (only changed keys + preserve_credentials, extra="forbid" body).
+
+describe("DeploymentDetails · redeploy deployment config override", () => {
+  beforeEach(() => {
+    // Default GETs (projects → single.json with active project id
+    // 1111…1111, quotas, empty deployments, courses, keycloak groups,
+    // flavors).
+    cy.mockApi();
+
+    // Detail fetch — RUNNING, owned by user-lec-1 (lecturer sub), and with a
+    // deployment_parameters JSON string so the dialog renders config fields.
+    cy.intercept("GET", "/api/v1/deployments/dep-alpha-0001*", (req) => {
+      if (req.url.includes("/logs")) {
+        return;
+      }
+      req.reply({ fixture: "deployments/detail-running-with-params.json" });
+    }).as("getDeployment");
+
+    cy.intercept("GET", "/api/v1/deployments/dep-alpha-0001/logs*", {
+      fixture: "deployments/logs-heat-ansible.json",
+    }).as("getLogs");
+
+    // SSE stream closed immediately — page settles into a stable post-load
+    // state before we interact.
+    cy.intercept("GET", "/api/v1/deployments/dep-alpha-0001/logs/stream*", {
+      statusCode: 200,
+      body: "",
+    }).as("getLogsStream");
+
+    cy.intercept("GET", "/api/v1/openstack/flavors*", {
+      statusCode: 200,
+      body: { flavors: [] },
+    }).as("getOpenstackFlavors");
+
+    cy.intercept("GET", "**/admin/realms/*/groups*", {
+      fixture: "keycloak/groups-direct.json",
+    }).as("getKeycloakAdminGroups");
+  });
+
+  it("changes one parameter and POSTs redeploy with only that override + preserve_credentials", () => {
+    // Redeploy endpoint — 202 with a RedeployDeploymentResponse envelope
+    // (redeployDeployment reads json.data). Registered before login so the
+    // click can't race it.
+    cy.intercept(
+      "POST",
+      "/api/v1/deployments/dep-alpha-0001/redeploy*",
+      {
+        statusCode: 202,
+        body: {
+          success: true,
+          message: "ok",
+          data: {
+            deployment_id: "dep-alpha-0001",
+            instance_count: 1,
+            status: "REDEPLOYING",
+            preserve_credentials: true,
+          },
+          errors: null,
+          timestamp: "2026-07-25T00:00:00Z",
+          request_id: "req-redeploy",
+        },
+      },
+    ).as("redeploy");
+
+    cy.loginAs("lecturer", "/deployment/dep-alpha-0001");
+    cy.wait("@getDeployment");
+    cy.contains("h1", "test-deploy-alpha").should("be.visible");
+
+    // Open the RedeployDialog via the Aktionen-card trigger. Scope to a
+    // button so we don't match the dialog submit (same label) once it opens.
+    cy.contains("button", "Neu deployen").scrollIntoView().click();
+
+    // Dialog rendered its config fields from deployment_parameters.parameters.
+    cy.get('[role="dialog"]').within(() => {
+      cy.contains("Deployment neu deployen").should("be.visible");
+
+      // Change only the hostname (text field). replicas (number) stays
+      // untouched, so it must NOT appear in the override.
+      cy.get("#redeploy-param-hostname")
+        .should("have.value", "old-host")
+        .clear()
+        .type("new-host");
+
+      // preserve_credentials checkbox is checked by default — leave it.
+      cy.get("#redeploy-preserve-credentials").should(
+        "have.attr",
+        "data-state",
+        "checked",
+      );
+
+      // Submit — scoped to the dialog so we hit the dialog CTA, not the card
+      // trigger.
+      cy.contains("button", "Neu deployen").click();
+    });
+
+    // Wire-contract assertions: only the changed key in the override,
+    // preserve_credentials true, and the active openstack project on the query.
+    cy.wait("@redeploy").then(({ request }) => {
+      expect(request.body.deployment_parameter_overrides).to.deep.equal({
+        hostname: "new-host",
+      });
+      expect(request.body.preserve_credentials).to.equal(true);
+      expect(request.url).to.include(
+        "openstack_project_id=11111111-1111-1111-1111-111111111111",
+      );
+    });
+
+    // Dialog closes after the successful 202 (onOpenChange(false)).
+    cy.get('[role="dialog"]').should("not.exist");
+  });
+});

--- a/cypress/e2e/student/student-dashboard-lists-deployments.cy.ts
+++ b/cypress/e2e/student/student-dashboard-lists-deployments.cy.ts
@@ -1,0 +1,78 @@
+/// <reference path="../../support/index.d.ts" />
+
+// student-dashboard-lists-deployments
+// ───────────────────────────────────
+// P0 success-path test: a PURE student (roles=["student"], no lecturer/admin)
+// landing on `/` must be routed to /student/dashboard and see their assigned
+// deployments, loaded from GET /api/v1/student/deployments.
+//
+// Why this test exists
+//   The student self-service area (StudentDashboard.tsx + the pure-student
+//   branch of App.tsx) is a distinct surface from the lecturer app. It has its
+//   own router registration (only /student/*, /config, and a catch-all
+//   redirect) and its own single API fetch (getStudentDeployments(), NO query
+//   params). If either the pure-student routing or that fetch/render regresses,
+//   students land on a blank page and never see the environments their lecturer
+//   assigned to them. This spec pins that core path end to end.
+//
+// Fixture notes
+//   - student/deployments-list.json wraps two StudentDeploymentDto rows in the
+//     EnvelopeArray shape ({ success, message, data, errors, timestamp,
+//     request_id }) that getStudentDeployments() unwraps via `resp?.data ?? []`
+//     in src/api/student.ts.
+//   - Statuses are varied (running / deploying) so both StatusBadge branches
+//     that a happy-path list exercises render: running → "Läuft",
+//     deploying → "Wird bereitgestellt".
+
+describe("StudentDashboard · lists assigned deployments", () => {
+  beforeEach(() => {
+    // mockApi wires harmless GET defaults. The pure-student bootstrap does NOT
+    // call any of them (no openstack-projects/quotas/deployments gate for
+    // students), but calling it is safe and keeps the spec consistent with the
+    // rest of the suite. The student endpoint is registered AFTER so — even if
+    // it overlapped — the later registration would win on Cypress's stack.
+    cy.mockApi();
+    cy.intercept("GET", "/api/v1/student/deployments", {
+      fixture: "student/deployments-list.json",
+    }).as("getStudentDeployments");
+  });
+
+  it("routes / → /student/dashboard and renders the deployment cards", () => {
+    // Pure student visits the app root.
+    cy.loginAs("student", "/");
+
+    // App.tsx pure-student branch registers `/` → Navigate /student/dashboard.
+    cy.location("pathname").should("eq", "/student/dashboard");
+
+    // Proves getStudentDeployments() actually fired (no arbitrary timer).
+    cy.wait("@getStudentDeployments");
+
+    // ── Page shell ──────────────────────────────────────────────────────────
+    // Unconditional header inside StudentDashboard — anchor that the page
+    // rendered at all.
+    cy.contains("h1", "Meine Deployments").should("be.visible");
+    cy.contains(
+      "Hier siehst du alle Umgebungen, die dir dein Dozent zugewiesen hat.",
+    ).should("be.visible");
+
+    // ── Deployment cards ────────────────────────────────────────────────────
+    // Each fixture row's name (CardTitle) must reach the DOM.
+    cy.contains("sql-lab-stu").should("be.visible");
+    cy.contains("web-workshop-stu").should("be.visible");
+
+    // StatusBadge mapping. running → "Läuft", deploying → "Wird bereitgestellt".
+    // Hitting both branches means a StatusBadge regression surfaces here.
+    cy.contains("Läuft").should("be.visible");
+    cy.contains("Wird bereitgestellt").should("be.visible");
+
+    // Sanity: the loading placeholder must be gone once data resolved.
+    cy.contains("Lade Deployments...").should("not.exist");
+
+    // ── Sidebar ─────────────────────────────────────────────────────────────
+    // A pure student sees exactly one nav item ("Meine Deployments") and the
+    // role label "Student". The <h1> also says "Meine Deployments", so scope
+    // the nav assertion to the <nav> element to prove the nav item exists.
+    cy.get("nav").contains("Meine Deployments").should("be.visible");
+    cy.contains("Student").should("be.visible");
+  });
+});

--- a/cypress/e2e/student/student-deployment-details-credentials.cy.ts
+++ b/cypress/e2e/student/student-deployment-details-credentials.cy.ts
@@ -1,0 +1,94 @@
+/// <reference path="../../support/index.d.ts" />
+
+// student-deployment-details-credentials
+// ──────────────────────────────────────
+// P1 success test: a student opening /student/deployment/:id sees the
+// deployment's VMs and their access credentials.
+//
+// Page flow (src/pages/StudentDeploymentDetails.tsx):
+//   1. StudentDeploymentDetailsPage reads :deploymentId from the route and
+//      renders StudentDeploymentDetails.
+//   2. There is NO single-item endpoint — the page re-fetches the whole list
+//      via GET /api/v1/student/deployments (getStudentDeployments) and filters
+//      client-side by id. So the list fixture MUST contain "stu-dep-1".
+//   3. Once the deployment is found, credentials auto-load via
+//      GET /api/v1/student/deployments/{id}/credentials
+//      (getStudentDeploymentCredentials). The response is an Envelope<T> —
+//      the api unwraps `.data` into DeploymentCredentialsResponse.
+//   4. Instances render through the shared CredentialInstanceCard with
+//      mode="student": a group Accordion (first group open by default) with a
+//      per-access row (Username / Password / URL). SSH accesses that carry an
+//      ssh_private_key additionally show an "SSH Private Key" block.
+//
+// Why this test exists
+//   Displaying the group credentials is the core value of the student area —
+//   without it, students cannot reach their assigned VMs. This pins the two
+//   chained fetches (list → filter → credentials) and the mode="student"
+//   rendering of the CredentialInstanceCard.
+
+describe("Student deployment details · VMs and credentials", () => {
+  beforeEach(() => {
+    // Lecturer/admin GET defaults (harmless for the student page). Registered
+    // first so the student-specific overrides below win on later intercepts.
+    cy.mockApi();
+
+    // Student list endpoint — MUST include the target id, because the detail
+    // page filters this list client-side (no single-item endpoint exists).
+    cy.intercept("GET", "/api/v1/student/deployments", {
+      fixture: "student/deployments-with-target.json",
+    }).as("getStudentDeployments");
+
+    // Credentials for the target deployment. Envelope response ({ data: … })
+    // matching DeploymentCredentialsResponse.
+    cy.intercept(
+      "GET",
+      "/api/v1/student/deployments/stu-dep-1/credentials",
+      { fixture: "student/credentials.json" },
+    ).as("getCredentials");
+  });
+
+  it("shows the deployment's VMs and its group access credentials", () => {
+    cy.loginAs("student", "/student/deployment/stu-dep-1");
+
+    // Both chained fetches fire: the list (filtered locally) and, once the
+    // deployment is found, its credentials.
+    cy.wait(["@getStudentDeployments", "@getCredentials"]);
+
+    // ── Header: deployment name from the filtered list entry ────────────────
+    cy.contains("h1", "Datenbank-Praktikum SS26").should("be.visible");
+
+    // ── The two sections render ─────────────────────────────────────────────
+    cy.contains("Virtuelle Maschinen").should("be.visible");
+    cy.contains("Deine Zugangsdaten").should("be.visible");
+
+    // ── VM list from the deployment fixture: name + IP badge / "keine IP" ────
+    cy.contains("pg-lab-primary").should("be.visible");
+    cy.contains("10.0.7.21").should("be.visible");
+    cy.contains("pg-lab-web").should("be.visible");
+    cy.contains("keine IP").should("be.visible");
+
+    // ── Credentials card (CredentialInstanceCard, mode="student") ────────────
+    // The group Accordion opens the first group by default → its access rows
+    // are visible without a click.
+    cy.contains("Gruppe A").should("be.visible");
+
+    // Both access types from the single instance render. The type label sits
+    // in a `truncate min-w-0` <h4>, so assert existence (be.visible fails on
+    // the clipped element) rather than visibility.
+    cy.contains("SSH").should("exist");
+    cy.contains("Web URL").should("exist");
+
+    // Username is rendered in clear text (only the password is masked).
+    cy.contains("student-gruppe-a").should("be.visible");
+
+    // SSH access carries a private key → the SSH Private Key block appears.
+    // The label lives in a clipped Accordion/flex container, so assert exist.
+    cy.contains("SSH Private Key").should("exist");
+
+    // ── Password stays masked until the Eye toggle is used ───────────────────
+    cy.contains("S3cure-Pw-42!").should("not.exist");
+
+    // ── Back button is present ───────────────────────────────────────────────
+    cy.contains("Zurück zur Übersicht").should("be.visible");
+  });
+});

--- a/cypress/e2e/student/student-role-routing-guard.cy.ts
+++ b/cypress/e2e/student/student-role-routing-guard.cy.ts
@@ -1,0 +1,63 @@
+/// <reference path="../../support/index.d.ts" />
+
+// student-role-routing-guard
+// ──────────────────────────
+// P0 permission test: a PURE student (roles=["student"], no lecturer/admin)
+// must NOT be able to reach lecturer/admin surfaces. App.tsx renders a
+// student-only <Routes> block (only /student/*, /config, and a catch-all
+// redirect). Any non-student path — /dashboard, /appstore, /courses, /admin/*
+// — therefore hits the catch-all `*` → Navigate /student/dashboard.
+//
+// Why this test exists
+//   The pure-student branch in App.tsx is the client-side permission gate that
+//   keeps students out of the lecturer/admin UI. If that branch regresses (e.g.
+//   the catch-all is dropped or a lecturer route leaks in), a student could
+//   mount a lecturer page and fire lecturer-only endpoints (which the backend
+//   answers with 403, but the UI would still attempt them and break). This spec
+//   pins the guard: direct navigation to non-student routes always redirects to
+//   /student/dashboard, and the lecturer/admin data endpoints never fire.
+//
+// Strategy
+//   - cy.mockApi() registers the lecturer/admin GET defaults (getDeployments,
+//     getTemplates, …). For a pure student NONE of these must be requested — we
+//     assert 0 calls on getDeployments and getTemplates to prove the student
+//     never mounted a lecturer page.
+//   - The student's own endpoint (GET /api/v1/student/deployments) is stubbed
+//     with the existing student/deployments-list.json fixture so the student
+//     dashboard renders its heading, proving the redirect landed on a real page
+//     and not a blank screen.
+
+describe("App routing · pure-student permission guard", () => {
+  beforeEach(() => {
+    // Lecturer/admin GET defaults. If the guard holds, none of these fire for
+    // a pure student. Registered first so the student override below wins.
+    cy.mockApi();
+    // The student's own list endpoint — stubbed so the dashboard renders.
+    cy.intercept("GET", "/api/v1/student/deployments", {
+      fixture: "student/deployments-list.json",
+    }).as("getStudentDeployments");
+  });
+
+  it("redirects a pure student from /dashboard and /appstore to /student/dashboard", () => {
+    // ── /dashboard (lecturer home) → catch-all → /student/dashboard ──────────
+    cy.loginAs("student", "/dashboard");
+    cy.location("pathname").should("eq", "/student/dashboard");
+
+    // The student endpoint firing + heading rendering proves we landed on the
+    // real student page (not a blank / lecturer shell).
+    cy.wait("@getStudentDeployments");
+    cy.contains("h1", "Meine Deployments").should("be.visible");
+
+    // ── /appstore (lecturer AppStore) → catch-all → /student/dashboard ───────
+    cy.loginAs("student", "/appstore");
+    cy.location("pathname").should("eq", "/student/dashboard");
+    cy.contains("h1", "Meine Deployments").should("be.visible");
+
+    // ── Lecturer/admin endpoints must NEVER have fired ───────────────────────
+    // If a lecturer route had mounted, DashboardPage would have called the
+    // deployments list and AppStorePage the templates list. Zero calls proves
+    // the student never reached those surfaces.
+    cy.get("@getDeployments.all").should("have.length", 0);
+    cy.get("@getTemplates.all").should("have.length", 0);
+  });
+});

--- a/cypress/e2e/visual/visual-capture.cy.ts
+++ b/cypress/e2e/visual/visual-capture.cy.ts
@@ -1,4 +1,4 @@
-/// <reference path="../support/index.d.ts" />
+/// <reference path="../../support/index.d.ts" />
 
 // Visual-regression capture spec
 // ──────────────────────────────
@@ -76,7 +76,10 @@ describe("visual capture", () => {
           cy.mockApi(page.overrides ?? {});
           mockStudentApis();
           cy.loginAs(page.role, page.url);
-          cy.contains(page.ready, { timeout: 15000 }).should("be.visible");
+          // Scope to the page <h1>: the ready strings (e.g. "Dashboard",
+          // "Kurse") also appear as sidebar nav links, which are hidden on
+          // mobile — matching them would fail the visibility assertion.
+          cy.contains("h1", page.ready, { timeout: 15000 }).should("be.visible");
           cy.wait(400);
           cy.screenshot(`${vp.folder}/${page.slug}`, {
             capture: "viewport",
@@ -90,9 +93,12 @@ describe("visual capture", () => {
           cy.mockApi();
           mockStudentApis();
           cy.loginAs("lecturer", "/dashboard");
-          cy.contains("Dashboard").should("be.visible");
+          cy.contains("h1", "Dashboard").should("be.visible");
           cy.get('[aria-label="Menü öffnen"]').click();
-          cy.contains("Kurse").should("be.visible");
+          // Two sidebars live in the DOM: the desktop one (hidden md:flex) and
+          // the drawer's. Scope to the open Sheet dialog so we match the
+          // drawer's visible "Kurse" link, not the hidden desktop nav.
+          cy.get('[role="dialog"]').contains("Kurse").should("be.visible");
           cy.wait(500);
           cy.screenshot("mobile/09-drawer-open", {
             capture: "viewport",

--- a/cypress/e2e/visual/visual-capture.cy.ts
+++ b/cypress/e2e/visual/visual-capture.cy.ts
@@ -11,7 +11,7 @@ type PageSpec = {
   url: string;
   role: "lecturer" | "admin" | "student";
   ready: string;
-  overrides?: Record<string, { fixture?: string; body?: any; statusCode?: number }>;
+  overrides?: Record<string, { fixture: string }>;
 };
 
 const PAGES: PageSpec[] = [

--- a/cypress/e2e/wizard/wizard-36-months-runtime.cy.ts
+++ b/cypress/e2e/wizard/wizard-36-months-runtime.cy.ts
@@ -1,0 +1,136 @@
+/// <reference path="../../support/index.d.ts" />
+
+// wizard-36-months-runtime
+// ─────────────────────────
+// P2 edge-case test for the DeploymentWizard's runtime ("Laufzeit") select.
+//
+// Why this test exists
+//   Feat #179 added a 36-month ("3 Jahre") runtime option to the wizard.
+//   The runtime lives in a Radix Select on step 0 ("Template & Zugriff",
+//   DeploymentWizard.tsx ~L1233-1253), defaulting to "4" (4 Monate). On
+//   submit, handleDeploy() serializes `runtime_months: parseInt(runtime, 10)`
+//   into the POST /api/v1/deployments payload (~L901). Because 36 is a
+//   non-default value, a regression that dropped the option or reset the
+//   state would silently ship deployments with the wrong (default) runtime.
+//   This test drives the full wizard exactly like
+//   wizard-full-flow-to-deploy-success, but selects "3 Jahre" before
+//   submitting and pins runtime_months: 36 in the POST body.
+//
+// What's asserted
+//   - The runtime Select on step 0 offers and accepts the "3 Jahre" option.
+//   - POST /api/v1/deployments carries runtime_months === 36.
+//   - Navigation still reaches /deployment/<new id> (flow stays intact).
+
+describe("DeploymentWizard · 36-month runtime (3 Jahre)", () => {
+  beforeEach(() => {
+    cy.mockApi();
+
+    cy.intercept("GET", "/api/v1/templates/tpl-wp-0001", {
+      fixture: "templates/detail-wordpress.json",
+    }).as("getTemplateDetail");
+    cy.intercept(
+      "GET",
+      "/api/v1/template-versions/template/tpl-wp-0001*",
+      { fixture: "template-versions/list-wordpress.json" },
+    ).as("getTemplateVersionsForTemplate");
+    cy.intercept(
+      "GET",
+      "/api/v1/template-versions/tv-wp-1*",
+      { fixture: "template-versions/version-detail-wordpress.json" },
+    ).as("getTemplateVersionDetail");
+
+    cy.intercept("GET", "**/admin/realms/*/groups*", {
+      fixture: "keycloak/groups-direct.json",
+    }).as("getKeycloakGroupsDirect");
+    cy.intercept("GET", "**/admin/realms/*/groups/*/members*", {
+      body: [
+        {
+          id: "stu-1",
+          username: "stud1",
+          email: "stud1@dhbw.de",
+          firstName: "Stu",
+          lastName: "Dent",
+          enabled: true,
+          emailVerified: true,
+        },
+      ],
+    }).as("getKeycloakGroupMembers");
+
+    cy.intercept(
+      "POST",
+      "/api/v1/deployments",
+      { statusCode: 201, fixture: "deployments/created.json" },
+    ).as("createDeployment");
+
+    cy.intercept(
+      "GET",
+      "/api/v1/deployments/dep-new-001*",
+      { fixture: "deployments/detail-deploying.json" },
+    ).as("getNewDeployment");
+    cy.intercept(
+      "GET",
+      "/api/v1/deployments/*/logs*",
+      { fixture: "deployments/logs-empty.json" },
+    ).as("getNewDeploymentLogs");
+  });
+
+  it("selects the 3-Jahre runtime and POSTs runtime_months: 36", () => {
+    cy.loginAs("lecturer", "/deploy/tpl-wp-0001");
+
+    cy.wait("@getTemplateDetail");
+    cy.wait("@getTemplateVersionsForTemplate");
+    cy.contains("Template & Zugriff").should("be.visible");
+
+    // ── Fill step 0 ────────────────────────────────────────────────────
+    cy.get("#deployment-name").clear().type("test-deploy-36-months");
+    cy.get("#deployment-name").should("have.value", "test-deploy-36-months");
+
+    // ── Select the 36-month runtime ─────────────────────────────────────
+    // The runtime Select lives on step 0, in the first card next to the
+    // deployment name (DeploymentWizard.tsx ~L1233-1253), labeled
+    // "Laufzeit" and defaulting to "4 Monate". Scope the trigger by that
+    // label so we don't grab the version / course selects, then pick the
+    // "3 Jahre" option from the portal.
+    cy.contains("label", /Laufzeit/i)
+      .parent()
+      .find('[role="combobox"]')
+      .click();
+    cy.get('[role="option"]').contains("3 Jahre").click();
+    cy.contains("label", /Laufzeit/i)
+      .parent()
+      .find('[role="combobox"]')
+      .should("contain.text", "3 Jahre");
+
+    // ── Pick the course group + distribute the student ──────────────────
+    cy.wait("@getKeycloakGroupsDirect");
+    cy.contains("label", /Kurs auswählen/i)
+      .parent()
+      .find('[role="combobox"]')
+      .click();
+    cy.get('[role="option"]').contains("Test-Gruppe").click();
+    cy.wait("@getKeycloakGroupMembers");
+
+    cy.contains("button", /Auto-Verteilen/i).click();
+
+    // ── Shortcut to review + submit ─────────────────────────────────────
+    cy.contains("button", "Direkt zur Übersicht")
+      .should("not.be.disabled")
+      .click();
+    cy.contains("Deployment-Zusammenfassung").should("be.visible");
+
+    cy.contains("button", "Anwendung deployen").click();
+
+    // ── The key assertion: runtime_months made it into the payload ──────
+    cy.wait("@createDeployment").then((intercept) => {
+      expect(intercept.request.body).to.have.property("runtime_months", 36);
+      expect(intercept.request.body).to.have.property(
+        "name",
+        "test-deploy-36-months",
+      );
+    });
+
+    // ── Flow stays intact → navigates to the new deployment ─────────────
+    cy.url().should("include", "/deployment/dep-new-001");
+    cy.wait("@getNewDeployment");
+  });
+});

--- a/cypress/fixtures/course-filters/list.json
+++ b/cypress/fixtures/course-filters/list.json
@@ -1,0 +1,27 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    {
+      "id": "cf-sql",
+      "name": "SQL",
+      "created_at": "2026-06-01T00:00:00Z",
+      "updated_at": "2026-06-01T00:00:00Z"
+    },
+    {
+      "id": "cf-web",
+      "name": "Web",
+      "created_at": "2026-06-01T00:00:00Z",
+      "updated_at": "2026-06-01T00:00:00Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 100,
+    "total_items": 2,
+    "total_pages": 1
+  },
+  "errors": null,
+  "timestamp": "2026-06-27T00:00:00Z",
+  "request_id": "req-course-filters"
+}

--- a/cypress/fixtures/courses/list-with-deployments.json
+++ b/cypress/fixtures/courses/list-with-deployments.json
@@ -1,0 +1,49 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    {
+      "id": "course-sql-1",
+      "name": "WWI21 SQL",
+      "keycloak_course_id": "grp-sql",
+      "deployments": [
+        {
+          "id": "dep-sql-1",
+          "name": "SQL Lab",
+          "template_version_id": "tv-sql-1",
+          "deployment_mode": "single",
+          "status": "running",
+          "created_at": "2026-06-20T10:00:00Z"
+        }
+      ],
+      "created_at": "2026-06-01T00:00:00Z",
+      "updated_at": "2026-06-20T00:00:00Z"
+    },
+    {
+      "id": "course-web-1",
+      "name": "INF22 Web",
+      "keycloak_course_id": "grp-web",
+      "deployments": [
+        {
+          "id": "dep-web-1",
+          "name": "Web Lab",
+          "template_version_id": "tv-web-1",
+          "deployment_mode": "single",
+          "status": "running",
+          "created_at": "2026-06-21T10:00:00Z"
+        }
+      ],
+      "created_at": "2026-06-01T00:00:00Z",
+      "updated_at": "2026-06-21T00:00:00Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 100,
+    "total_items": 2,
+    "total_pages": 1
+  },
+  "errors": null,
+  "timestamp": "2026-06-27T00:00:00Z",
+  "request_id": "req-courses-with-deployments"
+}

--- a/cypress/fixtures/deployments/admin-list.json
+++ b/cypress/fixtures/deployments/admin-list.json
@@ -1,0 +1,102 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": [
+    {
+      "id": "dep-admin-0001",
+      "name": "admin-deploy-alpha",
+      "template_version_id": "tv-alpha-1",
+      "course_id": "course-alpha",
+      "deployment_mode": "single",
+      "status": "running",
+      "openstack_stack_id": "stack-alpha",
+      "config_json": null,
+      "deployment_parameters": "{\"teacher\":{\"id\":\"user-lec-1\",\"first_name\":\"Petra\",\"last_name\":\"Professorin\",\"email\":\"petra.prof@dhbw.de\"}}",
+      "access_types_json": "[]",
+      "owner_id": "user-lec-1",
+      "expires_at": "2027-01-01T00:00:00Z",
+      "expiry_warning_at": "2026-12-15T00:00:00Z",
+      "created_at": "2026-06-20T10:00:00Z",
+      "updated_at": "2026-06-26T10:00:00Z",
+      "template_version": {
+        "id": "tv-alpha-1",
+        "version": "1.0.0",
+        "template_id": "tpl-alpha",
+        "template_name": "Alpha Template"
+      },
+      "course": {
+        "id": "course-alpha",
+        "name": "Kurs Alpha",
+        "lecturer_id": "user-lec-1"
+      },
+      "instances": []
+    },
+    {
+      "id": "dep-admin-0002",
+      "name": "admin-deploy-beta",
+      "template_version_id": "tv-beta-1",
+      "course_id": "course-beta",
+      "deployment_mode": "single",
+      "status": "running",
+      "openstack_stack_id": "stack-beta",
+      "config_json": null,
+      "deployment_parameters": "{\"teacher\":{\"id\":\"user-lec-2\",\"first_name\":\"Dieter\",\"last_name\":\"Dozent\",\"email\":\"dieter.dozent@dhbw.de\"}}",
+      "access_types_json": "[]",
+      "owner_id": "user-lec-2",
+      "expires_at": "2027-01-01T00:00:00Z",
+      "expiry_warning_at": "2026-12-15T00:00:00Z",
+      "created_at": "2026-06-25T10:00:00Z",
+      "updated_at": "2026-06-25T12:00:00Z",
+      "template_version": {
+        "id": "tv-beta-1",
+        "version": "0.9.0",
+        "template_id": "tpl-beta",
+        "template_name": "Beta Template"
+      },
+      "course": {
+        "id": "course-beta",
+        "name": "Kurs Beta",
+        "lecturer_id": "user-lec-2"
+      },
+      "instances": []
+    },
+    {
+      "id": "dep-admin-0003",
+      "name": "admin-deploy-gamma",
+      "template_version_id": "tv-gamma-1",
+      "course_id": "course-gamma",
+      "deployment_mode": "single",
+      "status": "failed",
+      "openstack_stack_id": null,
+      "config_json": null,
+      "deployment_parameters": "{\"teacher\":{\"id\":\"user-lec-1\",\"first_name\":\"Petra\",\"last_name\":\"Professorin\",\"email\":\"petra.prof@dhbw.de\"}}",
+      "access_types_json": "[]",
+      "owner_id": "user-lec-1",
+      "expires_at": "2027-01-01T00:00:00Z",
+      "expiry_warning_at": "2026-12-15T00:00:00Z",
+      "created_at": "2026-06-10T10:00:00Z",
+      "updated_at": "2026-06-11T10:00:00Z",
+      "template_version": {
+        "id": "tv-gamma-1",
+        "version": "0.1.0",
+        "template_id": "tpl-gamma",
+        "template_name": "Gamma Template"
+      },
+      "course": {
+        "id": "course-gamma",
+        "name": "Kurs Gamma",
+        "lecturer_id": "user-lec-1"
+      },
+      "instances": []
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "page_size": 20,
+    "total_items": 3,
+    "total_pages": 1
+  },
+  "errors": null,
+  "timestamp": "2026-06-27T00:00:00Z",
+  "request_id": "req-admin-list-deployments"
+}

--- a/cypress/fixtures/deployments/detail-running-with-params.json
+++ b/cypress/fixtures/deployments/detail-running-with-params.json
@@ -1,0 +1,36 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "id": "dep-alpha-0001",
+    "owner_id": "user-lec-1",
+    "name": "test-deploy-alpha",
+    "template_version_id": "tv-alpha-1",
+    "course_id": "course-alpha",
+    "deployment_mode": "single",
+    "status": "RUNNING",
+    "openstack_stack_id": "stack-alpha",
+    "config_json": null,
+    "deployment_parameters": "{\"parameters\":{\"hostname\":\"old-host\",\"replicas\":2}}",
+    "access_types_json": "[]",
+    "expires_at": "2027-01-01T00:00:00Z",
+    "expiry_warning_at": "2026-12-15T00:00:00Z",
+    "created_at": "2026-06-20T10:00:00Z",
+    "updated_at": "2026-06-26T10:00:00Z",
+    "template_version": {
+      "id": "tv-alpha-1",
+      "version": "1.0.0",
+      "template_id": "tpl-alpha",
+      "template_name": "Alpha Template"
+    },
+    "course": {
+      "id": "course-alpha",
+      "name": "Kurs Alpha",
+      "lecturer_id": "user-lec-1"
+    },
+    "instances": []
+  },
+  "errors": null,
+  "timestamp": "2026-06-27T00:00:00Z",
+  "request_id": "req-detail-running-params"
+}

--- a/cypress/fixtures/deployments/detail-running.json
+++ b/cypress/fixtures/deployments/detail-running.json
@@ -3,6 +3,7 @@
   "message": "ok",
   "data": {
     "id": "dep-alpha-0001",
+    "owner_id": "user-lec-1",
     "name": "test-deploy-alpha",
     "template_version_id": "tv-alpha-1",
     "course_id": "course-alpha",

--- a/cypress/fixtures/keycloak/groups-courses.json
+++ b/cypress/fixtures/keycloak/groups-courses.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "grp-sql",
+    "name": "WWI21 SQL",
+    "path": "/WWI21 SQL",
+    "subGroups": []
+  },
+  {
+    "id": "grp-web",
+    "name": "INF22 Web",
+    "path": "/INF22 Web",
+    "subGroups": []
+  }
+]

--- a/cypress/fixtures/lecturers/detail-1.json
+++ b/cypress/fixtures/lecturers/detail-1.json
@@ -1,0 +1,28 @@
+{
+  "success": true,
+  "message": "ok",
+  "data": {
+    "id": "lec-1",
+    "external_id": "kc-1",
+    "display_name": "Eve Stark",
+    "email": "eve@dhbw.de",
+    "username": "lecturer",
+    "last_login_at": "2026-07-01T09:00:00Z",
+    "template_count": 2,
+    "deployment_count": 1,
+    "openstack_project_count": 1,
+    "templates": [
+      { "id": "tpl-a1", "name": "Ubuntu Basis", "visibility": "public", "version_count": 2 },
+      { "id": "tpl-a2", "name": "Kali Pentest", "visibility": "private", "version_count": 1 }
+    ],
+    "deployments": [
+      { "id": "dep-a1", "name": "eve-kurs-ss26", "status": "running", "course_id": "c-1", "expires_at": "2026-11-01T00:00:00Z", "created_at": "2026-06-25T10:00:00Z" }
+    ],
+    "openstack_projects": [
+      { "id": "osp-a1", "openstack_project_name": "eve-project", "region_name": "RegionOne" }
+    ]
+  },
+  "errors": null,
+  "timestamp": "2026-07-10T00:00:00Z",
+  "request_id": "req-lec-detail-1"
+}

--- a/cypress/fixtures/student/credentials.json
+++ b/cypress/fixtures/student/credentials.json
@@ -1,0 +1,41 @@
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "deployment_id": "stu-dep-1",
+    "instances": [
+      {
+        "instance_id": "inst-stu-1a",
+        "vm_name": "pg-lab-primary",
+        "openstack_stack_id": "stack-abc-123",
+        "accesses": [
+          {
+            "id": "acc-ssh-1",
+            "access_type": "ssh",
+            "username": "student-gruppe-a",
+            "password": "S3cure-Pw-42!",
+            "ssh_private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gt\nZWQyNTUxOQAAACDFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfakeFAKEfg\n-----END OPENSSH PRIVATE KEY-----\n",
+            "connection_url": "ssh student-gruppe-a@10.0.7.21",
+            "port": 22,
+            "group_id": "grp-a-001",
+            "group_name": "Gruppe A"
+          },
+          {
+            "id": "acc-web-1",
+            "access_type": "web_url",
+            "username": "webadmin",
+            "password": "Web-Pass-99",
+            "ssh_private_key": null,
+            "connection_url": "https://pg-lab-primary.example.edu",
+            "port": 443,
+            "group_id": "grp-a-001",
+            "group_name": "Gruppe A"
+          }
+        ]
+      }
+    ]
+  },
+  "errors": null,
+  "timestamp": "2026-07-25T12:00:00Z",
+  "request_id": "req-stu-creds-1"
+}

--- a/cypress/fixtures/student/deployments-list.json
+++ b/cypress/fixtures/student/deployments-list.json
@@ -1,0 +1,50 @@
+{
+  "success": true,
+  "message": "OK",
+  "data": [
+    {
+      "id": "dep-stu-001",
+      "name": "sql-lab-stu",
+      "status": "running",
+      "template": {
+        "name": "SQL Lab",
+        "version": "1.2.0"
+      },
+      "instances": [
+        {
+          "id": "inst-stu-001a",
+          "vm_name": "sql-lab-stu-db",
+          "ip_address": "10.0.5.11"
+        },
+        {
+          "id": "inst-stu-001b",
+          "vm_name": "sql-lab-stu-app",
+          "ip_address": "10.0.5.12"
+        }
+      ],
+      "created_at": "2026-07-10T09:00:00Z",
+      "expires_at": "2026-08-10T09:00:00Z"
+    },
+    {
+      "id": "dep-stu-002",
+      "name": "web-workshop-stu",
+      "status": "deploying",
+      "template": {
+        "name": "Web Workshop",
+        "version": "0.9.1"
+      },
+      "instances": [
+        {
+          "id": "inst-stu-002a",
+          "vm_name": "web-workshop-stu-web",
+          "ip_address": null
+        }
+      ],
+      "created_at": "2026-07-20T14:30:00Z",
+      "expires_at": "2026-08-20T14:30:00Z"
+    }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-25T12:00:00Z",
+  "request_id": "req-stu-list-1"
+}

--- a/cypress/fixtures/student/deployments-with-target.json
+++ b/cypress/fixtures/student/deployments-with-target.json
@@ -1,0 +1,50 @@
+{
+  "success": true,
+  "message": "OK",
+  "data": [
+    {
+      "id": "stu-dep-1",
+      "name": "Datenbank-Praktikum SS26",
+      "status": "running",
+      "template": {
+        "name": "PostgreSQL Lab",
+        "version": "2.1.0"
+      },
+      "instances": [
+        {
+          "id": "inst-stu-1a",
+          "vm_name": "pg-lab-primary",
+          "ip_address": "10.0.7.21"
+        },
+        {
+          "id": "inst-stu-1b",
+          "vm_name": "pg-lab-web",
+          "ip_address": null
+        }
+      ],
+      "created_at": "2026-07-12T08:00:00Z",
+      "expires_at": "2026-09-12T08:00:00Z"
+    },
+    {
+      "id": "stu-dep-2",
+      "name": "Netzwerk-Workshop",
+      "status": "deploying",
+      "template": {
+        "name": "Network Workshop",
+        "version": "0.5.0"
+      },
+      "instances": [
+        {
+          "id": "inst-stu-2a",
+          "vm_name": "net-workshop-router",
+          "ip_address": null
+        }
+      ],
+      "created_at": "2026-07-22T10:15:00Z",
+      "expires_at": "2026-08-22T10:15:00Z"
+    }
+  ],
+  "errors": null,
+  "timestamp": "2026-07-25T12:00:00Z",
+  "request_id": "req-stu-list-target"
+}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -17,6 +17,7 @@
 type Role =
   | "lecturer"
   | "admin"
+  | "student"
   | "unauthenticated"
   | "expiring"
   | "init-error";

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -8,6 +8,7 @@ export {};
 type Role =
   | "lecturer"
   | "admin"
+  | "student"
   | "unauthenticated"
   | "expiring"
   | "init-error";


### PR DESCRIPTION
## Was & Warum

Bringt die Cypress-Integrationstest-Suite auf den aktuellen `staging`-Stand. Seit der ursprünglichen Suite (`d1af1a7`) sind ~7.800 `src/`-Zeilen dazugekommen (Student-Self-Service, Admin-Rework, Redeploy, Kurs-Filter u.a.) — mehrere Tests waren dadurch veraltet und große neue Bereiche ungetestet.

## Ergebnis

- **46/46 Tests grün** über **30 Specs**
- **TypeScript** (`tsc --noEmit -p cypress/tsconfig.json`): 0 Fehler
- **ESLint**: 0 Fehler (40 pre-existing Warnings)
- **Build** (`vite build`): success
- **0 Produktivcode-Änderungen**, **0 neue `data-testid`**

## Reparaturen (6)

| Test | Ursache | Fix |
| --- | --- | --- |
| `auth-admin-bypasses-setup-gate` | `/admin` in `/admin/projects\|templates\|lecturers` gesplittet | Ziel → `/admin/projects` |
| `admin-approve-template-version` | Queue nach `/admin/templates` verschoben | Route angepasst |
| `detail-delete-confirmation-flow` | Owner-Only-Gate (#126) deaktivierte Button | `owner_id` in Fixture |
| `auth-non-admin-cannot-access-admin-route` | war `skip` (Befund); via `ProtectedRoute` behoben | neu geschrieben (Redirect-Assertion) + reaktiviert |
| `detail-issue-207-ungrouped-members` | Card-Titel off-screen | `scrollIntoView()` |
| `visual-capture` | Mobile: Match auf versteckten Sidebar-Link; falscher Reference-Pfad | `cy.contains("h1", …)` + Pfad-Fix |

## Neue Feature-Tests (11)

**Student-Self-Service:** `student-dashboard-lists-deployments` (P0), `student-role-routing-guard` (P0), `student-deployment-details-credentials` (P1)
**Admin:** `lecturer-management-lists` (P1), `lecturer-delete-cascade-poll` (P1), `admin-project-overview-renders` (P1), `admin-reject-template-with-reason` (P1)
**Deployment/Courses:** `redeploy-deployment-config-override` (P1), `course-filters-toggle-chip` (P1), `course-filters-admin-crud` (P1)
**Wizard/Dashboard:** `wizard-36-months-runtime` (P2), `dashboard-expiry-color-tiers` (P2)

## Sicherheits-Verbesserung bestätigt

Der zuvor in `cypress/SECURITY-FINDINGS.md` dokumentierte Privilege-Escalation-Befund (`/admin` ohne Frontend-Rollen-Gate) ist auf `staging` **behoben** — `ProtectedRoute requireAdmin` leitet Nicht-Admins auf `/dashboard` um. Der geskippte Test ist reaktiviert und sichert den Guard; das Finding steht jetzt auf **RESOLVED**.

## Konventionen

- Alle API-Calls via `cy.intercept` + Fixtures gemockt; Keycloak komplett gestubbt (window-Hook)
- Keine festen Wartezeiten (`cy.wait(<number>)`) — nur Alias-/Assertion-Timeouts
- Stabile Selektoren (role/text/id/aria); ein Sub-Agent pro Test, ein Commit pro Test

## Hinweise

- **CI**: `npm run test:e2e` ist noch **nicht** in der Pipeline verdrahtet — sollte als PR-Schritt ergänzt werden (via `start-server-and-test`).
- Details, verbliebene Risiken und 10 Kandidaten für Folge-Tests: `cypress/REPORT-STAGING-UPDATE.md` + `cypress/TEST-MATRIX-DELTA.md`.
